### PR TITLE
bFn changed to match with buffer.js prototype

### DIFF
--- a/server/runtime/devices/modbus/datatypes.js
+++ b/server/runtime/devices/modbus/datatypes.js
@@ -45,7 +45,7 @@ const Datatypes = {
     /**
      * Float64
      */
-    Float64: _gen(8, 'readDoubleBE', 4),
+    Float64: _gen(8, 'DoubleBE', 4),
     /**
      * String
      */


### PR DESCRIPTION
"readDoubleBE" has to be just "DoubleBE", to comply with buffer.js.
At runtime, concatenation with the prefix "read" is already being done, which was resulting in "readreadDoubleBE"