### PR TITLE
Double word reading from Premium PLCs

### DIFF
--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -185,7 +185,9 @@ export enum ModbusTagType {
     UInt32LE = 'UInt32LE',
     Float32LE = 'Float32LE',
     Float64LE = 'Float64LE',
-    Float32MLE = 'Float32MLE'
+    Float32MLE = 'Float32MLE',
+    Int32MLE = 'Int32MLE',
+    UInt32MLE = 'UInt32MLE'
     // String = 'String'
 }
 

--- a/server/runtime/devices/modbus/datatypes.js
+++ b/server/runtime/devices/modbus/datatypes.js
@@ -47,7 +47,7 @@ const Datatypes = {
     /**
      * Int32
      */
-    Int32: _gen(4, 'Int32BE', 2, 2),
+    Int32: _gen(4, 'Int32BE', 2),
     /**
      * UInt32
      */
@@ -97,7 +97,7 @@ const Datatypes = {
     /**
      * Float32MLE
      */
-     Float32MLE: _gen(4, 'FloatBE', 2, 2),
+    Float32MLE: _gen(4, 'FloatBE', 2, 2),
 
     /**
      * String

--- a/server/runtime/devices/modbus/datatypes.js
+++ b/server/runtime/devices/modbus/datatypes.js
@@ -47,7 +47,7 @@ const Datatypes = {
     /**
      * Int32
      */
-    Int32: _gen(4, 'Int32BE', 2),
+    Int32: _gen(4, 'Int32BE', 2, 2),
     /**
      * UInt32
      */
@@ -86,6 +86,14 @@ const Datatypes = {
      */
     Float64LE: _gen(8, 'DoubleLE', 4),
     
+    /**
+     * Int32MLE
+     */
+    Int32MLE: _gen(4, 'Int32BE', 2, 2),
+    /**
+     * UInt32MLE
+     */
+    UInt32MLE: _gen(4, 'UInt32BE', 2, 2),
     /**
      * Float32MLE
      */


### PR DESCRIPTION
Added two new types of tags to support double word reading from Schneider Electric/Modicon Premium PLCs: Int32MLE and UInt32MLE (words have inverted order).