### PR TITLE
Input gauge value is now updated every time variable value changes

### DIFF
--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -407,7 +407,8 @@ export class FuxaViewComponent implements OnInit, AfterViewInit {
                     htmlevent.dbg = 'key pressed ' + htmlevent.dom.id + ' ' + htmlevent.dom.value;
                     htmlevent.id = htmlevent.dom.id;
                     htmlevent.value = htmlevent.dom.value;
-                    self.gaugesManager.putEvent(htmlevent);
+                    self.gaugesManager.putEvent(htmlevent);                
+                    htmlevent.dom.blur();
                 }
             };
             if (this.hmi.layout.inputdialog === 'true') {
@@ -429,7 +430,19 @@ export class FuxaViewComponent implements OnInit, AfterViewInit {
                     }
                 }
                 htmlevent.dom.onblur = function (ev) {
-                    self.toggleShowInputDialog(false);
+                    // Not sure what is the point to call this one. This onblur() occurs 300ms after showing the dialog, when dialogs own input gets focus. Why shall we then try to hide the input dialog?
+                    // The reason why dialog is not being hidden is that toggleShowInputDialog(true) get called multiple times and the timer is then canceled.
+                    // self.toggleShowInputDialog(false);
+                }
+            }else{
+                htmlevent.dom.onblur = function (ev) {
+                    // Update variable value in case it has changed while input had focus
+                    let variables = self.gaugesManager.getBindSignalsValue(htmlevent.ga);
+                    let svgeles = FuxaViewComponent.getSvgElements(htmlevent.ga.id);
+
+                    if (variables.length && svgeles.length) {
+                        self.gaugesManager.processValue(htmlevent.ga, svgeles[0], variables[0], new GaugeStatus());
+                    }
                 }
             }
 

--- a/client/src/app/gauges/controls/html-input/html-input.component.ts
+++ b/client/src/app/gauges/controls/html-input/html-input.component.ts
@@ -76,7 +76,9 @@ export class HtmlInputComponent extends GaugeBaseComponent implements OnInit {
                     } else {
                         val = parseFloat(val.toFixed(5));
                     }
-                    if (!input.value || input.value.length <= 0) {
+
+                    // Do not update value if input is in focus!
+                    if(!(document.hasFocus && input.id == document.activeElement.id )){
                         input.value = val;
                     }
                     // check actions


### PR DESCRIPTION
Updating is paused when input has focus (meaning user is editing it). This does not apply when input dialog is in use.
If user leaves input (blur) without changing its value, variable value is written to input in case it has changed while updates were paused.
Also after a key-enter event, input is blurred immediately to make sure that same value is not applied multiple times (if user press the key accidentally multiple times)