### PR TITLE
Add allow-same-origin flag to solve CORS problems using different ports

### DIFF
--- a/client/src/app/iframe/iframe.component.html
+++ b/client/src/app/iframe/iframe.component.html
@@ -1,1 +1,1 @@
-<iframe width="100%" height="100%" frameBorder="0" [src]="urlSafe" sandbox="allow-forms allow-scripts allow-modals"></iframe>
+<iframe width="100%" height="100%" frameBorder="0" [src]="urlSafe" sandbox="allow-forms allow-scripts allow-modals allow-same-origin"></iframe>


### PR DESCRIPTION
add allow-same-origin in sandbox attribute from iFrame to allow open page in the same domain with different ports