### PR TITLE
code guard for settings.alarms

### DIFF
--- a/client/src/app/_services/settings.service.ts
+++ b/client/src/app/_services/settings.service.ts
@@ -80,10 +80,10 @@ export class SettingsService {
             this.appSettings.logFull = settings.logFull;
             dirty = true;
         }
-        if (settings.alarms?.retention !== this.appSettings.alarms?.retention) {
-            this.appSettings.alarms.retention = settings.alarms.retention;
+        if (settings.alarms && settings.alarms.retention !== this.appSettings.alarms?.retention) {
+            this.appSettings.alarms.retention = settings.alarms.retention ?? this.appSettings.alarms?.retention;
             dirty = true;
-        }
+        }        
         return dirty;
     }
 


### PR DESCRIPTION
If project not have alarms the exception ocurrs:

```
main.b881eef4511e81e6.js:1 ERROR TypeError: Cannot read properties of undefined (reading 'retention')
    at i.setSettings (main.b881eef4511e81e6.js:1:943916)
    at Object.next (main.b881eef4511e81e6.js:1:942563)
    at D.next (main.b881eef4511e81e6.js:1:5549641)
    at F._next (main.b881eef4511e81e6.js:1:5549325)
    at F.next (main.b881eef4511e81e6.js:1:5549020)
    at main.b881eef4511e81e6.js:1:5556733
    at e._next (main.b881eef4511e81e6.js:1:5555843)
    at e.next (main.b881eef4511e81e6.js:1:5549020)
    at main.b881eef4511e81e6.js:1:5556567
    at e._next (main.b881eef4511e81e6.js:1:55558
```