### PR TITLE
Bypass daq connection if failure (#995)

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -348,10 +348,12 @@ function startFuxa() {
         }
     }).catch(function (err) {
         logger.error('server.failed-to-start');
-        if (err.stack) {
-            logger.error(err.stack);
-        } else {
-            logger.error(err);
+        if (err) {
+            if (err.stack) {
+                logger.error(err.stack);
+            } else {
+                logger.error(err);
+            }
         }
     });
 }

--- a/server/runtime/storage/influxdb/index.js
+++ b/server/runtime/storage/influxdb/index.js
@@ -39,10 +39,14 @@ function Influx(_settings, _log, _currentStorate) {
                 // rejectUnauthorized: n.rejectUnauthorized,
                 token
             }
-            client = new InfluxDB(clientOptions);
-            writeApi = client.getWriteApi(settings.daqstore.organization, settings.daqstore.bucket, 's');
-            queryApi = client.getQueryApi(settings.daqstore.organization);
-            status = InfluxDBStatusEnum.OPEN;
+            try {
+                client = new InfluxDB(clientOptions);
+                writeApi = client.getWriteApi(settings.daqstore.organization, settings.daqstore.bucket, 's');
+                queryApi = client.getQueryApi(settings.daqstore.organization);
+                status = InfluxDBStatusEnum.OPEN;    
+            } catch (error) {
+                logger.error('influxdb-init failed! ' + error.message); 
+            }
         } else if (influxdbVersion === VERSION_18_FLUX) {
             try {
                 const parsedUrl = new URL(settings.daqstore.url);


### PR DESCRIPTION
I'm not sure if it's the optimal solution, but as it stands, if the DAQ connection fails, users are unable to access Fuxa to rectify the incorrect address. Implementing a bypass would grant users the ability to do so.

Fix for #995 