### PR TITLE
Fix: Bacnet Device connection error

### DIFF
--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -340,7 +340,7 @@ function BACNETclient(_data, _logger, _events) {
                 tryExplicit = settings['broadcastAddress'].indexOf('255') === -1;
             }
 
-            if (utils.getNetworkInterfaces().indexOf(ipInterface) === -1) {
+            if (ipInterface != '0.0.0.0' && utils.getNetworkInterfaces().indexOf(ipInterface) === -1) {
                 reject(`'${data.name}' selected interface don't exist!`);
                 return;
             }


### PR DESCRIPTION
The solution to the problem of lack of communication with BACnet devices. Adding an exception to ignore the IP address '0.0.0.0'.

![image](https://github.com/frangoteam/FUXA/assets/124029090/30a140fb-e970-4dac-bc42-aca181e174e5)


Specific questions can be referred to https://github.com/frangoteam/FUXA/issues/949