### PR TITLE
Enhanced Device Polling Rate

### DIFF
--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -178,10 +178,21 @@ function Device(data, runtime) {
             comm.init(MODBUSclient.ModbusTypes.TCP);
         }
         return comm.connect().then(function () {
-            devicePolling = setInterval(function () {
+            devicePolling = bindClockTick(function(ms) {
                 self.polling();
-            }, pollingInterval);
+                // console.log(data.name + " - > pollingInterval: " + pollingInterval + " " + new Date().toLocaleString())
+            }) 
         });
+    }
+
+    function bindClockTick(callback) {
+        var SECOND = pollingInterval;
+        function tick() {
+            var now = Date.now();         
+            callback(now);         
+            setTimeout(tick, SECOND - (now % SECOND));
+        }        
+        tick();
     }
 
     /**


### PR DESCRIPTION
On the device PollingRate, I noticed that if we set the rate into 5secs, and the Fuxa server start at 08:02, then the next polling rate will be 08:07, 08:12 , 08:17 and so on and so forth.. 

This request ensures that the polling rate will always be modulos to the pollingRate settings in the device. 
If you set the rate to be 5secs, and the Fuxa server start at 08:02, then the next polling will be at 08:05, 08:10, 08:15 and so on and so forth... 
Setting the pollingRate into 10 secs, then the polling will be modulos of 10 -> 08:10, 08:20, 08:30 and so on and so forth.

PS: Really new to Github, this is my first time to pull request, Apologies if I did something wrong or mistakes. 😄 
