### PR TITLE
feature:  Electron App Support

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+_appdata
+_db
+_logs

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,3 +2,5 @@ node_modules
 _appdata
 _db
 _logs
+
+out/

--- a/app/forge.config.js
+++ b/app/forge.config.js
@@ -1,0 +1,54 @@
+const { FusesPlugin } = require('@electron-forge/plugin-fuses');
+const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+const fs = require('fs')
+const path = require('path')
+
+module.exports = {
+  packagerConfig: {
+    asar: true,
+  },
+  rebuildConfig: {},
+  makers: [
+    {
+      name: '@electron-forge/maker-squirrel',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
+    },
+    {
+      name: '@electron-forge/maker-deb',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-rpm',
+      config: {},
+    },
+  ],
+  plugins: [
+    {
+      name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {},
+    },
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
+    }),
+  ],
+  hooks:{
+    packageAfterCopy: async (config, buildPath, electronVersion, platform, arch) => {
+      let dst = buildPath;
+      fs.cpSync(path.join(__dirname, '../server'), path.join(dst,'server'), {recursive: true,dereference: true});
+      fs.cpSync(path.join(__dirname, '../client/dist'), path.join(dst,'client','dist'), {recursive: true,dereference: true});
+      fs.cpSync(path.join(__dirname,'settings.app.js'),path.join(dst,'server','settings.default.js'))
+    }
+  }
+};

--- a/app/forge.config.js
+++ b/app/forge.config.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-zip',
-      platforms: ['darwin'],
+      platforms: ['darwin','linux','windows'],
     },
     {
       name: '@electron-forge/maker-deb',

--- a/app/index.js
+++ b/app/index.js
@@ -8,7 +8,7 @@ let serverEntry = path.join(__dirname, 'server/main.js')
 if (!fs.existsSync(serverEntry)) {
     serverEntry = path.join(__dirname, '../server/main.js')
 }
-const appData = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/ApplicationSupport' : process.env.HOME + "/.local/share")
+const appData = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : process.env.HOME + "/.local/share")
 const userDataDir = path.join(appData, 'fuxa-app', 'data')
 
 if (!fs.existsSync(userDataDir)) {

--- a/app/index.js
+++ b/app/index.js
@@ -1,0 +1,24 @@
+const {app, BrowserWindow} = require('electron')
+const path = require('node:path')
+
+const fs = require('node:fs')
+let serverEntry = path.join(__dirname, 'server/main.js')
+if (!fs.existsSync(serverEntry)) {
+    serverEntry = path.join(__dirname, '../server/main.js')
+}
+require(serverEntry)
+
+const createWindow = () => {
+    const win = new BrowserWindow({
+        width: 1024,
+        height: 768,
+    })
+    //wait for server startup
+    setTimeout(()=>{
+        win.loadURL('http://localhost:1881')
+    },1000)
+}
+
+app.whenReady().then(() => {
+    createWindow()
+})

--- a/app/index.js
+++ b/app/index.js
@@ -1,8 +1,6 @@
 const {app, utilityProcess, BrowserWindow} = require('electron')
 const path = require('node:path')
-
 const fs = require('fs')
-const {fork} = require('child_process');
 
 let serverEntry = path.join(__dirname, 'server/main.js')
 if (!fs.existsSync(serverEntry)) {
@@ -12,8 +10,7 @@ const appData = process.env.APPDATA || (process.platform == 'darwin' ? process.e
 const userDataDir = path.join(appData, 'fuxa-app', 'data')
 
 if (!fs.existsSync(userDataDir)) {
-    fs.mkdirSync(userDataDir)
-    // fs.copyFileSync(path.join(__dirname, 'settings.default.js'),path.join(userDataDir,'settings.default.js'))
+    fs.mkdirSync(userDataDir, {recursive: true})
 }
 //setting for fuxa server
 process.env.userDir = userDataDir
@@ -32,16 +29,6 @@ const createWindow = () => {
     setTimeout(() => {
         win.loadURL('http://localhost:1881')
     }, 1000)
-
-    // const worker = new BrowserWindow({
-    //     show:true,
-    //     width: 1024,
-    //     height: 768,
-    //     webPreferences: {
-    //         nodeIntegration: true
-    //     }
-    // })
-    // worker.loadFile(path.join(__dirname,'server.html'))
 }
 
 app.whenReady().then(() => {

--- a/app/index.js
+++ b/app/index.js
@@ -1,22 +1,47 @@
-const {app, BrowserWindow} = require('electron')
+const {app, utilityProcess, BrowserWindow} = require('electron')
 const path = require('node:path')
 
-const fs = require('node:fs')
+const fs = require('fs')
+const {fork} = require('child_process');
+
 let serverEntry = path.join(__dirname, 'server/main.js')
 if (!fs.existsSync(serverEntry)) {
     serverEntry = path.join(__dirname, '../server/main.js')
 }
+const appData = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/ApplicationSupport' : process.env.HOME + "/.local/share")
+const userDataDir = path.join(appData, 'fuxa-app', 'data')
+
+if (!fs.existsSync(userDataDir)) {
+    fs.mkdirSync(userDataDir)
+    // fs.copyFileSync(path.join(__dirname, 'settings.default.js'),path.join(userDataDir,'settings.default.js'))
+}
+//setting for fuxa server
+process.env.userDir = userDataDir
+
 require(serverEntry)
 
 const createWindow = () => {
     const win = new BrowserWindow({
         width: 1024,
         height: 768,
+        webPreferences: {
+            // preload: path.join(__dirname, 'preload.js')
+        }
     })
     //wait for server startup
-    setTimeout(()=>{
+    setTimeout(() => {
         win.loadURL('http://localhost:1881')
-    },1000)
+    }, 1000)
+
+    // const worker = new BrowserWindow({
+    //     show:true,
+    //     width: 1024,
+    //     height: 768,
+    //     webPreferences: {
+    //         nodeIntegration: true
+    //     }
+    // })
+    // worker.loadFile(path.join(__dirname,'server.html'))
 }
 
 app.whenReady().then(() => {

--- a/app/package.json
+++ b/app/package.json
@@ -4,8 +4,10 @@
   "description": "FUXA is a web-based Process Visualization (SCADA/HMI/Dashboard) software. With FUXA you can create modern process visualizations with individual designs for your machines and real-time data display.",
   "main": "index.js",
   "scripts": {
-    "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "electron-forge start",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "package": "electron-forge package",
+    "make": "electron-forge make"
   },
   "keywords": [
     "scada",
@@ -14,6 +16,17 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@electron-forge/cli": "^7.4.0",
+    "@electron-forge/maker-deb": "^7.4.0",
+    "@electron-forge/maker-rpm": "^7.4.0",
+    "@electron-forge/maker-squirrel": "^7.4.0",
+    "@electron-forge/maker-zip": "^7.4.0",
+    "@electron-forge/plugin-auto-unpack-natives": "^7.4.0",
+    "@electron-forge/plugin-fuses": "^7.4.0",
+    "@electron/fuses": "^1.8.0",
     "electron": "^30.0.1"
+  },
+  "dependencies": {
+    "electron-squirrel-startup": "^1.0.0"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "fuxa-app",
+  "version": "1.0.0",
+  "description": "FUXA is a web-based Process Visualization (SCADA/HMI/Dashboard) software. With FUXA you can create modern process visualizations with individual designs for your machines and real-time data display.",
+  "main": "index.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "scada",
+    "hmi"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "^30.0.1"
+  }
+}

--- a/app/settings.app.js
+++ b/app/settings.app.js
@@ -1,0 +1,66 @@
+
+module.exports = {
+    // Version to manage update
+    version: 1.1,
+
+    // Standard language (editor)
+    language: 'en',
+
+    // The tcp port that the FUXA web server is listening on
+    uiPort: process.env.PORT || 1881,
+
+    // Used to identify a directory of logger
+    // Default: '_logs'
+    // logDir: '_logs',
+
+    // Used to storage Database like DAQ, User
+    // Default: '_db'
+    // dbDir: '_db',
+
+    // DAQ Enabled
+    // Default: true
+    daqEnabled: true,
+
+    // DAQ DB to Tokenizer the file and save in archive
+    // Default: 24 Hours (1 Day), 0 is disabled only 1 DB file
+    daqTokenizer: 24,
+
+    // By default, server accepts connections on all IPv4 interfaces.
+    // To listen on all IPv6 addresses, set uiHost to "::",
+    // The following property can be used to listen on a specific interface. For
+    // example, the following would only allow connections from the local machine.
+    //uiHost: "127.0.0.1",
+
+    // Used to identify a directory of static content
+    // that should be served at http://localhost:1881/.
+    // Default: '/client/dist'
+    //httpStatic: '/usr/home/fuxa/dist',
+
+    // The maximum size of HTTP request that will be accepted by the runtime api.
+    // Default: 15mb
+    //apiMaxLength: '15mb',
+
+    // Used to disable the server API used for Backend communication (Standalone application)
+    // disable to use only the Editor
+    //disableServer: false,
+
+    // The following property can be used to enable HTTPS !NOT SUPPORTED NOW!
+    // See http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
+    // for details on its contents.
+    // See the comment at the top of this file on how to load the `fs` module used by
+    // this setting.
+    //
+    //https: {
+    //    key: fs.readFileSync('privatekey.pem'),
+    //    cert: fs.readFileSync('certificate.pem')
+    //},
+
+    // Used to enable security, authentication and authorization and crypt Token
+    //secureEnabled: true,
+    //secretCode: 'frangoteam751',
+    //tokenExpiresIn: '1h'  // '1h'=1hour, 60=60seconds, '1d'=1day
+
+    // Enable GPIO in Raspberry
+    // To enable only by Raspberry Host
+
+}

--- a/server/main.js
+++ b/server/main.js
@@ -53,6 +53,12 @@ if (parsedArgs.help) {
 // Define directory
 var rootDir = __dirname;
 var workDir = path.resolve(process.cwd(), '_appdata');
+
+if(process.env.userDir){
+    rootDir = process.env.userDir;
+    workDir = path.resolve(process.env.userDir, '_appdata');
+}
+
 if (parsedArgs.userDir) {
     rootDir = parsedArgs.userDir;
     workDir = path.resolve(parsedArgs.userDir, '_appdata');
@@ -66,7 +72,7 @@ if (!fs.existsSync(workDir)) {
     fs.mkdirSync(workDir);
 }
 
-// Read app settings 
+// Read app settings
 var appSettingsFile = path.join(workDir, 'settings.js');
 if (fs.existsSync(appSettingsFile)) {
     // _appdata/settings.js exists
@@ -157,7 +163,7 @@ try {
 
 // Check logger
 if (!settings.logDir) {
-    settings.logDir = path.resolve(rootDir, '_logs'); 
+    settings.logDir = path.resolve(rootDir, '_logs');
 }
 if (!fs.existsSync(settings.logDir)) {
     fs.mkdirSync(settings.logDir);
@@ -220,7 +226,7 @@ if (parsedArgs.port !== undefined){
 }
 settings.uiHost = settings.uiHost || "0.0.0.0";
 
-// Wait ending initialization 
+// Wait ending initialization
 events.once('init-runtime-ok', function () {
     logger.info('FUXA init in  ' + utils.endTime(startTime) + 'ms.');
     startFuxa();
@@ -274,7 +280,7 @@ app.use('/' + settings.httpUploadFileStatic, express.static(settings.uploadFileD
 app.use('/_images', express.static(settings.imagesFileDir));
 
 var accessLogStream = fs.createWriteStream(settings.logDir + '/api.log', {flags: 'a'});
-app.use(morgan('combined', { 
+app.use(morgan('combined', {
     stream: accessLogStream,
     skip: function (req, res) { return res.statusCode < 400 }
 }));


### PR DESCRIPTION
Use Electron package as a appliction 

[also see ](https://www.electronjs.org/docs/latest/tutorial/tutorial-packaging)

tested in Mac M1,Mac Intel.
runtime data storage in  process.env.APPDATA 

OSX: ${HOME}/Library/Application Support/fuxa-app  
Linux ${HOME}/.local/share/fuxa-app
 
![2871714006306_ pic](https://github.com/frangoteam/FUXA/assets/225988/4ba351c8-38a1-46a3-86c1-5c39e3d26176)
![2851714006278_ pic](https://github.com/frangoteam/FUXA/assets/225988/afca1408-e8c5-43aa-922d-8459c2004a8a)
![2861714006288_ pic](https://github.com/frangoteam/FUXA/assets/225988/05f5da7e-7b4b-434d-b3e3-4811b335e18c)

----
# Build Server and Client First
```
cd server 
npm i
cd ../client
npm i
npm run build
````

# Packaging
```
cd app
npm i
npm run package
```
