### PR TITLE
Add Support for Relative Paths in Iframe URLs When Using Proxy Pass

### DIFF
--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -213,7 +213,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     onGoToLink(event: string) {
-        if (event.indexOf('://') >= 0) {
+        if (event.indexOf('://') >= 0 || event[0] == '/') {
             this.showHomeLink = true;
             this.changeDetector.detectChanges();
             this.setIframe(event);


### PR DESCRIPTION
### Pull Request Description

**Context:**
When using FUXA behind a web server with proxy pass to run multiple applications at the same address, such as:

- `www.mycustomer.com/FUXA`
- `www.mycustomer.com/ANOTHER-SYSTEM`
- `www.mycustomer.com/ANOTHER-SYSTEM-2`

it's beneficial to use relative paths in the iframe URL.

**Proposed Changes:**
1. **Support Relative Paths:**
   - Modify iframe URL references to support relative paths for better integration with other systems on the same domain.

2. **Proxy Configuration Adjustments:**
   - Review and adjust proxy settings to ensure proper resolution of relative paths.

**Motivation:**
- Improve flexibility and compatibility of FUXA when hosted behind a web server with proxy pass.
- Simplify integration and maintenance of multiple applications under the same domain.

Please review the changes and provide feedback.