### PR TITLE
Add option for read/write scripts for tags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:4200/#",
-      "webRoot": "${workspaceFolder}/client/src"
+      "webRoot": "${workspaceFolder}/client/"
     },
     {
       "type": "node",

--- a/client/src/app/_helpers/utils.ts
+++ b/client/src/app/_helpers/utils.ts
@@ -1,5 +1,4 @@
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
-import { AbstractControl, ValidationErrors } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 
 declare const numeral: any;
@@ -557,4 +556,3 @@ export class EscapeHtmlPipe implements PipeTransform {
         return this.sanitizer.bypassSecurityTrustHtml(content);
     }
 }
-

--- a/client/src/app/_helpers/utils.ts
+++ b/client/src/app/_helpers/utils.ts
@@ -1,4 +1,5 @@
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
+import { AbstractControl, ValidationErrors } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 
 declare const numeral: any;
@@ -556,3 +557,15 @@ export class EscapeHtmlPipe implements PipeTransform {
         return this.sanitizer.bypassSecurityTrustHtml(content);
     }
 }
+//https://stackoverflow.com/questions/55748238/how-to-create-a-custom-form-validator-to-accept-only-valid-json-in-angular
+export function jsonValidator(control: AbstractControl): ValidationErrors | null {
+    try {
+        if (control.value && control.value.length > 0) {
+            JSON.parse(control.value);
+        }
+    } catch (e) {
+        console.log(e.toString());
+        return { jsonInvalid: true };
+    }
+    return null;
+};

--- a/client/src/app/_helpers/utils.ts
+++ b/client/src/app/_helpers/utils.ts
@@ -557,15 +557,4 @@ export class EscapeHtmlPipe implements PipeTransform {
         return this.sanitizer.bypassSecurityTrustHtml(content);
     }
 }
-//https://stackoverflow.com/questions/55748238/how-to-create-a-custom-form-validator-to-accept-only-valid-json-in-angular
-export function jsonValidator(control: AbstractControl): ValidationErrors | null {
-    try {
-        if (control.value && control.value.length > 0) {
-            JSON.parse(control.value);
-        }
-    } catch (e) {
-        console.log(e.toString());
-        return { jsonInvalid: true };
-    }
-    return null;
-};
+

--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -79,6 +79,7 @@ export class Tag {
     init: string;
     /** Value scaling properties */
     scale: TagScale;
+    scaleFunction: string;
     /** System Tag used in FUXA Server, example device status connection */
     sysType: TagSystemType;
     /** Description */

--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -79,8 +79,14 @@ export class Tag {
     init: string;
     /** Value scaling properties */
     scale: TagScale;
+    /** Scale function to use when reading tag */
+    scaleReadFunction: string;
+    /** Optional JSON encoded params and values for above script */
+    scaleReadParams: string;
     /** Scale function to use when writing tag */
-    scaleFunction: string;
+    scaleWriteFunction: string;
+    /** Optional JSON encoded params and values for above script */
+    scaleWriteParams: string;
     /** System Tag used in FUXA Server, example device status connection */
     sysType: TagSystemType;
     /** Description */

--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -79,6 +79,7 @@ export class Tag {
     init: string;
     /** Value scaling properties */
     scale: TagScale;
+    /** Scale function to use when writing tag */
     scaleFunction: string;
     /** System Tag used in FUXA Server, example device status connection */
     sysType: TagSystemType;

--- a/client/src/app/device/device-list/device-list.component.ts
+++ b/client/src/app/device/device-list/device-list.component.ts
@@ -353,6 +353,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
                     tags[i].daq = tagOption.daq;
                     tags[i].format = tagOption.format;
                     tags[i].scale = tagOption.scale;
+                    tags[i].scaleFunction = tagOption.scaleFunction;
                 }
                 this.projectService.setDeviceTags(this.deviceSelected);
             }

--- a/client/src/app/device/device-list/device-list.component.ts
+++ b/client/src/app/device/device-list/device-list.component.ts
@@ -353,7 +353,10 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
                     tags[i].daq = tagOption.daq;
                     tags[i].format = tagOption.format;
                     tags[i].scale = tagOption.scale;
-                    tags[i].scaleFunction = tagOption.scaleFunction;
+                    tags[i].scaleReadFunction = tagOption.scaleReadFunction;
+                    tags[i].scaleReadParams = tagOption.scaleReadParams;
+                    tags[i].scaleWriteFunction = tagOption.scaleWriteFunction;
+                    tags[i].scaleWriteParams = tagOption.scaleWriteParams;
                 }
                 this.projectService.setDeviceTags(this.deviceSelected);
             }

--- a/client/src/app/device/tag-options/tag-options.component.css
+++ b/client/src/app/device/tag-options/tag-options.component.css
@@ -1,0 +1,8 @@
+.ng-invalid:not(form) {
+    
+    background-color: lightcoral;
+  }
+  .my-form-field mat-list-item {
+    padding: 0px;
+    font-size: 12px;
+}

--- a/client/src/app/device/tag-options/tag-options.component.css
+++ b/client/src/app/device/tag-options/tag-options.component.css
@@ -1,7 +1,3 @@
-.ng-invalid:not(form) {
-    
-    background-color: lightcoral;
-  }
   .my-form-field mat-list-item {
     padding: 0px;
     font-size: 12px;

--- a/client/src/app/device/tag-options/tag-options.component.html
+++ b/client/src/app/device/tag-options/tag-options.component.html
@@ -68,6 +68,13 @@
                 </div>
             </ng-container>
         </ng-container>
+        <div class="my-form-field block mt10" style="width: 300px">
+            <span>{{'gauges.property-event-script' | translate}}</span>
+            <mat-select formControlName="scaleFunction" (selectionChange)="onScriptChanged($event.value)">
+                <mat-option (click)="formGroup.controls.scaleFunction.reset()"></mat-option>
+                <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
+            </mat-select>
+        </div>
     </div>
     <div mat-dialog-actions class="dialog-action">
         <button mat-raised-button (click)="onNoClick()">{{'dlg.cancel' | translate}}</button>

--- a/client/src/app/device/tag-options/tag-options.component.html
+++ b/client/src/app/device/tag-options/tag-options.component.html
@@ -69,15 +69,46 @@
             </ng-container>
         </ng-container>
         <div class="my-form-field block mt10" style="width: 300px">
-            <span>{{'gauges.property-event-script' | translate}}</span>
-            <mat-select formControlName="scaleFunction" (selectionChange)="onScriptChanged($event.value)">
-                <mat-option (click)="formGroup.controls.scaleFunction.reset()"></mat-option>
+            <span>{{'device.tag-scale-read-script' | translate}}</span>
+            <mat-select formControlName="scaleReadFunction" (selectionChange)="onReadScriptChanged($event.value)" matTooltip="{{'device.tag-scale-read-script-tooltip' | translate}}">
+                <mat-option (click)="formGroup.controls.scaleReadFunction.reset()"></mat-option>
                 <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
             </mat-select>
+        </div>
+        <div *ngIf="configedReadParams[formGroup.value.scaleReadFunction]?.length > 0" class="my-form-field block mt10" style="width: 300px">
+            <span>{{'device.tag-scale-read-script-params' | translate}}</span>
+            <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
+                    <mat-list-item *ngFor="let item of configedReadParams[formGroup.value.scaleReadFunction]">
+                        <div class="block mt10 flex" >
+                            <span>{{item.name}}:</span>
+                            <input [(ngModel)]="item.value"  style="width:140px;margin-left: 10px;" [ngModelOptions]="{standalone: true}">                            
+                        </div>
+                    </mat-list-item>                    
+            </mat-list>
+        </div>
+       
+        <div class="my-form-field block mt10" style="width: 300px">
+            <span>{{'device.tag-scale-write-script' | translate}}</span>
+            <mat-select formControlName="scaleWriteFunction" (selectionChange)="onWriteScriptChanged($event.value)" matTooltip="{{'device.tag-scale-write-script-tooltip' | translate}}">
+                <mat-option (click)="formGroup.controls.scaleWriteFunction.reset()"></mat-option>
+                <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
+            </mat-select>
+        </div>
+        
+        <div *ngIf="configedWriteParams[formGroup.value.scaleWriteFunction]?.length > 0" class="my-form-field block mt10" style="width: 300px">
+            <span>{{'device.tag-scale-write-script-params' | translate}}</span>
+            <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
+                    <mat-list-item *ngFor="let item of configedWriteParams[formGroup.value.scaleWriteFunction]">
+                        <div class="block mt10 flex" >
+                            <span>{{item.name}}:</span>
+                            <input [(ngModel)]="item.value"  style="width:140px;margin-left: 10px;" [ngModelOptions]="{standalone: true}">                            
+                        </div>
+                    </mat-list-item>
+            </mat-list>
         </div>
     </div>
     <div mat-dialog-actions class="dialog-action">
         <button mat-raised-button (click)="onNoClick()">{{'dlg.cancel' | translate}}</button>
-        <button mat-raised-button color="primary" (click)="onOkClick()" [disabled]="formGroup.invalid">{{'dlg.ok' | translate}}</button>
+        <button mat-raised-button color="primary" (click)="onOkClick()" [disabled]="disableForm()">{{'dlg.ok' | translate}}</button>
     </div>
 </form>

--- a/client/src/app/device/tag-options/tag-options.component.html
+++ b/client/src/app/device/tag-options/tag-options.component.html
@@ -70,7 +70,7 @@
         </ng-container>
         <div class="my-form-field block mt10" style="width: 300px">
             <span>{{'device.tag-scale-read-script' | translate}}</span>
-            <mat-select formControlName="scaleReadFunction" (selectionChange)="onReadScriptChanged($event.value)" matTooltip="{{'device.tag-scale-read-script-tooltip' | translate}}">
+            <mat-select formControlName="scaleReadFunction" matTooltip="{{'device.tag-scale-read-script-tooltip' | translate}}">
                 <mat-option (click)="formGroup.controls.scaleReadFunction.reset()"></mat-option>
                 <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
             </mat-select>
@@ -89,7 +89,7 @@
        
         <div class="my-form-field block mt10" style="width: 300px">
             <span>{{'device.tag-scale-write-script' | translate}}</span>
-            <mat-select formControlName="scaleWriteFunction" (selectionChange)="onWriteScriptChanged($event.value)" matTooltip="{{'device.tag-scale-write-script-tooltip' | translate}}">
+            <mat-select formControlName="scaleWriteFunction" matTooltip="{{'device.tag-scale-write-script-tooltip' | translate}}">
                 <mat-option (click)="formGroup.controls.scaleWriteFunction.reset()"></mat-option>
                 <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
             </mat-select>

--- a/client/src/app/device/tag-options/tag-options.component.html
+++ b/client/src/app/device/tag-options/tag-options.component.html
@@ -24,87 +24,96 @@
             <span>{{'device.tag-format' | translate}}</span>
             <input numberOnly formControlName="format" min="0" max="10" type="number" style="width:300px">
         </div>
-        <div class="my-form-field block mt10">
-            <span>{{'device.tag-scale' | translate}}</span>
-            <mat-select formControlName="scaleMode" style="width: 300px">
-                <mat-option *ngFor="let ev of scaleModeType | enumToArray" matTooltip="{{ev.value + '-tooltip' | translate}}" [value]="ev.key">
-                    {{ ev.value | translate }}
-                </mat-option>
-            </mat-select>
-        </div>
-        <ng-container [ngSwitch]="formGroup.controls.scaleMode.value">
-            <ng-container *ngSwitchCase="'convertDateTime'">
-                <div class="my-form-field block mt10">
-                    <span>{{'device.tag-convert-datetime-format' | translate}}</span>
-                    <input formControlName="dateTimeFormat" style="width:300px">
-                </div>
-            </ng-container>
-            <ng-container *ngSwitchCase="'convertTickTime'">
-                <div class="my-form-field block mt10">
-                    <span>{{'device.tag-convert-ticktime-format' | translate}}</span>
-                    <input formControlName="dateTimeFormat" style="width:300px">
-                </div>
-            </ng-container>
-            <ng-container *ngSwitchCase="'linear'">
-                <div class="block mt5">
-                    <div class="my-form-field">
-                        <span>{{'device.tag-raw-low' | translate}}</span>
-                        <input formControlName="rawLow" type="number" style="width:140px">
+        <div *ngIf="!isFuxaServerTag()">
+            <div class="my-form-field block mt10">
+                <span>{{'device.tag-scale' | translate}}</span>
+                <mat-select formControlName="scaleMode" style="width: 300px">
+                    <mat-option *ngFor="let ev of scaleModeType | enumToArray"
+                        matTooltip="{{ev.value + '-tooltip' | translate}}" [value]="ev.key">
+                        {{ ev.value | translate }}
+                    </mat-option>
+                </mat-select>
+            </div>
+            <ng-container [ngSwitch]="formGroup.controls.scaleMode.value">
+                <ng-container *ngSwitchCase="'convertDateTime'">
+                    <div class="my-form-field block mt10">
+                        <span>{{'device.tag-convert-datetime-format' | translate}}</span>
+                        <input formControlName="dateTimeFormat" style="width:300px">
                     </div>
-                    <div class="my-form-field ftr">
-                        <span>{{'device.tag-raw-high' | translate}}</span>
-                        <input formControlName="rawHigh" type="number" style="width:140px">
+                </ng-container>
+                <ng-container *ngSwitchCase="'convertTickTime'">
+                    <div class="my-form-field block mt10">
+                        <span>{{'device.tag-convert-ticktime-format' | translate}}</span>
+                        <input formControlName="dateTimeFormat" style="width:300px">
                     </div>
-                </div>
-                <div class="block mt5">
-                    <div class="my-form-field">
-                        <span>{{'device.tag-scaled-low' | translate}}</span>
-                        <input formControlName="scaledLow" type="number" style="width:140px">
-                    </div>
-                    <div class="my-form-field ftr">
-                        <span>{{'device.tag-scaled-high' | translate}}</span>
-                        <input formControlName="scaledHigh" type="number" style="width:140px">
-                    </div>
-                </div>
-            </ng-container>
-        </ng-container>
-        <div class="my-form-field block mt10" style="width: 300px">
-            <span>{{'device.tag-scale-read-script' | translate}}</span>
-            <mat-select formControlName="scaleReadFunction" matTooltip="{{'device.tag-scale-read-script-tooltip' | translate}}">
-                <mat-option (click)="formGroup.controls.scaleReadFunction.reset()"></mat-option>
-                <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
-            </mat-select>
-        </div>
-        <div *ngIf="configedReadParams[formGroup.value.scaleReadFunction]?.length > 0" class="my-form-field block mt10" style="width: 300px">
-            <span>{{'device.tag-scale-read-script-params' | translate}}</span>
-            <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
-                    <mat-list-item *ngFor="let item of configedReadParams[formGroup.value.scaleReadFunction]">
-                        <div class="block mt10 flex" >
-                            <span>{{item.name}}:</span>
-                            <input [(ngModel)]="item.value"  style="width:140px;margin-left: 10px;" [ngModelOptions]="{standalone: true}">                            
+                </ng-container>
+                <ng-container *ngSwitchCase="'linear'">
+                    <div class="block mt5">
+                        <div class="my-form-field">
+                            <span>{{'device.tag-raw-low' | translate}}</span>
+                            <input formControlName="rawLow" type="number" style="width:140px">
                         </div>
-                    </mat-list-item>                    
-            </mat-list>
-        </div>
-       
-        <div class="my-form-field block mt10" style="width: 300px">
-            <span>{{'device.tag-scale-write-script' | translate}}</span>
-            <mat-select formControlName="scaleWriteFunction" matTooltip="{{'device.tag-scale-write-script-tooltip' | translate}}">
-                <mat-option (click)="formGroup.controls.scaleWriteFunction.reset()"></mat-option>
-                <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
-            </mat-select>
-        </div>
-        
-        <div *ngIf="configedWriteParams[formGroup.value.scaleWriteFunction]?.length > 0" class="my-form-field block mt10" style="width: 300px">
-            <span>{{'device.tag-scale-write-script-params' | translate}}</span>
-            <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
-                    <mat-list-item *ngFor="let item of configedWriteParams[formGroup.value.scaleWriteFunction]">
-                        <div class="block mt10 flex" >
+                        <div class="my-form-field ftr">
+                            <span>{{'device.tag-raw-high' | translate}}</span>
+                            <input formControlName="rawHigh" type="number" style="width:140px">
+                        </div>
+                    </div>
+                    <div class="block mt5">
+                        <div class="my-form-field">
+                            <span>{{'device.tag-scaled-low' | translate}}</span>
+                            <input formControlName="scaledLow" type="number" style="width:140px">
+                        </div>
+                        <div class="my-form-field ftr">
+                            <span>{{'device.tag-scaled-high' | translate}}</span>
+                            <input formControlName="scaledHigh" type="number" style="width:140px">
+                        </div>
+                    </div>
+                </ng-container>
+            </ng-container>
+            <div class="my-form-field block mt10" style="width: 300px">
+                <span>{{'device.tag-scale-read-script' | translate}}</span>
+                <mat-select formControlName="scaleReadFunction"
+                    matTooltip="{{'device.tag-scale-read-script-tooltip' | translate}}">
+                    <mat-option (click)="formGroup.controls.scaleReadFunction.reset()"></mat-option>
+                    <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
+                </mat-select>
+            </div>
+            <div *ngIf="configedReadParams[formGroup.value.scaleReadFunction]?.length > 0" class="my-form-field block mt10"
+                style="width: 300px">
+                <span>{{'device.tag-scale-read-script-params' | translate}}</span>
+                <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
+                    <mat-list-item *ngFor="let item of configedReadParams[formGroup.value.scaleReadFunction]">
+                        <div class="block mt10 flex">
                             <span>{{item.name}}:</span>
-                            <input [(ngModel)]="item.value"  style="width:140px;margin-left: 10px;" [ngModelOptions]="{standalone: true}">                            
+                            <input [(ngModel)]="item.value" style="width:140px;margin-left: 10px;"
+                                [ngModelOptions]="{standalone: true}">
                         </div>
                     </mat-list-item>
-            </mat-list>
+                </mat-list>
+            </div>
+        
+            <div class="my-form-field block mt10" style="width: 300px">
+                <span>{{'device.tag-scale-write-script' | translate}}</span>
+                <mat-select formControlName="scaleWriteFunction"
+                    matTooltip="{{'device.tag-scale-write-script-tooltip' | translate}}">
+                    <mat-option (click)="formGroup.controls.scaleWriteFunction.reset()"></mat-option>
+                    <mat-option *ngFor="let script of scripts; index as i" [value]="script.id">{{script.name}}</mat-option>
+                </mat-select>
+            </div>
+        
+            <div *ngIf="configedWriteParams[formGroup.value.scaleWriteFunction]?.length > 0" class="my-form-field block mt10"
+                style="width: 300px">
+                <span>{{'device.tag-scale-write-script-params' | translate}}</span>
+                <mat-list matTooltip="{{'device.tag-scale-script-params-tooltip' | translate}}">
+                    <mat-list-item *ngFor="let item of configedWriteParams[formGroup.value.scaleWriteFunction]">
+                        <div class="block mt10 flex">
+                            <span>{{item.name}}:</span>
+                            <input [(ngModel)]="item.value" style="width:140px;margin-left: 10px;"
+                                [ngModelOptions]="{standalone: true}">
+                        </div>
+                    </mat-list-item>
+                </mat-list>
+            </div>
         </div>
     </div>
     <div mat-dialog-actions class="dialog-action">

--- a/client/src/app/device/tag-options/tag-options.component.ts
+++ b/client/src/app/device/tag-options/tag-options.component.ts
@@ -291,6 +291,9 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
         }
         return false;
     }
+    isFuxaServerTag() {
+        return this.data.device?.id === FuxaServer.id;
+    }
 
     private loadScripts() {
         //scripts that can be used to scale a tag must have the first parameter named "value" of

--- a/client/src/app/device/tag-options/tag-options.component.ts
+++ b/client/src/app/device/tag-options/tag-options.component.ts
@@ -125,31 +125,21 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                 if (!scaleReadFunction.value) {
                     scaleReadFunction.value = this.data.tags[i].scaleReadFunction;
                 }
-                //if (scaleReadParams.value.length === 0) {
-                    //scaleReadParams.value = this.data.tags[i].scaleReadParams;
-                    let script = this.scripts.find(s => s.id === this.data.tags[i].scaleReadFunction);
-                    if (this.data.tags[i].scaleReadParams) {
-                        const tagParams = JSON.parse(this.data.tags[i].scaleReadParams) as ScriptParam[];
-                        const notValid = this.initializeScriptParams(script, tagParams, this.configedReadParams);
-                        // if (notValid) {
-                        //     scaleReadParams.value = undefined;
-                        // }
-                    }
-                //}
+
+                let script = this.scripts.find(s => s.id === this.data.tags[i].scaleReadFunction);
+                if (this.data.tags[i].scaleReadParams) {
+                    const tagParams = JSON.parse(this.data.tags[i].scaleReadParams) as ScriptParam[];
+                    const notValid = this.initializeScriptParams(script, tagParams, this.configedReadParams);
+                }
                 if (!scaleWriteFunction.value) {
                     scaleWriteFunction.value = this.data.tags[i].scaleWriteFunction;
                 }
-                //if (!scaleWriteParams.value) {
-                //    scaleWriteParams.value = this.data.tags[i].scaleWriteParams;
-                    script = this.scripts.find(s => s.id === this.data.tags[i].scaleWriteFunction);
-                    if (this.data.tags[i].scaleWriteParams) {
-                        const tagParams = JSON.parse(this.data.tags[i].scaleWriteParams) as ScriptParam[];
-                        const notValid = this.initializeScriptParams(script, tagParams, this.configedWriteParams);
-                        //if (notValid) {
-                        //    scaleWriteParams.value = undefined;
-                        //}
-                    }
-                //}
+
+                script = this.scripts.find(s => s.id === this.data.tags[i].scaleWriteFunction);
+                if (this.data.tags[i].scaleWriteParams) {
+                    const tagParams = JSON.parse(this.data.tags[i].scaleWriteParams) as ScriptParam[];
+                    const notValid = this.initializeScriptParams(script, tagParams, this.configedWriteParams);
+                }
             }
             let values = {};
             if (enabled.valid && enabled.value !== null) {
@@ -180,15 +170,11 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             if (scaleReadFunction.valid && scaleReadFunction.value) {
                 values = {...values, scaleReadFunction: scaleReadFunction.value};
             }
-            // if (scaleReadParams.valid && scaleReadParams.value) {
-            //     values = {...values, scaleReadParams: scaleReadParams.value};
-            // }
+
             if (scaleWriteFunction.valid && scaleWriteFunction.value) {
                 values = {...values, scaleWriteFunction: scaleWriteFunction.value};
             }
-            // if (scaleWriteParams.valid && scaleWriteParams.value) {
-            //     values = {...values, scaleWriteParams: scaleWriteParams.value};
-            // }
+
             this.formGroup.patchValue(values);
             if (this.data.device?.id === FuxaServer.id) {
                 this.formGroup.controls.scaleMode.disable();

--- a/client/src/app/device/tag-options/tag-options.component.ts
+++ b/client/src/app/device/tag-options/tag-options.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { FormArray, FormGroup, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FuxaServer, TagDaq, TagScale, TagScaleModeType } from '../../_models/device';
-import { Utils, jsonValidator } from '../../_helpers/utils';
+import { Utils} from '../../_helpers/utils';
 import { ProjectService } from '../../_services/project.service';
 import { Subscription } from 'rxjs';
 import { Script, ScriptMode, ScriptParam, ScriptParamType } from '../../_models/script';
@@ -21,8 +21,6 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
     formGroup: UntypedFormGroup;
     scaleModeType = TagScaleModeType;
     scripts: Script[];
-    selectedReadScript: Script;
-    selectedWriteScript: Script;
     configedReadParams: {[key: string]: ScriptAndParam[]} = {};
     configedWriteParams: {[key: string]: ScriptParam[]} = {};
 
@@ -54,9 +52,7 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             dateTimeFormat: null,
             scaleRead: null,
             scaleReadFunction: null,
-            scaleReadParams: this.fb.array([]),
             scaleWriteFunction: null,
-            scaleWriteParams: null,
         });
 
         this.formGroup.controls.enabled.valueChanges.subscribe(enabled => {
@@ -83,9 +79,9 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             let scaledHigh = { value: null, valid: true };
             let dateTimeFormat = { value: null, valid: true };
             let scaleReadFunction = { value: null, valid: true };
-            let scaleReadParams = { value: [], valid: true };
+            //let scaleReadParams = { value: [], valid: true };
             let scaleWriteFunction = { value: null, valid: true };
-            let scaleWriteParams = { value: null, valid: true };
+            //let scaleWriteParams = { value: null, valid: true };
             for (let i = 0; i < this.data.tags.length; i++) {
                 if (!this.data.tags[i].daq) {
                     continue;
@@ -131,7 +127,7 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                 }
                 //if (scaleReadParams.value.length === 0) {
                     //scaleReadParams.value = this.data.tags[i].scaleReadParams;
-                    const script = this.scripts.find(s => s.id === this.data.tags[i].scaleReadFunction);
+                    let script = this.scripts.find(s => s.id === this.data.tags[i].scaleReadFunction);
                     if (this.data.tags[i].scaleReadParams) {
                         const tagParams = JSON.parse(this.data.tags[i].scaleReadParams) as ScriptParam[];
                         const notValid = this.initializeScriptParams(script, tagParams, this.configedReadParams);
@@ -143,17 +139,17 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                 if (!scaleWriteFunction.value) {
                     scaleWriteFunction.value = this.data.tags[i].scaleWriteFunction;
                 }
-                if (!scaleWriteParams.value) {
-                    scaleWriteParams.value = this.data.tags[i].scaleWriteParams;
-                    const script = this.scripts.find(s => s.id === this.data.tags[i].scaleWriteFunction);
+                //if (!scaleWriteParams.value) {
+                //    scaleWriteParams.value = this.data.tags[i].scaleWriteParams;
+                    script = this.scripts.find(s => s.id === this.data.tags[i].scaleWriteFunction);
                     if (this.data.tags[i].scaleWriteParams) {
                         const tagParams = JSON.parse(this.data.tags[i].scaleWriteParams) as ScriptParam[];
                         const notValid = this.initializeScriptParams(script, tagParams, this.configedWriteParams);
-                        if (notValid) {
-                            scaleWriteParams.value = undefined;
-                        }
+                        //if (notValid) {
+                        //    scaleWriteParams.value = undefined;
+                        //}
                     }
-                }
+                //}
             }
             let values = {};
             if (enabled.valid && enabled.value !== null) {
@@ -184,25 +180,21 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             if (scaleReadFunction.valid && scaleReadFunction.value) {
                 values = {...values, scaleReadFunction: scaleReadFunction.value};
             }
-            if (scaleReadParams.valid && scaleReadParams.value) {
-                values = {...values, scaleReadParams: scaleReadParams.value};
-            }
+            // if (scaleReadParams.valid && scaleReadParams.value) {
+            //     values = {...values, scaleReadParams: scaleReadParams.value};
+            // }
             if (scaleWriteFunction.valid && scaleWriteFunction.value) {
                 values = {...values, scaleWriteFunction: scaleWriteFunction.value};
             }
-            if (scaleWriteParams.valid && scaleWriteParams.value) {
-                values = {...values, scaleWriteParams: scaleWriteParams.value};
-            }
+            // if (scaleWriteParams.valid && scaleWriteParams.value) {
+            //     values = {...values, scaleWriteParams: scaleWriteParams.value};
+            // }
             this.formGroup.patchValue(values);
-            //this.loadParamsFormArray(this.configedReadParams, this.scaleReadParams);
-            //this.formGroup.setControl('scaleRead', this.initScripsFC('readscripts', this.configedReadParams));
             if (this.data.device?.id === FuxaServer.id) {
                 this.formGroup.controls.scaleMode.disable();
             }
             this.formGroup.updateValueAndValidity();
             this.onCheckScaleMode(this.formGroup.value.scaleMode);
-            this.onReadScriptChanged(this.formGroup.value.scaleReadFunction);
-            this.onWriteScriptChanged(this.formGroup.value.scaleWriteFunction);
         }
 
         this.formGroup.controls.scaleMode.valueChanges.subscribe(value => {
@@ -250,15 +242,6 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
         } else {
             readParamsStr = undefined;
         }
-
-        // const readParams = [];
-        // for (const p of this.scaleReadParams.controls) {
-        //     if (p.value.scriptId === this.formGroup.value.scaleReadFunction) {
-        //         const param: ScriptParam = new ScriptParam(p.get('name').value, ScriptParamType.value);
-        //         readParams.push(param);
-        //     }
-        // }
-        // const readParamsStr = readParams.length > 0 ? JSON.stringify(readParams) : undefined;
         let writeParamsStr;
         if (this.configedWriteParams[this.formGroup.value.scaleWriteFunction]) {
             writeParamsStr = JSON.stringify(this.configedWriteParams[this.formGroup.value.scaleWriteFunction]);
@@ -308,84 +291,7 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
         }
         return false;
     }
-    onReadScriptChanged(scriptId) {
-        console.log(`Selected script ${scriptId}`);
-       // this.enablePramsArray(this.scaleReadParams, scriptId);
-        // if (scriptId) {
-        //     this.formGroup.controls.scaleReadParams.setValidators(jsonValidator);
-        //     this.selectedReadScript = this.scripts.find(s => s.id === scriptId);
-        // } else {
-        //     this.formGroup.controls.scaleReadParams.clearValidators();
-        //     this.selectedReadScript = undefined;
-        // }
-        this.formGroup.updateValueAndValidity();
-    }
-    onWriteScriptChanged(scriptId) {
-        console.log(`Selected script            ${scriptId}`);
-        if (scriptId) {
-            this.formGroup.controls.scaleWriteParams.setValidators(jsonValidator);
-            this.selectedWriteScript = this.scripts.find(s => s.id === scriptId);
-        } else {
-            this.formGroup.controls.scaleWriteParams.clearValidators();
-            this.selectedWriteScript = undefined;
-        }
-        this.formGroup.updateValueAndValidity();
-    }
 
-    // get readScripts() {
-    //     return this.formGroup.get('scaleRead') as FormArray;
-    // }
-
-    // getReadParametersFormArray(scriptIndex: number) {
-    //     return this.readScripts.controls[scriptIndex].get('parameters') as FormArray;
-    //   }
-
-    //   getReadParameterControls(scriptIndex: number) {
-    //     return this.getReadParametersFormArray(scriptIndex).controls;
-    //   }
-
-    //   addReadScript(script: Script) {
-    //     this.readScripts.push(this.getScriptItem(script.name, script.id));
-    //   }
-    //   addReadParameter(scriptIndex: number, name: string, value: any) {
-    //     this.getReadParametersFormArray(scriptIndex).push(this.getParameterItem(name, value));
-    //   }
-    //   private addScriptFC(scriptsFCA: FormArray, script: Script) {
-    //     scriptsFCA.push(this.getParameterItem())
-
-    //   }
-    // private initScripsFC(name: string, defaultScriptParams: {[key: string]: ScriptAndParam[]}): FormGroup {
-    //     const fb = this.fb.group({
-    //       name: name,
-    //       scripts: this.fb.array([])
-    //     });
-    //     const fbsArray = fb.get('scripts') as FormArray;
-    //     for (const script of this.scripts) {
-    //         //this.addScriptFC(fb.get('scripts') as FormArray, script);
-    //         const sfg = this.getScriptItem(script.name, script.id);
-    //         const sfgPArray = sfg.get('parameters') as FormArray;
-    //         for (const p of defaultScriptParams[script.id]) {
-    //             const pfg = this.getParameterItem(p.name, p.value);
-    //             sfgPArray.push(pfg);
-    //         }
-    //         fbsArray.push(sfg);
-    //     }
-    //     return fb;
-    // }
-    // private getScriptItem(name: string, id: string) {
-    //     return this.fb.group({
-    //       name: name,
-    //       id: id,
-    //       parameters: this.fb.array([])
-    //     });
-    //   }
-
-    //   private getParameterItem(name: string = undefined, value: any = undefined) {
-    //     return this.fb.group({
-    //       name: name,
-    //       value:[value, Validators.required]
-    //     });
-    //   }
     private loadScripts() {
         //scripts that can be used to scale a tag must have the first parameter named "value" of
         // type value and be
@@ -421,46 +327,7 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
         }
         this.scripts = filteredScripts;
 	}
-    // get scaleReadParams() {
-    //     return this.formGroup.get('scaleReadParams') as FormArray;
-    // }
-    // private addReadParam(scriptId: string, name: string, value: any) {
-    //     const param = this.fb.group( {
-    //         scriptId: [scriptId],
-    //         name: [name],
-    //         value: [value,[Validators.required]]
-    //     });
-    //     this.scaleReadParams.push(param);
-    // }
-    // private addParamToFormArray(paramsArray: FormArray, scriptId: string, name: string, value: any) {
-    //     const param = this.fb.group( {
-    //         scriptId: [scriptId],
-    //         name: [name],
-    //         value: [value,[Validators.required]]
-    //     });
-    //     paramsArray.push(param);
-    // }
-    // private enablePramsArray(paramsArray: FormArray, scriptId: string) {
-    //     for (const fcParam of paramsArray.controls) {
-    //         if (fcParam.value.scriptId === scriptId) {
-    //             fcParam.enable;
-    //         } else {
-    //             fcParam.disable;
-    //         }
-    //     }
-    // }
-    // private enableParamsForSelectedScripts(allParamsForAllScripts: FormArray) {
-    //     this.enablePramsArray(allParamsForAllScripts, this.formGroup.value.scaleReadFunction);
-    // }
-    // private loadParamsFormArray(defaultScriptParams: {[key: string]: ScriptAndParam[]}, paramsArray: FormArray) {
-    //     //defaultScriptParams now updated with passed in values, build formarray from this
-    //     for (const key in defaultScriptParams) {
-    //         const sp = defaultScriptParams[key];
-    //         for (const p of sp) {
-    //             this.addParamToFormArray(paramsArray, p.scriptId, p.name, p.value);
-    //         }
-    //     }
-    // }
+
     /**
      * updates this.configedParams list with the previously saved list of param/values for
      * the script.

--- a/client/src/app/device/tag-options/tag-options.component.ts
+++ b/client/src/app/device/tag-options/tag-options.component.ts
@@ -1,12 +1,15 @@
 import { ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormArray, FormGroup, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { FuxaServer, TagDaq, TagScale, TagScaleModeType } from '../../_models/device';
-import { Utils } from '../../_helpers/utils';
+import { Utils, jsonValidator } from '../../_helpers/utils';
 import { ProjectService } from '../../_services/project.service';
 import { Subscription } from 'rxjs';
-import { Script, ScriptMode } from '../../_models/script';
+import { Script, ScriptMode, ScriptParam, ScriptParamType } from '../../_models/script';
 
+class ScriptAndParam extends ScriptParam {
+    scriptId: string;
+}
 @Component({
     selector: 'app-tag-options',
     templateUrl: './tag-options.component.html',
@@ -18,6 +21,10 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
     formGroup: UntypedFormGroup;
     scaleModeType = TagScaleModeType;
     scripts: Script[];
+    selectedReadScript: Script;
+    selectedWriteScript: Script;
+    configedReadParams: {[key: string]: ScriptAndParam[]} = {};
+    configedWriteParams: {[key: string]: ScriptParam[]} = {};
 
     private subscriptionLoad: Subscription;
 
@@ -45,7 +52,11 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             scaledLow: null,
             scaledHigh: null,
             dateTimeFormat: null,
-            scaleFunction: null
+            scaleRead: null,
+            scaleReadFunction: null,
+            scaleReadParams: this.fb.array([]),
+            scaleWriteFunction: null,
+            scaleWriteParams: null,
         });
 
         this.formGroup.controls.enabled.valueChanges.subscribe(enabled => {
@@ -71,7 +82,10 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
             let scaledLow = { value: null, valid: true };
             let scaledHigh = { value: null, valid: true };
             let dateTimeFormat = { value: null, valid: true };
-            let scaleFunction = { value: null, valid: true };
+            let scaleReadFunction = { value: null, valid: true };
+            let scaleReadParams = { value: [], valid: true };
+            let scaleWriteFunction = { value: null, valid: true };
+            let scaleWriteParams = { value: null, valid: true };
             for (let i = 0; i < this.data.tags.length; i++) {
                 if (!this.data.tags[i].daq) {
                     continue;
@@ -112,8 +126,33 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                 } else if (scaleMode.value !== this.data.tags[i].scale?.mode) {
                     scaleMode.valid = false;
                 }
-                if (!scaleFunction.value) {
-                    scaleFunction.value = this.data.tags[i].scaleFunction;
+                if (!scaleReadFunction.value) {
+                    scaleReadFunction.value = this.data.tags[i].scaleReadFunction;
+                }
+                //if (scaleReadParams.value.length === 0) {
+                    //scaleReadParams.value = this.data.tags[i].scaleReadParams;
+                    const script = this.scripts.find(s => s.id === this.data.tags[i].scaleReadFunction);
+                    if (this.data.tags[i].scaleReadParams) {
+                        const tagParams = JSON.parse(this.data.tags[i].scaleReadParams) as ScriptParam[];
+                        const notValid = this.initializeScriptParams(script, tagParams, this.configedReadParams);
+                        // if (notValid) {
+                        //     scaleReadParams.value = undefined;
+                        // }
+                    }
+                //}
+                if (!scaleWriteFunction.value) {
+                    scaleWriteFunction.value = this.data.tags[i].scaleWriteFunction;
+                }
+                if (!scaleWriteParams.value) {
+                    scaleWriteParams.value = this.data.tags[i].scaleWriteParams;
+                    const script = this.scripts.find(s => s.id === this.data.tags[i].scaleWriteFunction);
+                    if (this.data.tags[i].scaleWriteParams) {
+                        const tagParams = JSON.parse(this.data.tags[i].scaleWriteParams) as ScriptParam[];
+                        const notValid = this.initializeScriptParams(script, tagParams, this.configedWriteParams);
+                        if (notValid) {
+                            scaleWriteParams.value = undefined;
+                        }
+                    }
                 }
             }
             let values = {};
@@ -142,15 +181,28 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                     dateTimeFormat: dateTimeFormat.value
                 };
             }
-            if (scaleFunction.valid && scaleFunction.value) {
-                values = {...values, scaleFunction: scaleFunction.value};
+            if (scaleReadFunction.valid && scaleReadFunction.value) {
+                values = {...values, scaleReadFunction: scaleReadFunction.value};
+            }
+            if (scaleReadParams.valid && scaleReadParams.value) {
+                values = {...values, scaleReadParams: scaleReadParams.value};
+            }
+            if (scaleWriteFunction.valid && scaleWriteFunction.value) {
+                values = {...values, scaleWriteFunction: scaleWriteFunction.value};
+            }
+            if (scaleWriteParams.valid && scaleWriteParams.value) {
+                values = {...values, scaleWriteParams: scaleWriteParams.value};
             }
             this.formGroup.patchValue(values);
+            //this.loadParamsFormArray(this.configedReadParams, this.scaleReadParams);
+            //this.formGroup.setControl('scaleRead', this.initScripsFC('readscripts', this.configedReadParams));
             if (this.data.device?.id === FuxaServer.id) {
                 this.formGroup.controls.scaleMode.disable();
             }
             this.formGroup.updateValueAndValidity();
             this.onCheckScaleMode(this.formGroup.value.scaleMode);
+            this.onReadScriptChanged(this.formGroup.value.scaleReadFunction);
+            this.onWriteScriptChanged(this.formGroup.value.scaleWriteFunction);
         }
 
         this.formGroup.controls.scaleMode.valueChanges.subscribe(value => {
@@ -192,6 +244,27 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
     }
 
     onOkClick(): void {
+        let readParamsStr;
+        if (this.configedReadParams[this.formGroup.value.scaleReadFunction]) {
+            readParamsStr = JSON.stringify(this.configedReadParams[this.formGroup.value.scaleReadFunction]);
+        } else {
+            readParamsStr = undefined;
+        }
+
+        // const readParams = [];
+        // for (const p of this.scaleReadParams.controls) {
+        //     if (p.value.scriptId === this.formGroup.value.scaleReadFunction) {
+        //         const param: ScriptParam = new ScriptParam(p.get('name').value, ScriptParamType.value);
+        //         readParams.push(param);
+        //     }
+        // }
+        // const readParamsStr = readParams.length > 0 ? JSON.stringify(readParams) : undefined;
+        let writeParamsStr;
+        if (this.configedWriteParams[this.formGroup.value.scaleWriteFunction]) {
+            writeParamsStr = JSON.stringify(this.configedWriteParams[this.formGroup.value.scaleWriteFunction]);
+        } else {
+            writeParamsStr = undefined;
+        }
         this.dialogRef.close({
             daq: new TagDaq(
                 this.formGroup.value.enabled,
@@ -208,32 +281,230 @@ export class TagOptionsComponent implements OnInit, OnDestroy {
                 scaledHigh: this.formGroup.value.scaledHigh,
                 dateTimeFormat: this.formGroup.value.dateTimeFormat
             } : null,
-            scaleFunction: this.formGroup.value.scaleFunction,
+            scaleReadFunction: this.formGroup.value.scaleReadFunction,
+            scaleReadParams: readParamsStr,
+            scaleWriteFunction: this.formGroup.value.scaleWriteFunction,
+            scaleWriteParams: writeParamsStr,
         });
     }
 
-    onScriptChanged(scriptId) {
+    disableForm() {
+        return this.formGroup.invalid || this.paramsInValid();
+    }
+    paramsInValid() {
+        if (this.formGroup.value.scaleReadFunction) {
+            for (const p of this.configedReadParams[this.formGroup.value.scaleReadFunction]) {
+                if (!p.value) {
+                    return true;
+                }
+            }
+        }
+        if (this.formGroup.value.scaleWriteFunction) {
+            for (const p of this.configedWriteParams[this.formGroup.value.scaleWriteFunction]) {
+                if (!p.value) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    onReadScriptChanged(scriptId) {
         console.log(`Selected script ${scriptId}`);
-        // if (event && this.scripts) {
-        //     let script = this.scripts.find(s => s.id === scriptId);
-        //     event.actoptions[SCRIPT_PARAMS_MAP] = [];
-        //     if (script && script.parameters) {
-        //         event.actoptions[SCRIPT_PARAMS_MAP] = JSON.parse(JSON.stringify(script.parameters));
-        //     }
+       // this.enablePramsArray(this.scaleReadParams, scriptId);
+        // if (scriptId) {
+        //     this.formGroup.controls.scaleReadParams.setValidators(jsonValidator);
+        //     this.selectedReadScript = this.scripts.find(s => s.id === scriptId);
+        // } else {
+        //     this.formGroup.controls.scaleReadParams.clearValidators();
+        //     this.selectedReadScript = undefined;
         // }
+        this.formGroup.updateValueAndValidity();
+    }
+    onWriteScriptChanged(scriptId) {
+        console.log(`Selected script            ${scriptId}`);
+        if (scriptId) {
+            this.formGroup.controls.scaleWriteParams.setValidators(jsonValidator);
+            this.selectedWriteScript = this.scripts.find(s => s.id === scriptId);
+        } else {
+            this.formGroup.controls.scaleWriteParams.clearValidators();
+            this.selectedWriteScript = undefined;
+        }
+        this.formGroup.updateValueAndValidity();
     }
 
+    // get readScripts() {
+    //     return this.formGroup.get('scaleRead') as FormArray;
+    // }
+
+    // getReadParametersFormArray(scriptIndex: number) {
+    //     return this.readScripts.controls[scriptIndex].get('parameters') as FormArray;
+    //   }
+
+    //   getReadParameterControls(scriptIndex: number) {
+    //     return this.getReadParametersFormArray(scriptIndex).controls;
+    //   }
+
+    //   addReadScript(script: Script) {
+    //     this.readScripts.push(this.getScriptItem(script.name, script.id));
+    //   }
+    //   addReadParameter(scriptIndex: number, name: string, value: any) {
+    //     this.getReadParametersFormArray(scriptIndex).push(this.getParameterItem(name, value));
+    //   }
+    //   private addScriptFC(scriptsFCA: FormArray, script: Script) {
+    //     scriptsFCA.push(this.getParameterItem())
+
+    //   }
+    // private initScripsFC(name: string, defaultScriptParams: {[key: string]: ScriptAndParam[]}): FormGroup {
+    //     const fb = this.fb.group({
+    //       name: name,
+    //       scripts: this.fb.array([])
+    //     });
+    //     const fbsArray = fb.get('scripts') as FormArray;
+    //     for (const script of this.scripts) {
+    //         //this.addScriptFC(fb.get('scripts') as FormArray, script);
+    //         const sfg = this.getScriptItem(script.name, script.id);
+    //         const sfgPArray = sfg.get('parameters') as FormArray;
+    //         for (const p of defaultScriptParams[script.id]) {
+    //             const pfg = this.getParameterItem(p.name, p.value);
+    //             sfgPArray.push(pfg);
+    //         }
+    //         fbsArray.push(sfg);
+    //     }
+    //     return fb;
+    // }
+    // private getScriptItem(name: string, id: string) {
+    //     return this.fb.group({
+    //       name: name,
+    //       id: id,
+    //       parameters: this.fb.array([])
+    //     });
+    //   }
+
+    //   private getParameterItem(name: string = undefined, value: any = undefined) {
+    //     return this.fb.group({
+    //       name: name,
+    //       value:[value, Validators.required]
+    //     });
+    //   }
     private loadScripts() {
-        //scripts that can be used to scale a tag must take exactly one parameter (new tag value) and be
+        //scripts that can be used to scale a tag must have the first parameter named "value" of
+        // type value and be
         //run on the server
-        const filteredScripts = this.projectService.getScripts().filter(script => script.parameters.length === 1 && script.mode === ScriptMode.SERVER);
+        //if additional parameters are used they must be of type value and the value to pass
+        //must be provided in this form /////
+        const filteredScripts = this.projectService.getScripts().filter(script => {
+            if (script.parameters.length > 0 && script.mode === ScriptMode.SERVER) {
+                if (script.parameters[0].name !== 'value' || script.parameters[0].type !== ScriptParamType.value) {
+                    return false;
+                }
+                for (const param of script.parameters) {
+                    if (param.type !== ScriptParamType.value) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        });
+        // get default param/value list for each script
+        for (const script of filteredScripts) {
+            const paramCopy = [];
+            //skip the first param, as it is the value to scale
+            for (let i = 1; i < script.parameters.length; i++ ) {
+                const pc = new ScriptAndParam(script.parameters[i].name, script.parameters[i].type);
+                pc.scriptId = script.id;
+                pc.value = ('value' in script.parameters[i]) ? script.parameters[i].value : null;
+                paramCopy.push(pc);
+           }
+           this.configedReadParams[script.id] = paramCopy;
+           this.configedWriteParams[script.id] = paramCopy;
+        }
         this.scripts = filteredScripts;
 	}
+    // get scaleReadParams() {
+    //     return this.formGroup.get('scaleReadParams') as FormArray;
+    // }
+    // private addReadParam(scriptId: string, name: string, value: any) {
+    //     const param = this.fb.group( {
+    //         scriptId: [scriptId],
+    //         name: [name],
+    //         value: [value,[Validators.required]]
+    //     });
+    //     this.scaleReadParams.push(param);
+    // }
+    // private addParamToFormArray(paramsArray: FormArray, scriptId: string, name: string, value: any) {
+    //     const param = this.fb.group( {
+    //         scriptId: [scriptId],
+    //         name: [name],
+    //         value: [value,[Validators.required]]
+    //     });
+    //     paramsArray.push(param);
+    // }
+    // private enablePramsArray(paramsArray: FormArray, scriptId: string) {
+    //     for (const fcParam of paramsArray.controls) {
+    //         if (fcParam.value.scriptId === scriptId) {
+    //             fcParam.enable;
+    //         } else {
+    //             fcParam.disable;
+    //         }
+    //     }
+    // }
+    // private enableParamsForSelectedScripts(allParamsForAllScripts: FormArray) {
+    //     this.enablePramsArray(allParamsForAllScripts, this.formGroup.value.scaleReadFunction);
+    // }
+    // private loadParamsFormArray(defaultScriptParams: {[key: string]: ScriptAndParam[]}, paramsArray: FormArray) {
+    //     //defaultScriptParams now updated with passed in values, build formarray from this
+    //     for (const key in defaultScriptParams) {
+    //         const sp = defaultScriptParams[key];
+    //         for (const p of sp) {
+    //             this.addParamToFormArray(paramsArray, p.scriptId, p.name, p.value);
+    //         }
+    //     }
+    // }
+    /**
+     * updates this.configedParams list with the previously saved list of param/values for
+     * the script.
+     * @param script
+     * @param tagParams
+     * @returns returns true if the param/value list no longer matches script param/value list,
+     * in which case the this.configedParams is not updated (default list will be used)
+     */
+    private initializeScriptParams(script: Script, tagParams: ScriptParam[], toUpdate: {[key: string]: ScriptParam[]}) {
+        if (script) {
+            // verify current params list match script params/values list
+            let parametersChanged = false;
+            if (tagParams.length !== script.parameters.length - 1) {
+                parametersChanged = true;
+            } else {
+                for (const [index, param] of script.parameters.entries()) {
+                    if (index === 0) {
+                        continue;// skip first param as it is for the tag value
+                    }
+                    if (!(tagParams.some(p => p.name === param.name))) {
+                        parametersChanged = true;
+                        break;
+                    }
+                }
+            }
+            if (parametersChanged) {
+                return true;
+            } else {
+                // haven't changed, update the working list with the previously saved
+                // param/values
+                toUpdate[script.id] = tagParams;
+                return false;
+            }
+        }
+        return true;
+    }
 }
 
 export interface ITagOption {
     daq: TagDaq;
     format: number;
     scale: TagScale;
-    scaleFunction: string;
+    scaleReadFunction: string;
+    scaleReadParams: string;
+    scaleWriteFunction: string;
+    scaleWriteParams: string;
 }

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -911,6 +911,14 @@
     "device.tag-convert-ticktime": "Milliseconds to Time format (Remaining or Duration)",
     "device.tag-convert-ticktime-tooltip": "Example format: 'HH:mm:ss' for 56:45:10",
     "device.tag-convert-ticktime-format": "Time format (HH:mm:ss)",
+    "device.tag-scale-read-script": "Read Scale Script",
+    "device.tag-scale-read-script-tooltip": "Script to transform value received from client",
+    "device.tag-scale-read-script-params": "Enter Read Script Parameter Values",
+    "device.tag-scale-write-script": "Write Scale Script",
+    "device.tag-scale-write-script-tooltip": "Script to transform value before write to client",
+    "device.tag-scale-write-script-params": "Enter Write Script Parameter Values",
+    "device.tag-scale-script-params-tooltip": "JSON formated array of parameters with values to pass to script",
+    
 
     "device.connect-ok": "Ok",
     "device.connect-error": "Error",

--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -143,7 +143,7 @@ function BACNETclient(_data, _logger, _events, _runtime) {
             for (var deviceId in objectsMapToRead) {
                 try {
                     const deviceAddress = _getDeviceAddress(devices[deviceId]);
-                    await client.readPropertyMultiple(deviceAddress, objectsMapToRead[deviceId], (err, value) => {
+                    await client.readPropertyMultiple(deviceAddress, objectsMapToRead[deviceId], async (err, value) => {
                         if (err) {        
                             logger.error(`'${data.name}' readPropertyMultiple error! ${err}`);
                         } else {
@@ -167,7 +167,7 @@ function BACNETclient(_data, _logger, _events, _runtime) {
                                     }
                                 });
                                 if (result.length) {
-                                    let varsValueChanged = _updateVarsValue(deviceId, result);
+                                    let varsValueChanged = await _updateVarsValue(deviceId, result);
                                     lastTimestampValue = new Date().getTime();
                                     _emitValues(Object.values(varsValue));
                                     if (this.addDaq && !utils.isEmptyObject(varsValueChanged)) {

--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -134,6 +134,20 @@ function BACNETclient(_data, _logger, _events, _runtime) {
         });
     }
 
+    // Next function wraps the API client.readPropertyMultiple call into a Promise
+    // and handles the callbacks with resolve and reject.
+    // https://stackoverflow.com/questions/5010288/how-to-make-a-function-wait-until-a-callback-has-been-called-using-node-js
+    this.apiFunctionWrapper = function (deviceAddress, requestArray) {
+        return new Promise((resolve, reject) => {
+            client.readPropertyMultiple(deviceAddress, requestArray, async (err, value) => {
+                if (err) {
+                    logger.error(`'${data.name}' readPropertyMultiple error! ${err}`);
+                    reject(err);
+                }
+                resolve(value);
+            });
+        });
+}
     /**
      * Take the current Objects (Tags) value (only changed), Reset the change flag, Emit Tags value
      * Save DAQ value
@@ -143,43 +157,40 @@ function BACNETclient(_data, _logger, _events, _runtime) {
             for (var deviceId in objectsMapToRead) {
                 try {
                     const deviceAddress = _getDeviceAddress(devices[deviceId]);
-                    await client.readPropertyMultiple(deviceAddress, objectsMapToRead[deviceId], async (err, value) => {
-                        if (err) {        
-                            logger.error(`'${data.name}' readPropertyMultiple error! ${err}`);
-                        } else {
-                            if (!(value && value.values && value.values[0] && value.values[0].values)) {
-                                logger.error(`'${data.name}' readPropertyMultiple error! unknow`);
-                            } else if (value.values && value.values.length) {
-                                let result = [];
-                                let errors = [];
-                                value.values.forEach(data => { 
-                                    if (data.objectId && data.values && data.values[0].id === bacnet.enum.PropertyIdentifier.PRESENT_VALUE) {
-                                        let address = _formatId(data.objectId.type, data.objectId.instance);
-                                        if (data.values[0].value && data.values[0].value.type === bacnet.enum.ApplicationTag.ERROR) {
-                                            errors.push({ address: address, value: data.values[0].value.value, type:  data.objectId.type });    
-                                        } else {
-                                            result.push({ 
-                                                address: address,
-                                                rawValue: data.values[0].value[0].value,
-                                                type: data.objectId.type
-                                            });
-                                        }
-                                    }
-                                });
-                                if (result.length) {
-                                    let varsValueChanged = await _updateVarsValue(deviceId, result);
-                                    lastTimestampValue = new Date().getTime();
-                                    _emitValues(Object.values(varsValue));
-                                    if (this.addDaq && !utils.isEmptyObject(varsValueChanged)) {
-                                        this.addDaq(varsValueChanged, data.name, data.id);
-                                    }
+                    //wrap the client.readPropertyMultiple in a promise so the callback can be awaited
+                    const value = await this.apiFunctionWrapper(deviceAddress, objectsMapToRead[deviceId]);
+
+                    if (!(value && value.values && value.values[0] && value.values[0].values)) {
+                        logger.error(`'${data.name}' readPropertyMultiple error! unknow`);
+                    } else if (value.values && value.values.length) {
+                        let result = [];
+                        value.values.forEach(bacData => {
+                            if (bacData.objectId && bacData.values && bacData.values[0].id === bacnet.enum.PropertyIdentifier.PRESENT_VALUE) {
+                                let address = _formatId(bacData.objectId.type, bacData.objectId.instance);
+                                if (bacData.values[0].value && bacData.values[0].value.type === bacnet.enum.ApplicationTag.ERROR ||
+                                    bacData.values[0].value.length > 0 && bacData.values[0].value[0].type === bacnet.enum.ApplicationTag.ERROR ) {
+                                        logger.error(`'${data.name}' readPropertyMultiple error! errorClass: ${bacData.values[0].value[0].value.errorClass}, errorCode: ${bacData.values[0].value[0].value.errorCode}`);
+                                } else {
+                                    result.push({
+                                        address: address,
+                                        rawValue: bacData.values[0].value[0].value,
+                                        type: bacData.objectId.type
+                                    });
                                 }
                             }
-                            if (lastStatus !== 'connect-ok') {
-                                _emitStatus('connect-ok');                    
+                        });
+                        if (result.length) {
+                            let varsValueChanged = await _updateVarsValue(deviceId, result);
+                            lastTimestampValue = new Date().getTime();
+                            _emitValues(Object.values(varsValue));
+                            if (this.addDaq && !utils.isEmptyObject(varsValueChanged)) {
+                                this.addDaq(varsValueChanged, data.name, data.id);
                             }
                         }
-                    });
+                    }
+                    if (lastStatus !== 'connect-ok') {
+                        _emitStatus('connect-ok');
+                    }
                 } catch (err) {
                     if (err) {
                         logger.error(`'${data.name}' readPropertyMultiple error! ${err}`);
@@ -188,7 +199,7 @@ function BACNETclient(_data, _logger, _events, _runtime) {
             }
             _checkWorking(false);
         } else {
-            _emitStatus('connect-busy');                    
+            _emitStatus('connect-busy');
         }
 
     }
@@ -632,7 +643,7 @@ function BACNETclient(_data, _logger, _events, _runtime) {
                 varsValue[tag.id].changed = varsValue[tag.id].rawValue !== vars[index].rawValue;
                 if (!utils.isNullOrUndefined(vars[index].rawValue)) {
                     varsValue[tag.id].rawValue = vars[index].rawValue;
-                    varsValue[tag.id].value = await deviceUtils.tagValueCompose(vars[index].rawValue, varsValue[tag.id]);
+                    varsValue[tag.id].value = await deviceUtils.tagValueCompose(vars[index].rawValue, tag, runtime);
                     vars[index].value = varsValue[tag.id].value;
                     if (this.addDaq && deviceUtils.tagDaqToSave(varsValue[tag.id], timestamp)) {
                         changed[tag.id] = { id: tag.id, value: varsValue[tag.id].value, type: vars[index].type, daq: tag.daq, timestamp: timestamp };

--- a/server/runtime/devices/device-utils.js
+++ b/server/runtime/devices/device-utils.js
@@ -21,7 +21,9 @@ module.exports = {
 
     tagValueCompose: async function (value, tag, runtime = undefined) {
         var obj = {value: null };
-        value = await callScaleScript(tag.scaleReadFunction, tag.scaleReadParams, runtime, true, value);
+        if (tag.scaleReadFunction) {
+            value = await callScaleScript(tag.scaleReadFunction, tag.scaleReadParams ? tag.scaleReadParams : undefined, runtime, true, value);
+        }
      
         if (tag && utils.isNumber(value, obj)) {
             try {
@@ -58,7 +60,9 @@ module.exports = {
                 console.error(err);
             }
         }
-        value = await callScaleScript(tag.scaleWriteFunction, tag.scaleWriteParams, runtime, false, value);
+        if (tag.scaleWriteFunction) {
+            value = await callScaleScript(tag.scaleWriteFunction, tag.scaleWriteParams ? tag.scaleWriteParams : undefined, runtime, false, value);
+        }
         
         return value;
     }

--- a/server/runtime/devices/device-utils.js
+++ b/server/runtime/devices/device-utils.js
@@ -129,4 +129,5 @@ const callScaleScript = async (scriptId, params, runtime, isRead, value) => {
         }
         return value;
     }
+    return value;
 }

--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -55,7 +55,7 @@ function Device(data, runtime) {
         if (!MODBUSclient) {
             return null;
         }
-        comm = MODBUSclient.create(data, logger, events, manager);        
+        comm = MODBUSclient.create(data, logger, events, manager, runtime);        
     } else if (data.type === DeviceEnum.BACnet) {
         if (!BACNETclient) {
             return null;

--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -45,12 +45,12 @@ function Device(data, runtime) {
         if (!S7client) {
             return null;
         }
-        comm = S7client.create(data, logger, events, manager);
+        comm = S7client.create(data, logger, events, manager, runtime);
     } else if (data.type === DeviceEnum.OPCUA) {
         if (!OpcUAclient) {
             return null;
         }
-        comm = OpcUAclient.create(data, logger, events, manager);
+        comm = OpcUAclient.create(data, logger, events, manager, runtime);
     } else if (data.type === DeviceEnum.ModbusRTU || data.type === DeviceEnum.ModbusTCP) {
         if (!MODBUSclient) {
             return null;
@@ -60,12 +60,12 @@ function Device(data, runtime) {
         if (!BACNETclient) {
             return null;
         }
-        comm = BACNETclient.create(data, logger, events, manager);        
+        comm = BACNETclient.create(data, logger, events, manager, runtime);        
     } else if (data.type === DeviceEnum.WebAPI) {
         if (!HTTPclient) {
             return null;
         }
-        comm = HTTPclient.create(data, logger, events, manager);        
+        comm = HTTPclient.create(data, logger, events, manager, runtime);        
     } else if (data.type === DeviceEnum.MQTTclient) {
         if (!MQTTclient) {
             return null;
@@ -76,7 +76,7 @@ function Device(data, runtime) {
         if (!EthernetIPclient) {
             return null;
         }
-        comm = EthernetIPclient.create(data, logger, events, manager);     
+        comm = EthernetIPclient.create(data, logger, events, manager, runtime);     
     } else if (data.type === DeviceEnum.FuxaServer) {
         if (!FuxaServer) {
             return null;
@@ -236,9 +236,9 @@ function Device(data, runtime) {
     /**
      * Call Device to set Tag value
      */
-    this.setValue = function (id, value, fnc) {
+    this.setValue = async function (id, value, fnc) {
         var fncvalue = this.getValueInFunction(this.getValue(id), value, fnc);
-        return comm.setValue(id, value);
+        return await comm.setValue(id, value);
     }
 
     /**
@@ -386,9 +386,11 @@ function Device(data, runtime) {
                     var restored = 0;
                     toRestore.forEach(element => {
                         if (element.id && !utils.isNullOrUndefined(element.value)) {
-                            if (self.setValue(element.id, element.value)) {
-                                restored++;
-                            }
+                            self.setValue(element.id, element.value).then((result) => {
+                                if (result) {
+                                    restored++;
+                                }
+                            });
                         }
                     });
                     logger.info(`'${property.name}' restored ${restored}/${toRestore.length} values`);

--- a/server/runtime/devices/fuxaserver/index.js
+++ b/server/runtime/devices/fuxaserver/index.js
@@ -56,7 +56,7 @@ function FuxaServer(_data, _logger, _events) {
         if (_checkWorking(true)) {
             try {
                 if (tocheck) {
-                    var varsValueChanged = _checkVarsChanged();
+                    var varsValueChanged = await _checkVarsChanged();
                     lastTimestampValue = new Date().getTime();
                     _emitValues(varsValue);
                     if (this.addDaq && !utils.isEmptyObject(varsValueChanged)) {
@@ -242,12 +242,12 @@ function FuxaServer(_data, _logger, _events) {
     /**
      * Return the Tags that have value changed and clear value changed flag of all Tags 
      */
-    var _checkVarsChanged = () => {
+    var _checkVarsChanged = async () => {
         const timestamp = new Date().getTime();
         var result = {};
         for (var id in data.tags) {
             if (!utils.isNullOrUndefined(data.tags[id].value)) {
-                data.tags[id].value = deviceUtils.tagValueCompose(data.tags[id].value, data.tags[id]);
+                data.tags[id].value = await deviceUtils.tagValueCompose(data.tags[id].value, data.tags[id]);
                 data.tags[id].timestamp = timestamp;
                 if (this.addDaq && deviceUtils.tagDaqToSave(data.tags[id], timestamp)) {
                     result[id] = data.tags[id];

--- a/server/runtime/devices/index.js
+++ b/server/runtime/devices/index.js
@@ -265,7 +265,9 @@ function setTagValue(tagid, value) {
     try {
         let deviceid = getDeviceIdFromTag(tagid)
         if (activeDevices[deviceid]) {
-            return activeDevices[deviceid].setValue(tagid, value);
+            activeDevices[deviceid].setValue(tagid, value).then(result => {
+                return result;
+            });
         }
     } catch (err) {
         console.error(err);
@@ -371,9 +373,9 @@ function isWoking() {
  * @param {*} sigid 
  * @param {*} value 
  */
-function setDeviceValue(deviceid, sigid, value, fnc) {
+async function setDeviceValue(deviceid, sigid, value, fnc) {
     if (activeDevices[deviceid]) {
-        activeDevices[deviceid].setValue(sigid, value, fnc);
+        await activeDevices[deviceid].setValue(sigid, value, fnc);
     }
 }
 

--- a/server/runtime/devices/modbus/index.js
+++ b/server/runtime/devices/modbus/index.js
@@ -290,17 +290,21 @@ function MODBUSclient(_data, _logger, _events, _runtime) {
             var offset = parseInt(data.tags[sigid].address) - 1;   // because settings address from 1 to 65536 but communication start from 0
             value = deviceUtils.tagRawCalculator(value, data.tags[sigid]);
 
-            //var val = datatypes[data.tags[sigid].type].formatter(convertValue(value, data.tags[sigid].divisor, true));
             const divVal = convertValue(value, data.tags[sigid].divisor, true);
             var val;
             if (data.tags[sigid].scaleFunction) {
-                //const script = runtime.scriptsMgr.scriptModule.getScript({id: data.tags[sigid].scaleFunction });
-                const script = {id: data.tags[sigid].scaleFunction, name: null, parameters: [{name: 'value', type: 'value', value: divVal}] };
-                const bufVal = await runtime.scriptsMgr.runScript(script);
-                val = [];
-                for (let i = 0; i < bufVal.length;) {
-                    val.push(bufVal.readUInt16BE(i));
-                    i = i + 2;
+                const script = { id: data.tags[sigid].scaleFunction, name: null, parameters: [{ name: 'value', type: 'value', value: divVal }] };
+                try {
+
+                    const bufVal = await runtime.scriptsMgr.runScript(script);
+                    val = [];
+                    for (let i = 0; i < bufVal.length;) {
+                        val.push(bufVal.readUInt16BE(i));
+                        i = i + 2;
+                    }
+                } catch (error) {
+                    logger.error(`'${data.tags[sigid].name}' setValue script error! ${error.toString()}`);
+                    return false;
                 }
 
             } else {

--- a/server/runtime/devices/modbus/index.js
+++ b/server/runtime/devices/modbus/index.js
@@ -297,6 +297,10 @@ function MODBUSclient(_data, _logger, _events, _runtime) {
                 try {
 
                     const bufVal = await runtime.scriptsMgr.runScript(script);
+                    if ((bufVal.length % 2) !== 0 ) {
+                        logger.error(`'${data.tags[sigid].name}' setValue script error, returned buffer invalid must be mod 2`);
+                        return false;
+                    }
                     val = [];
                     for (let i = 0; i < bufVal.length;) {
                         val.push(bufVal.readUInt16BE(i));

--- a/server/runtime/scripts/index.js
+++ b/server/runtime/scripts/index.js
@@ -74,7 +74,7 @@ function ScriptsManager(_runtime) {
                     result = await scriptModule.runTestScript(script);
                 } else {
                     logger.info(`Run script ${script.name}`);
-                    result = scriptModule.runScript(script);
+                    result = await scriptModule.runScript(script);
                 }
                 resolve(result || `Script OK: ${script.name}`);
             } catch (err) {

--- a/server/runtime/scripts/msm.js
+++ b/server/runtime/scripts/msm.js
@@ -47,7 +47,7 @@ function MyScriptsModule(_events, _logger) {
 
         var result = _scriptsToModule(tempScripts, eventsIncludes);
         if (result.module) {
-            var paramsValue = _script.parameters.map(p => p.value || p);
+            var paramsValue = _script.parameters.map(p => _isNullOrUndefined(p.value) ? p : p.value);
             result.module[initEvents.name](events, _script.outputId);
             return result.module[_script.name](...paramsValue);
         }
@@ -55,8 +55,8 @@ function MyScriptsModule(_events, _logger) {
     }
 
     this.runScript = function (_script) {
-        if (scriptsModule) {
-            var paramsValue = _script.parameters.map(p => p.value || p);
+        if (scriptsModule) {            
+            var paramsValue = _script.parameters.map(p => _isNullOrUndefined(p.value) ? p : p.value);
             if (!_script.name) {
                 _script = Object.values(scriptsMap).find(s => s.id === _script.id);
             }
@@ -136,6 +136,9 @@ function MyScriptsModule(_events, _logger) {
         var m = new Module();
         m._compile(src, filename);
         return m.exports;
+    }
+    var _isNullOrUndefined = function (ele) {
+        return (ele === null || ele === undefined) ? true : false;
     }
 }
 


### PR DESCRIPTION
As discussed in this issue:
https://github.com/frangoteam/FUXA/issues/1197

I've tested with 
bacnet (see below for additional notes)
http client
modbus
mqtt
opcua

General script calling
In msm.js lines 50 and 59 you had:
var paramsValue = _script.parameters.map(p => p.value || p);

when p.value === 0, this would pass p.  I assume that is not wanted and 0 should be passed to the script.  I changed it to:
var paramsValue = _script.parameters.map(p => _isNullOrUndefined(p.value) ? p : p.value);

perhaps it should only check for undefined?


Bacnet:

While testing the various clients I noticed that there might be a problem with the way the Bacnet polling is done.  
The polling method in Bacnet does:
await client.readPropertyMultiple(...)
but the node-bacnet client is not async.  

Tag scripts use the existing methods for calling scripts, which makes all scripts async.  So I've changed all the code to handle this.  The problem with how the bacnet client works is that the polling routine can be called multiple times while still waiting for the result from a previous call.

Example:  User configures 3 second polling, but response takes longer than 3 seconds.
Time
0s) polling is called ->  client.readPropertyMultiple(..., callback) returns immediately --> polling function returns 
the callback passed to client.readPropertyMultiple has not returned.
3s) polling is called ->  client.readPropertyMultiple(..., callback) returns immediately --> polling function returns 
the callback passed to client.readPropertyMultiple has not returned.
the callback for the first call to client.readPropertyMultiple returns...
6s) polling is called ->  client.readPropertyMultiple(..., callback) returns immediately --> polling function returns 
the callback passed to client.readPropertyMultiple has not returned.
the callback for the second call to client.readPropertyMultiple returns...

Basically the _checkWorking is not doing what it is supposed to. 

To solve this I wrapped the call to client.readPropertyMultiple in a promise.  This results in:

0s) polling is called ->  client.readPropertyMultiple(..., callback) returns immediately --> waits for response...
the callback passed to client.readPropertyMultiple has not returned.
3s) polling is called, _checkWorking fails
'BacnetTest' working overload! 0
polling exits
the callback for the first call to client.readPropertyMultiple returns...
the first polling call returns and clears the working flag
6s) polling is called ->  client.readPropertyMultiple(..., callback) returns immediately --> waits for response...

Other changes in the bacnet client:
changed the 
value.values.forEach(data => {
to
value.values.forEach(bacData => {
as data was too confusing with the data member
removed the errors[] array, wasn't used.
With the bacnet device simulator I was using, errors are indicated by  
bacData.values[0].value[0].type === bacnet.enum.ApplicationTag.ERROR
where as the current  check is done for
bacData.values[0].value.type === bacnet.enum.ApplicationTag.ERROR

I've changed the code to look for both, but perhaps this needs more testing if only one is correct. I was using the Bac simulator from SCADAEngine.com




