### PR TITLE
Switching from the BACnet library to node-backstack. Added support for Multistate objects.

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa-server",
-  "version": "1.1.19-1470",
+  "version": "1.1.19-1500",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -883,6 +883,25 @@
       "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
       "requires": {
         "precond": "0.2"
+      }
+    },
+    "bacstack": {
+      "version": "0.0.1-beta.14",
+      "resolved": "https://registry.npmjs.org/bacstack/-/bacstack-0.0.1-beta.14.tgz",
+      "integrity": "sha512-hmDL0MgGV8UNWffkMXIczlnqXC0g/9tfSXw0MjZ8Wd0dkgAYqNAPV4R6+n78zgUw52cezbzsTEFL3YK6kjspjQ==",
+      "requires": {
+        "debug": "^4.3.1",
+        "iconv-lite": "^0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "balanced-match": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "app-root-path": "2.2.1",
     "async": "3.2.3",
     "axios": "0.28.0",
+    "bacstack": "0.0.1-beta.14",
     "bcryptjs": "2.4.3",
     "bluebird": "3.7.2",
     "body-parser": "1.20.0",

--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -340,7 +340,7 @@ function BACNETclient(_data, _logger, _events) {
                 tryExplicit = settings['broadcastAddress'].indexOf('255') === -1;
             }
 
-            if (utils.getNetworkInterfaces().indexOf(ipInterface) === -1) {
+            if (ipInterface != '0.0.0.0' && utils.getNetworkInterfaces().indexOf(ipInterface) === -1) {
                 reject(`'${data.name}' selected interface don't exist!`);
                 return;
             }

--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -523,6 +523,11 @@ function BACNETclient(_data, _logger, _events) {
                 bacobj.type === bacnet.enum.ObjectType.BINARY_VALUE) {
                 tvalue.type = bacnet.enum.ApplicationTag.ENUMERATED;
                 tvalue.value = parseInt(value);
+            } else if (bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_INPUT ||
+                bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_OUTPUT ||
+                bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_VALUE) {
+                tvalue.type = bacnet.enum.ApplicationTag.UNSIGNED_INTEGER;
+                tvalue.value = parseInt(value);
             }
 
             client.writeProperty(address, bacobj, bacnet.enum.PropertyIdentifier.PRESENT_VALUE, [tvalue], { priority: 16 }, (err, result) => {
@@ -583,6 +588,12 @@ function BACNETclient(_data, _logger, _events) {
             return 'Variable';
         } else if (type === bacnet.enum.ObjectType.BINARY_VALUE) {
             return 'Variable';
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_INPUT) {
+            return 'Variable';
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_OUTPUT) {
+            return 'Variable';
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_VALUE) {
+            return 'Variable';
         } else {
             return 'Object';
         }
@@ -606,6 +617,12 @@ function BACNETclient(_data, _logger, _events) {
         } else if (type === bacnet.enum.ObjectType.BINARY_OUTPUT) {
             return true;
         } else if (type === bacnet.enum.ObjectType.BINARY_VALUE) {
+            return true;
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_INPUT) {
+            return true;
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_OUTPUT) {
+            return true;
+        } else if (type === bacnet.enum.ObjectType.MULTI_STATE_VALUE) {
             return true;
         } else {
             return false;

--- a/server/runtime/devices/bacnet/index.js
+++ b/server/runtime/devices/bacnet/index.js
@@ -154,7 +154,7 @@ function BACNETclient(_data, _logger, _events) {
                                 value.values.forEach(data => { 
                                     if (data.objectId && data.values && data.values[0].id === bacnet.enum.PropertyIdentifier.PRESENT_VALUE) {
                                         let address = _formatId(data.objectId.type, data.objectId.instance);
-                                        if (data.values[0].value && data.values[0].value.type === bacnet.enum.ApplicationTag.ERROR) {
+                                        if (data.values[0].value && data.values[0].value.type === bacnet.enum.ApplicationTags.ERROR) {
                                             errors.push({ address: address, value: data.values[0].value.value, type:  data.objectId.type });    
                                         } else {
                                             result.push({ 
@@ -356,15 +356,14 @@ function BACNETclient(_data, _logger, _events) {
             devices = {};
             try {
                 client.on('iAm', (device) => {
-                    if (device && device.payload &&  device.payload.deviceId && !devices[device.id]) {
+                    if (device &&  device.deviceId && !devices[device.id]) {
                         if (tdelay) {
                             clearTimeout(tdelay);
                         }
                         device = {
-                            ...device.payload,
-                            ...device.header,
-                            id: device.payload.deviceId,
-                            name: 'DeviceId ' + device.payload.deviceId
+                            ...device,
+                            id: device.deviceId,
+                            name: 'DeviceId ' + device.deviceId
                         };
                         devices[device.id] = device;
                         resolve();
@@ -510,23 +509,23 @@ function BACNETclient(_data, _logger, _events) {
 
     var _writeProperty = function(address, bacobj, value) {
         return new Promise(function (resolve, reject) {
-            var tvalue = {type: bacnet.enum.ApplicationTag.NULL, value: value};
+            var tvalue = {type: bacnet.enum.ApplicationTags.NULL, value: value};
             bacobj.type = parseInt(bacobj.type);
             bacobj.instance = parseInt(bacobj.instance);
             if (bacobj.type === bacnet.enum.ObjectType.ANALOG_INPUT || 
                 bacobj.type === bacnet.enum.ObjectType.ANALOG_OUTPUT || 
                 bacobj.type === bacnet.enum.ObjectType.ANALOG_VALUE) {
-                tvalue.type = bacnet.enum.ApplicationTag.REAL;
+                tvalue.type = bacnet.enum.ApplicationTags.REAL;
                 tvalue.value = parseFloat(value);
             } else if (bacobj.type === bacnet.enum.ObjectType.BINARY_INPUT || 
                 bacobj.type === bacnet.enum.ObjectType.BINARY_OUTPUT || 
                 bacobj.type === bacnet.enum.ObjectType.BINARY_VALUE) {
-                tvalue.type = bacnet.enum.ApplicationTag.ENUMERATED;
+                tvalue.type = bacnet.enum.ApplicationTags.ENUMERATED;
                 tvalue.value = parseInt(value);
             } else if (bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_INPUT ||
                 bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_OUTPUT ||
                 bacobj.type === bacnet.enum.ObjectType.MULTI_STATE_VALUE) {
-                tvalue.type = bacnet.enum.ApplicationTag.UNSIGNED_INTEGER;
+                tvalue.type = bacnet.enum.ApplicationTags.UNSIGNED_INTEGER;
                 tvalue.value = parseInt(value);
             }
 
@@ -739,8 +738,8 @@ module.exports = {
         // deviceCloseTimeout = settings.deviceCloseTimeout || 15000;
     },
     create: function (data, logger, events, manager) {
-        try { bacnet = require('node-bacnet'); } catch { }
-        if (!bacnet && manager) { try { bacnet = manager.require('node-bacnet'); } catch { } }
+        try { bacnet = require('bacstack'); } catch { }
+        if (!bacnet && manager) { try { bacnet = manager.require('bacstack'); } catch { } }
         if (!bacnet) return null;
         return new BACNETclient(data, logger, events);
     }


### PR DESCRIPTION
1.	Switching from the BACnet library to node-backstack.
When querying for the list of objects (OBJECT_LIST) and there is a large number of objects on the controllers (around 100), readProperty returns an incorrect value. Replaced it with the node-bacstack library. 
                
https://github.com/fh1ch/node-bacstack 
 
2.	Changing from readProperty to readPropertyMultiple when we querying for name of objects.
The change was made to reduce the number of packets when querying for a large number of objects.

3.	Added support for Multistate objects.
Added Multistate Variable, Multistate Input, Multistate Output.

