### PR TITLE
Fix alarm counter in header to display only active alarms

### DIFF
--- a/server/runtime/alarms/index.js
+++ b/server/runtime/alarms/index.js
@@ -72,7 +72,9 @@ function AlarmsManager(_runtime) {
                 var result = { highhigh: 0, high: 0, low: 0, info: 0, actions: [] };
                 if (alrs) {
                     Object.values(alrs).forEach(alr => {
-                        result[alr.type]++;
+                        if (alr.status == AlarmStatusEnum.ON) {
+                            result[alr.type]++;
+                        }
                         if (alr.type === AlarmsTypes.ACTION && !alr.offtime) {
                             var action = actionsProperty[alr.nametype];
                             if (action.subproperty) {


### PR DESCRIPTION
Currently, the alarm counter in the header sums all alarms regardless of their status, including those with the status **AlarmStatusEnum.VOID**, resulting in an _incorrect_ number. 

This pull request modifies the counter to display only the **ACTIVE** alarms. This behavior is standard in other tools, but we can improve it in the future to make this behavior configurable.