### PR TITLE
Fix: Incorrect Display Height of Toggle Switch

### DIFF
--- a/client/src/app/gui-helpers/ngx-switch/ngx-switch.component.html
+++ b/client/src/app/gui-helpers/ngx-switch/ngx-switch.component.html
@@ -1,6 +1,6 @@
 <label class="md-switch" [style.borderRadius]="options.radius + 'px'">
     <div class="toggle-button" #toggler>
-        <input type="checkbox" (change)="onClick()" #switcher>
+        <input type="checkbox" (change)="onClick()" #switcher style="vertical-align: middle;">
         <div class="inner-circle" #slider style="text-align: center;line-height: inherit;" [style.fontSize]="options.fontSize + 'px'" [style.fontFamily]="options.fontFamily">
         </div>
     </div>


### PR DESCRIPTION
#868 
This fix addresses an issue where the height of the toggle switch was not displaying correctly. The problem was resolved by setting the vertical-align style property to middle for the input element.