### PR TITLE
Round the number before converting it to a BigInt for ModBus

### DIFF
--- a/server/runtime/devices/modbus/datatypes.js
+++ b/server/runtime/devices/modbus/datatypes.js
@@ -2,14 +2,14 @@
 function _gen(bytes, bFn, WordLen, swapType, toCast = false) {
     return {
         bytes,
-        parser: (buffer, offset = 0) => { 
+        parser: (buffer, offset = 0) => {
             _swap(buffer, swapType, offset);
-            var value = buffer['read' + bFn](offset); 
-            return (toCast) ? Number(value) : value; 
+            var value = buffer['read' + bFn](offset);
+            return (toCast) ? Number(value) : value;
         },
         formatter: v => {
             var b = Buffer.allocUnsafe(bytes);//new Buffer(bytes);
-            b['write' + bFn](toCast ? BigInt(v) : v);
+            b['write' + bFn](toCast ? BigInt(Math.round(v)) : v);
             _swap(b, swapType);
             return b;
         },
@@ -21,8 +21,8 @@ function _swap(buffer, swapType, offset = 0) {
     if (swapType == 2) {
         var temp = buffer[offset + 0];
         buffer[offset + 0] = buffer[offset + 2]; buffer[offset + 2] = temp;
-        temp = buffer[offset + 1]; 
-        buffer[offset + 1] = buffer[offset + 3];buffer[offset + 3] = temp;
+        temp = buffer[offset + 1];
+        buffer[offset + 1] = buffer[offset + 3]; buffer[offset + 3] = temp;
     }
 }
 
@@ -65,7 +65,7 @@ const Datatypes = {
      * Int64
      */
     Int64: _gen(8, 'BigInt64BE', 4, 0, true),
-        
+
     /**
      * Int16LE
      */
@@ -94,7 +94,7 @@ const Datatypes = {
      * Int64
      */
     Int64LE: _gen(8, 'BigInt64LE', 4, 0, true),
-    
+
     /**
      * Int32MLE
      */


### PR DESCRIPTION
Hi, thank you for this awesome project, this is an incredible powerful software!

I ran into a problem while trying to use a `Divisor` with an `Int64` ModBus value. Reading the value works fine, but writing was throwing the following error:
```
RangeError: The number 9999.99998 cannot be converted to a BigInt because it is not an integer
```

`BigInt` only accepts integers, so in my opinion the correct behavior should be to round the value to the closest integer when `toCast` is true, which is only the case for integer types so this won't affect float types. I tested it with these changes and it fixed the problem for me.

There is also some whitespace changes from my editor, let me know if you want me to remove them.