### PR TITLE
Update odbc to v2.4.9 and node to v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bookworm
+FROM node:18-bookworm
 
 ARG NODE_SNAP=false
 
@@ -24,26 +24,6 @@ WORKDIR /usr/src/app
 
 # Copy odbcinst.ini to /etc
 RUN cp FUXA/odbc/odbcinst.ini /etc/odbcinst.ini
-
-# Clone node-odbc repository
-RUN git clone https://github.com/markdirish/node-odbc.git
-
-# Change working directory to node-odbc
-WORKDIR /usr/src/app/node-odbc
-
-# Install compatible versions of global npm packages
-RUN npm install -g node-gyp && \
-    npm install -g npm@8 && \
-    npm install -g node-addon-api && \
-    npm install -g @mapbox/node-pre-gyp
-
-# Install dependencies and build node-odbc
-RUN npm ci --production && \
-    ./node_modules/.bin/node-pre-gyp rebuild --production && \
-    ./node_modules/.bin/node-pre-gyp package
-
-# Build and install node-odbc
-#RUN npm install
 
 # Install Fuxa server
 WORKDIR /usr/src/app/FUXA/server

--- a/server/package.json
+++ b/server/package.json
@@ -39,7 +39,7 @@
     "node-schedule": "2.1.1",
     "nodemailer": "6.9.9",
     "nopt": "5.0.0",
-    "odbc": "2.4.8",
+    "odbc": "2.4.9",
     "pdfmake": "0.2.5",
     "socket.io": "2.5.0",
     "sqlite3": "5.1.5",


### PR DESCRIPTION
odbc v4.2.9 fixes install bugs, but requires node v18 have also removed the odbc build and install in the dockerfile as it's no longer needed