### PR TITLE
Enhance OpenCard Event with Configurable Reference Origin for X and Y Positions (Cursor or Window)

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -338,6 +338,11 @@ export enum GaugeEventActionType {
     onMonitor = 'shapes.event-onmonitor',
 }
 
+export enum GaugeEventRelativeFromType {
+    window = 'shapes.event-relativefrom-window',
+    mouse = 'shapes.event-relativefrom-mouse'
+}
+
 export enum GaugeEventSetValueType {
     set = 'shapes.event-setvalue-set',
     add = 'shapes.event-setvalue-add',

--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -15,7 +15,7 @@ import {
 import { Subject, Subscription, take } from 'rxjs';
 import { ChangeDetectorRef } from '@angular/core';
 
-import { Event, GaugeEvent, GaugeEventActionType, GaugeSettings, GaugeProperty, GaugeEventType, GaugeRangeProperty, GaugeStatus, Hmi, View, ViewType, Variable, ZoomModeType, InputOptionType, DocAlignType, DictionaryGaugeSettings } from '../_models/hmi';
+import { Event, GaugeEvent, GaugeEventActionType, GaugeSettings, GaugeProperty, GaugeEventType, GaugeRangeProperty, GaugeStatus, Hmi, View, ViewType, Variable, ZoomModeType, InputOptionType, DocAlignType, DictionaryGaugeSettings, GaugeEventRelativeFromType } from '../_models/hmi';
 import { GaugesManager } from '../gauges/gauges.component';
 import { Utils } from '../_helpers/utils';
 import { ScriptParam, SCRIPT_PARAMS_MAP, ScriptParamType } from '../_models/script';
@@ -720,8 +720,15 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
             return;
         }
         card = new CardModel(id);
-        card.x = event.clientX + (Utils.isNumeric(options.left) ? parseInt(options.left) : 0);
-        card.y = event.clientY + (Utils.isNumeric(options.top) ? parseInt(options.top) : 0);
+
+        if (options.relativeFrom && options.relativeFrom == Utils.getEnumKey(GaugeEventRelativeFromType, GaugeEventRelativeFromType.window)) {
+            card.x = (Utils.isNumeric(options.left) ? parseInt(options.left) : 0);
+            card.y = (Utils.isNumeric(options.top) ? parseInt(options.top) : 0);
+        } else {
+            card.x = event.clientX + (Utils.isNumeric(options.left) ? parseInt(options.left) : 0);
+            card.y = event.clientY + (Utils.isNumeric(options.top) ? parseInt(options.top) : 0);
+        }
+
         if (this.hmi.layout.hidenavigation) {
             card.y -= 48;
         }

--- a/client/src/app/gauges/gauge-property/flex-event/flex-event.component.html
+++ b/client/src/app/gauges/gauge-property/flex-event/flex-event.component.html
@@ -52,7 +52,7 @@
                 </mat-select>
             </div>
         </ng-template>
-        <div *ngIf="withPosition(item.action)" class="table mt5">
+        <div *ngIf="withPosition(item.action)" class="table mt8">
             <div class="my-form-field lbk">
                 <span>{{'general-x' | translate}}</span>
                 <input numberOnly [(ngModel)]="item.actoptions.left" type="number" style="width: 60px">
@@ -61,9 +61,17 @@
                 <span>{{'general-y' | translate}}</span>
                 <input numberOnly [(ngModel)]="item.actoptions.top" type="number" style="width: 60px">
             </div>
-            <div *ngIf="cardDestination === item.action" class="my-form-field lbk ml10 tac" style="max-width: 70px;">
+            <div *ngIf="cardDestination === item.action" class="my-form-field lbk ml10 tac" style="max-width: 70px;margin-top: 5px">
                 <span>{{'gauges.property-event-single-card' | translate}}</span>
                 <mat-slide-toggle color="primary" [(ngModel)]="item.actoptions.singleCard"></mat-slide-toggle>
+            </div>
+            <div class="my-form-field lbk" style="width: 240px;margin-top: 5px">
+                <span>{{'gauges.property-event-destination-relative-from' | translate}}</span>
+                <mat-select [(value)]="item.actoptions.relativeFrom">
+                    <mat-option *ngFor="let rf of relativeFromType | enumToArray" [value]="rf.key">
+                        {{ rf.value }}
+                    </mat-option>
+                </mat-select>
             </div>
         </div>
     </div>

--- a/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
+++ b/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {
     GaugeEvent,
     GaugeEventActionType,
+    GaugeEventRelativeFromType,
     GaugeEventSetValueType,
     GaugeEventType,
     GaugeProperty,
@@ -37,6 +38,7 @@ export class FlexEventComponent implements OnInit {
     eventType = {};
     setValueType = GaugeEventSetValueType;
     enterActionType = {};
+    relativeFromType = GaugeEventRelativeFromType;
     actionType = GaugeEventActionType;
     eventActionOnCard = Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onwindow);
     eventWithPosition = [Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.oncard),
@@ -61,6 +63,11 @@ export class FlexEventComponent implements OnInit {
         }
         this.viewPanels = <PanelData[]>Object.values(this.data.view?.items ?? [])?.filter((item: any) => item.type === 'svg-ext-own_ctrl-panel');//#issue on build  PanelComponent.TypeTag);
         this.enterActionType[Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onRunScript)] = this.translateService.instant(GaugeEventActionType.onRunScript);
+
+        Object.keys(this.relativeFromType).forEach(key => {
+            console.log(this.relativeFromType[key]);
+            this.translateService.get(this.relativeFromType[key]).subscribe((txt: string) => { this.relativeFromType[key] = txt; });
+        });
 
         Object.keys(this.actionType).forEach(key => {
             this.translateService.get(this.actionType[key]).subscribe((txt: string) => { this.actionType[key] = txt; });

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -699,6 +699,8 @@
     "shapes.event-onmonitor": "Monitor",
     "shapes.event-onViewToPanel": "Set View to Panel",
     "shapes.event-onLoad": "OnLoad",
+    "shapes.event-relativefrom-window": "Window",
+    "shapes.event-relativefrom-mouse": "Mouse",
 
     "pipe.property-props": "Property",
     "pipe.property-border-width": "Border width",
@@ -970,6 +972,7 @@
     "gauges.property-event-type": "Type",
     "gauges.property-event-action": "Action",
     "gauges.property-event-destination": "Destination",
+    "gauges.property-event-destination-relative-from": "Relative from",
     "gauges.property-event-destination-panel": "Panel",
     "gauges.property-event-destination-hide-close": "Hide Close",
     "gauges.property-event-single-card": "Single Card",

--- a/client/src/assets/i18n/pt.json
+++ b/client/src/assets/i18n/pt.json
@@ -340,7 +340,9 @@
     "shapes.action-clockwise": "Mudar sentido do Relógio",
     "shapes.action-anticlockwise": "Mudar Contra-relógio",
     "shapes.action-downup": "Cima e abaixo",
-
+    "shapes.event-relativefrom-window": "Janela",
+    "shapes.event-relativefrom-mouse": "Cursor",
+    
     "pipe.property-props": "Propriedade",
     "pipe.property-border-width": "Largura da fronteira",
     "pipe.property-border-color": "Cor da fronteira",
@@ -508,6 +510,7 @@
     "gauges.property-head-remove-mapvariable": "Remover a ligação",
     "gauges.property-tooltip-add-event": "Adicionar evento",
     "gauges.property-interval-msec": "Intervalo (msec.)",
+
 
     "bag.property-ticks": "Ticks",
     "bag.property-divisions": "Divisões",


### PR DESCRIPTION
### Description

This pull request introduces a new feature that allows users to set the reference origin for X and Y positions. The user can now choose between the mouse cursor or the window as the origin for calculating these positions.

### Key Changes

- Added functionality to set the origin reference for X and Y coordinates.
- Users can select either the mouse cursor or the window as the reference point for positioning.

### Why This Feature?

This enhancement provides greater flexibility in positioning elements based on user preference, improving the user experience in scenarios where precise positioning is required.

### Additional Notes

- No breaking changes were introduced.

![relative](https://github.com/user-attachments/assets/ef599f89-bc4f-4e76-ae79-5416080ba6d0)
