### PR TITLE
Added 350ms Polling Interval Option for PLC

### DIFF
--- a/client/src/app/device/device-property/device-property.component.ts
+++ b/client/src/app/device/device-property/device-property.component.ts
@@ -29,6 +29,7 @@ export class DevicePropertyComponent implements OnInit, OnDestroy {
 	showPassword: boolean;
 
 	pollingPlcType = [{text: '200 ms', value: 200},
+					  {text: '350 ms', value: 350},					  
 					  {text: '500 ms', value: 500},
 					  {text: '700 ms', value: 700},
 					  {text: '1 sec', value: 1000},


### PR DESCRIPTION
This pull request introduces the option to set the PLC polling interval to 350ms. Although this might seem like a minor change, in certain scenarios—like the one I'm encountering—this adjustment in polling time is critical and could benefit other users of the project.

Thank you for considering this change, and I'm open to discussing it further.

Thank you!
