### PR TITLE
 Add `openCard` Function to Script Editor

### DIFF
--- a/client/src/app/_models/script.ts
+++ b/client/src/app/_models/script.ts
@@ -127,6 +127,13 @@ export class SystemFunctions {
         params: [false]
     },
     {
+        name: '$openCard',
+        mode: null,
+        text: 'script.sys-fnc-opencard-text',
+        tooltip: 'script.sys-fnc-opencard-tooltip',
+        params: [false]
+    },
+    {
         name: '$enableDevice',
         mode: null,
         text: 'script.sys-fnc-enableDevice-text',

--- a/client/src/app/_services/hmi.service.ts
+++ b/client/src/app/_services/hmi.service.ts
@@ -28,6 +28,7 @@ export class HmiService {
     @Output() onDeviceTagsRequest: EventEmitter<any> = new EventEmitter();
     @Output() onScriptConsole: EventEmitter<any> = new EventEmitter();
     @Output() onGoTo: EventEmitter<ScriptSetView> = new EventEmitter();
+    @Output() onOpen: EventEmitter<ScriptOpenCard> = new EventEmitter();
 
     onServerConnection$ = new BehaviorSubject<boolean>(false);
 
@@ -569,12 +570,14 @@ export class HmiService {
     //#endregion
 
     public onScriptCommand(message: ScriptCommandMessage) {
-        switch (message.command) {
-            case ScriptCommandEnum.SETVIEW:
-                if (message.params && message.params.length) {
+        if (message.params && message.params.length) {
+            switch (message.command) {
+                case ScriptCommandEnum.SETVIEW:
                     this.onGoTo.emit(<ScriptSetView>{ viewName: message.params[0], force: message.params[1] });
-                }
+                case ScriptCommandEnum.OPENCARD:
+                    this.onOpen.emit(<ScriptOpenCard>{ viewName: message.params[0], options: message.params[1] });
                 break;
+            }
         }
     }
 }
@@ -646,6 +649,7 @@ export enum IoEventTypes {
 
 export const ScriptCommandEnum = {
     SETVIEW: 'SETVIEW',
+    OPENCARD: 'OPENCARD',
 };
 
 export interface ScriptCommandMessage {
@@ -656,6 +660,11 @@ export interface ScriptCommandMessage {
 export interface ScriptSetView {
     viewName: string;
     force: boolean;
+}
+
+export interface ScriptOpenCard {
+    viewName: string;
+    options: {};
 }
 
 export interface EndPointSettings {

--- a/client/src/app/_services/script.service.ts
+++ b/client/src/app/_services/script.service.ts
@@ -86,6 +86,7 @@ export class ScriptService {
         code = code.replace(/\$getTagDaqSettings\(/g, 'await this.$getTagDaqSettings(');
         code = code.replace(/\$setTagDaqSettings\(/g, 'await this.$setTagDaqSettings(');
         code = code.replace(/\$setView\(/g, 'this.$setView(');
+        code = code.replace(/\$openCard\(/g, 'this.$openCard(');
         code = code.replace(/\$enableDevice\(/g, 'this.$enableDevice(');
         code = code.replace(/\$getDeviceProperty\(/g, 'await this.$getDeviceProperty(');
         code = code.replace(/\$setDeviceProperty\(/g, 'await this.$setDeviceProperty(');
@@ -125,6 +126,13 @@ export class ScriptService {
         this.hmiService.onScriptCommand(<ScriptCommandMessage>{
             command: ScriptCommandEnum.SETVIEW,
             params: [viewName, force]
+        });
+    }
+
+    public $openCard(viewName: string, options?: {}) {
+        this.hmiService.onScriptCommand(<ScriptCommandMessage>{
+            command: ScriptCommandEnum.OPENCARD,
+            params: [viewName, options]
         });
     }
 

--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -702,7 +702,7 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     onOpenCard(id: string, event, viewref: string, options: any = {}) {
-        if (options.singleCard) {
+        if (options?.singleCard) {
             this.cards = [];
         }
         let view: View = this.getView(viewref);
@@ -720,16 +720,19 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
             return;
         }
         card = new CardModel(id);
-        card.x = event.clientX + (Utils.isNumeric(options.left) ? parseInt(options.left) : 0);
-        card.y = event.clientY + (Utils.isNumeric(options.top) ? parseInt(options.top) : 0);
+        card.x = (Utils.isNumeric(event?.clientX) ? parseInt(event?.clientX) : 0) + 
+            (Utils.isNumeric(options?.left) ? parseInt(options.left) : 0);
+        card.y = (Utils.isNumeric(event?.clientY) ? parseInt(event?.clientY) : 0) + 
+            (Utils.isNumeric(options?.top) ? parseInt(options.top) : 0);
+        
         if (this.hmi.layout.hidenavigation) {
             card.y -= 48;
         }
         card.width = view.profile.width;
         card.height = view.profile.height;
         card.view = view;
-        card.variablesMapping = options.variablesMapping;
-        card.disableDefaultClose = options.hideClose;
+        card.variablesMapping = options?.variablesMapping;
+        card.disableDefaultClose = options?.hideClose;
         if (this.parentcards) {
             this.parentcards.push(card);
         } else {

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -10,7 +10,7 @@ import { SidenavComponent } from '../sidenav/sidenav.component';
 import { FuxaViewComponent } from '../fuxa-view/fuxa-view.component';
 import { CardsViewComponent } from '../cards-view/cards-view.component';
 
-import { HmiService, ScriptSetView } from '../_services/hmi.service';
+import { HmiService, ScriptOpenCard, ScriptSetView } from '../_services/hmi.service';
 import { ProjectService } from '../_services/project.service';
 import { AuthService } from '../_services/auth.service';
 import { GaugesManager } from '../gauges/gauges.component';
@@ -74,6 +74,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     private subscriptionLoad: Subscription;
     private subscriptionAlarmsStatus: Subscription;
     private subscriptiongoTo: Subscription;
+    private subscriptionOpen: Subscription;
     private destroy$ = new Subject<void>();
     loggedUser$: Observable<User>;
 
@@ -106,6 +107,9 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
             });
             this.subscriptiongoTo = this.hmiService.onGoTo.subscribe((viewToGo: ScriptSetView) => {
                 this.onGoToPage(this.projectService.getViewId(viewToGo.viewName), viewToGo.force);
+            });
+            this.subscriptionOpen = this.hmiService.onOpen.subscribe((viewToOpen: ScriptOpenCard) => {
+                this.fuxaview.onOpenCard(null, null, this.projectService.getViewId(viewToOpen.viewName), viewToOpen.options);
             });
 
             this.serverErrorBanner$ = combineLatest([
@@ -157,6 +161,9 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
             }
             if (this.subscriptionAlarmsStatus) {
                 this.subscriptionAlarmsStatus.unsubscribe();
+            }
+            if (this.subscriptionOpen) {
+                this.subscriptionOpen.unsubscribe();
             }
             if (this.subscriptiongoTo) {
                 this.subscriptiongoTo.unsubscribe();

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -539,6 +539,8 @@
     "editor.cmenu-layer-delete": "Delete Layer",
     "editor.cmenu-layer-marge-down": "Merge Down",
     "editor.cmenu-layer-marge-all": "Merge All",
+    "editor.cmenu-unlock": "Unlock",
+    "editor.cmenu-lock": "Lock",
 
     "editor.transform": "Transform",
     "editor.transform-x": "x",
@@ -1198,6 +1200,8 @@
     "script.delay": "Delay (seconds)",
     "script.sys-fnc-setview-text": "$setView (View name)",
     "script.sys-fnc-setview-tooltip": "System function to set View on client: $setView (View name as string)",
+    "script.sys-fnc-opencard-text": "$openCard (View name)",
+    "script.sys-fnc-opencard-tooltip": "System function to open Card on client: $openCard (View name as string, Options as dict {left, top})",
     "script.sys-fnc-enableDevice-text": "$enableDevice (Device name, enable True/False)",
     "script.sys-fnc-enableDevice-tooltip": "System function to enable Device connection: $enableDevice (Device name as string, enable as boolean)",
     "script.sys-fnc-enableDevice-params": "'Device name', true",


### PR DESCRIPTION
### Description

This pull request introduces the `openCard` function to the script editor. This new functionality allows scripts to programmatically open cards within the user interface, enhancing flexibility in controlling the visual behavior of operations.

#### Syntax:
The `openCard` function takes two parameters: `ViewName` and an optional `options` object specifying the position with properties `left` and `top`. Here’s how you can use it:
```
openCard('ViewName', { 'left': ?, 'top': ? }); // The 'options' parameter is optional
```

#### Demonstration
Below is a demonstration video showcasing the use of `openCard`.


https://github.com/user-attachments/assets/0727004f-e085-46f2-9050-314520d6b999

---

I hope this contributes to our project. Thank you for considering this addition.
