### PR TITLE
Adjust AlarmQuery Date Bounds to Cover Full Days

### DIFF
--- a/client/src/app/alarms/alarm-view/alarm-view.component.ts
+++ b/client/src/app/alarms/alarm-view/alarm-view.component.ts
@@ -183,10 +183,10 @@ export class AlarmViewComponent implements OnInit, AfterViewInit, OnDestroy {
         this.showType = AlarmShowType.history;
         this.displayColumns = this.historyColumns;
         let query: AlarmQuery = <AlarmQuery>{
-            start: new Date(this.dateRange.value.startDate),
-            end: new Date(this.dateRange.value.endDate)
+            start: new Date(new Date(this.dateRange.value.startDate).setHours(0, 0, 0, 0)),
+            end: new Date(new Date(this.dateRange.value.endDate).setHours(23, 59, 59, 999))
         };
-		this.alarmsLoading = true;
+        this.alarmsLoading = true;
         this.hmiService.getAlarmsHistory(query).pipe(
             delay(1000)
         ).subscribe(result => {


### PR DESCRIPTION
### Purpose
This pull request adjusts the time boundaries of the `AlarmQuery` to ensure that the query encompasses the entire day from the start date to the end date. Previously, the query might not have included all events from the start and end of each day if events occurred at the very beginning or end of the day.

### Changes
- Set the start time to 00:00:00.000 on the start date, ensuring the query covers all events from the very first second of the day.
- Set the end time to 23:59:59.999 on the end date, ensuring the query covers all events until the very last millisecond of the day.

### Justification
Adjusting the start and end times of the `AlarmQuery` helps in generating complete data for daily reports, ensuring no data is missed due to time boundary issues. This is particularly useful in scenarios where precise data logging and reporting are critical, such as in security or monitoring applications.

Please review the changes and merge them if everything looks good. Thank you!
