### PR TITLE
User Interaction: Mouse Over and Out Event Binding on Gauges

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -318,6 +318,8 @@ export enum GaugeEventType {
     click = 'shapes.event-click',
     mousedown = 'shapes.event-mousedown',
     mouseup = 'shapes.event-mouseup',
+    mouseover = 'shapes.event-mouseover',
+    mouseout = 'shapes.event-mouseout',
     enter = 'shapes.event-enter',
     select = 'shapes.event-select',
     onLoad = 'shapes.event-onLoad',

--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -431,6 +431,18 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
                     self.runEvents(self, ga, ev, mouseUpEvents);
                 });
             }
+            let mouseOverEvents = self.gaugesManager.getBindMouseEvent(ga, GaugeEventType.mouseover);
+            if (mouseOverEvents && mouseOverEvents.length > 0) {
+                svgele.mouseover(function(ev) {
+                    self.runEvents(self, ga, ev, mouseOverEvents);
+                });
+            }
+            let mouseOutEvents = self.gaugesManager.getBindMouseEvent(ga, GaugeEventType.mouseout);
+            if (mouseOutEvents && mouseOutEvents.length > 0) {
+                svgele.mouseout(function(ev) {
+                    self.runEvents(self, ga, ev, mouseOutEvents);
+                });
+            }
         }
     }
 

--- a/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
+++ b/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
@@ -60,6 +60,8 @@ export class FlexEventComponent implements OnInit {
             this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.click)] = this.translateService.instant(GaugeEventType.click);
             this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mousedown)] = this.translateService.instant(GaugeEventType.mousedown);
             this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseup)] = this.translateService.instant(GaugeEventType.mouseup);
+            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseover)] = this.translateService.instant(GaugeEventType.mouseover);
+            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseout)] = this.translateService.instant(GaugeEventType.mouseout);
         }
         this.viewPanels = <PanelData[]>Object.values(this.data.view?.items ?? [])?.filter((item: any) => item.type === 'svg-ext-own_ctrl-panel');//#issue on build  PanelComponent.TypeTag);
         this.enterActionType[Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onRunScript)] = this.translateService.instant(GaugeEventActionType.onRunScript);

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -681,6 +681,8 @@
     "shapes.event-click": "Click",
     "shapes.event-mouseup": "MouseUp",
     "shapes.event-mousedown": "MouseDown",
+    "shapes.event-mouseover": "MouseOver",
+    "shapes.event-mouseout": "MouseOut",
     "shapes.event-enter": "Enter",
     "shapes.event-select": "Select",
     "shapes.event-onpage": "Open Page",


### PR DESCRIPTION
This pull request introduces the capability to bind mouse over and out events to gauge elements. By enabling these event bindings, we have expanded the possibilities for user actions and interactivity within the interface. This enhancement allows for a more dynamic and responsive user experience. 

Attached is a demonstration video showcasing the new functionality in action. Please review the changes and provide feedback. Thank you for your attention to this enhancement.

https://github.com/user-attachments/assets/521eb71f-6b6f-43f8-ac2e-28ee67155404

