### PR TITLE
Add Option for Auto-Selecting Text in Input Fields on Click

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -213,6 +213,7 @@ export interface InputOptionsProperty {
     timeformat?: InputTimeFormatType;
     convertion?: InputConvertionType;
     updatedEsc?: boolean;
+    selectOnClick?: boolean;
 }
 
 export enum InputOptionType {

--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -231,6 +231,15 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
                         },
                         (gaToBindHtmlEvent) => {
                             this.onBindHtmlEvent(gaToBindHtmlEvent);
+                            if (items[key]?.property?.options?.selectOnClick) {
+                                let existingOnClick = gaToBindHtmlEvent.dom.onclick;
+                        
+                                gaToBindHtmlEvent.dom.onclick = function(ev) {
+                                    if (existingOnClick) existingOnClick.call(this, ev);
+                                    gaToBindHtmlEvent.dom.select();
+                                    gaToBindHtmlEvent.dom.focus();
+                                }
+                            }
                         });
                     if (items[key].property) {
                         let gaugeSetting = items[key];

--- a/client/src/app/gauges/gauge-property/flex-input/flex-input.component.html
+++ b/client/src/app/gauges/gauge-property/flex-input/flex-input.component.html
@@ -101,15 +101,8 @@
         </div>
     </div>
     <div *ngIf="isInputCtrl()" class="mt15">
-        <div class="my-form-field ml10">
-            <span>{{'gauges.property-update-enabled' | translate}}</span>
-            <mat-slide-toggle color="primary" [(ngModel)]="property.options.updated" class="ml20"></mat-slide-toggle>
-        </div>
-        <div class="my-form-field ml20">
-            <span>{{'gauges.property-update-esc' | translate}}</span>
-            <mat-slide-toggle color="primary" [(ngModel)]="property.options.updatedEsc" [disabled]="!property.options.updated" class="ml20"></mat-slide-toggle>
-        </div>
-        <div class="my-form-field ml30" style="width: 140px;">
+        <div class="mt15">
+            <div class="my-form-field" style="width: 140px;">
             <span>{{'gauges.property-input-type' | translate}}</span>
             <mat-select [(ngModel)]="property.options.type" (selectionChange)="onTypeChange($event)">
                 <mat-option *ngFor="let ev of inputOptionType | enumToArray" [value]="ev.key">
@@ -146,6 +139,20 @@
                     </mat-option>
                 </mat-select>
             </div>
-        </ng-container>        
+        </ng-container>
+        <div class="mt15">
+            <div class="my-form-field">
+                <span>{{'gauges.property-update-enabled' | translate}}</span>
+                <mat-slide-toggle color="primary" [(ngModel)]="property.options.updated" class="ml20"></mat-slide-toggle>
+            </div>
+            <div class="my-form-field ml20">
+                <span>{{'gauges.property-update-esc' | translate}}</span>
+                <mat-slide-toggle color="primary" [(ngModel)]="property.options.updatedEsc" [disabled]="!property.options.updated" class="ml20"></mat-slide-toggle>
+            </div>
+            <div class="my-form-field ml20">
+                <span>{{'gauges.property-select-content-on-click' | translate}}</span>
+                <mat-slide-toggle color="primary" [(ngModel)]="property.options.selectOnClick" class="ml20"></mat-slide-toggle>
+            </div>
+        </div>
     </div>
 </div>

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1020,6 +1020,7 @@
 
     "gauges.property-update-enabled": "Enable update",
     "gauges.property-update-esc": "ESC update",
+    "gauges.property-select-content-on-click": "Select content on click",
     "gauges.property-numeric-enabled": "Only number",
     "gauges.property-format-digits": "Format digits",
     "gauges.property-actions": "Actions",


### PR DESCRIPTION
In most popular SCADA software systems, the standard behavior when clicking on input elements is to automatically select all the text. This facilitates easy replacement of the text. Following this common usability practice, this pull request introduces an option that allows users to enable this behavior for input elements within our application. A demonstrative video is included below to show how this new feature works.

https://github.com/user-attachments/assets/55cdd344-9e9e-449c-ac0b-ed0ceca3c11e

