### PR TITLE
Implement ChangeDetectorRef to Address ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,7 +1,7 @@
 <div id="main-container" class="container">
     <mat-progress-bar *ngIf="isLoading" mode="indeterminate" color="warn" style="position: absolute; top: 0px; left: 0px; right: 0px; z-index: 99999;">
     </mat-progress-bar>
-    <app-header class="header" [hidden]="isHidden()"></app-header>
+    <app-header class="header" *ngIf="isHidden()"></app-header>
     <div [ngClass]="getClass()">
         <router-outlet></router-outlet>
         <ngx-fab-button *ngIf="showDevNavigation()" #fabmenu icon="menu" iconOpen="menu" class="fab-button" color="rgba(68,138,255, 1)">

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,7 +1,7 @@
 <div id="main-container" class="container">
     <mat-progress-bar *ngIf="isLoading" mode="indeterminate" color="warn" style="position: absolute; top: 0px; left: 0px; right: 0px; z-index: 99999;">
     </mat-progress-bar>
-    <app-header class="header" *ngIf="isHidden()"></app-header>
+    <app-header class="header" [hidden]="isHidden()"></app-header>
     <div [ngClass]="getClass()">
         <router-outlet></router-outlet>
         <ngx-fab-button *ngIf="showDevNavigation()" #fabmenu icon="menu" iconOpen="menu" class="fab-button" color="rgba(68,138,255, 1)">

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, AfterViewInit, OnDestroy, ViewChild } from '@angular/core';
+import { Component, OnInit, AfterViewInit, OnDestroy, ViewChild, ChangeDetectorRef } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -34,6 +34,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 		private settingsService: SettingsService,
 		private translateService: TranslateService,
 		private heartbeatService: HeartbeatService,
+		private cdr: ChangeDetectorRef,
 		location: Location
 	) {
 		this.location = location;
@@ -81,6 +82,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 			// show loading manager
 			this.subscriptionShowLoading = this.appService.onShowLoading.subscribe(show => {
 				this.isLoading = show;
+				this.cdr.detectChanges();
 			}, error => {
 				this.isLoading = false;
 				console.error('Error to show loading');


### PR DESCRIPTION
This pull request introduces the use of `ChangeDetectorRef` across critical components in our Angular application to manually manage change detection. This change is aimed at resolving the persistent `ExpressionChangedAfterItHasBeenCheckedError` encountered during asynchronous data updates.

## Changes Made
- **Integration of `ChangeDetectorRef`:** `ChangeDetectorRef` has been injected into components that are susceptible to asynchronous state changes, such as those subscribing to data services or external events.
- **Manual Triggering of Change Detection:** Added `this.cdr.detectChanges()` calls immediately following updates to component state variables in asynchronous operations, ensuring that the view updates are in sync with the latest data.
