### PR TITLE
Reset Alarm Panel to Current Alarms on Reopen in History Mode

### DIFF
--- a/client/src/app/alarms/alarm-view/alarm-view.component.ts
+++ b/client/src/app/alarms/alarm-view/alarm-view.component.ts
@@ -168,6 +168,7 @@ export class AlarmViewComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     onClose() {
+        this.onShowAlarms();
         this.currentShowMode = 'collapse';
         this.showMode.emit('close');
         this.stopAskAlarmsValues();


### PR DESCRIPTION
## Description
This pull request introduces a feature that automatically resets the alarm panel to display current alarms when it is reopened, provided it was closed while in history mode. This change aims to prevent the common issue where operators unintentionally view outdated historical alarms instead of the current situation, which is critical for accurate and timely decision-making in operational environments.

## Motivation and Context
Operators can easily become confused if the alarm panel continues to display historical alarms when accessed during critical operations. This feature ensures that operators always have the most relevant and current data immediately upon opening the alarm panel, thereby improving response effectiveness and safety.

## Implementation Details
- The state of the alarm panel is checked upon closure.
- If the panel is in history mode, the state is flagged.
- Upon reopening, the panel checks for this flag and, if set, automatically switches to display current alarms.