### PR TITLE
Implement logApiLevel Setting for Configurable API Logging Levels

### DIFF
--- a/app/settings.app.js
+++ b/app/settings.app.js
@@ -13,6 +13,22 @@ module.exports = {
     // Default: '_logs'
     // logDir: '_logs',
 
+    logApiLevel: 'tiny',
+    // logApiLevel Configuration for Morgan Logging
+    //
+    // This configuration determines the format of logging by Morgan, indirectly acting as a 'level' of logging detail.
+    // The setting influences which predefined format or custom function Morgan uses to log HTTP requests.
+    //
+    // Possible values for logApiLevel:
+    // - 'dev': Colorful and concise output for development environments, showing the method, URL, status, response length, and response time.
+    // - 'combined': Apache combined log format. Very detailed, suitable for production environments.
+    // - 'common': Less detailed than 'combined', omitting the referrer and user-agent.
+    // - 'short': Shorter format that includes the remote address and request details.
+    // - 'tiny': Minimalist format, showing just the method, URL, status, response length, and response time.
+    //
+    // Default Value:
+    // - 'combined': By default, logApiLevel is set to 'combined', providing detailed logs suitable for thorough tracking and analysis.
+
     // Used to storage Database like DAQ, User
     // Default: '_db'
     // dbDir: '_db',

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 var express = require('express');
+var morgan = require('morgan');
 var bodyParser = require('body-parser');
 const authJwt = require('./jwt-helper');
 const rateLimit = require("express-rate-limit");
@@ -30,6 +31,8 @@ function init(_server, _runtime) {
     return new Promise(function (resolve, reject) {
         if (runtime.settings.disableServer !== false) {
             apiApp = express();
+            apiApp.use(morgan(['combined', 'common', 'dev', 'short', 'tiny'].
+                includes(runtime.settings.logApiLevel) ? runtime.settings.logApiLevel : 'combined'));
 
             var maxApiRequestSize = runtime.settings.apiMaxLength || '35mb';
             apiApp.use(bodyParser.json({limit:maxApiRequestSize}));

--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -13,6 +13,22 @@ module.exports = {
     // Default: '_logs'
     logDir: '_logs',
 
+    // logApiLevel Configuration for Morgan Logging
+    //
+    // This configuration determines the format of logging by Morgan, indirectly acting as a 'level' of logging detail.
+    // The setting influences which predefined format or custom function Morgan uses to log HTTP requests.
+    //
+    // Possible values for logApiLevel:
+    // - 'dev': Colorful and concise output for development environments, showing the method, URL, status, response length, and response time.
+    // - 'combined': Apache combined log format. Very detailed, suitable for production environments.
+    // - 'common': Less detailed than 'combined', omitting the referrer and user-agent.
+    // - 'short': Shorter format that includes the remote address and request details.
+    // - 'tiny': Minimalist format, showing just the method, URL, status, response length, and response time.
+    //
+    // Default Value:
+    // - 'combined': By default, logApiLevel is set to 'combined', providing detailed logs suitable for thorough tracking and analysis.
+    logApiLevel: 'tiny',
+
     // Used to storage Database like DAQ, User
     // Default: '_db'
     dbDir: '_db',


### PR DESCRIPTION
This pull request introduces the `logApiLevel` configuration setting, enabling dynamic control over the logging verbosity for our API. This enhancement allows administrators to adjust the log output to better suit development, testing, or production environments.

## Changes Made
- Added `logApiLevel` to the configuration settings object, allowing it to be set based on environment variables or configuration files.
- Integrated the `logApiLevel` setting into the Morgan logging middleware setup. The API now uses this setting to determine the logging format, defaulting to 'combined' if an unsupported format is specified.
- Updated the Express setup to conditionally apply Morgan based on the `logApiLevel`, with a validation check against supported Morgan formats (`combined`, `common`, `dev`, `short`, `tiny`).

Please review the changes for accuracy and completeness of the implementation. Feedback on the new configuration options and their integration with the existing system is especially appreciated.