### PR TITLE
fix: webAPI http request Error if value is null

### DIFF
--- a/server/runtime/devices/httprequest/index.js
+++ b/server/runtime/devices/httprequest/index.js
@@ -329,7 +329,7 @@ function HTTPclient(_data, _logger, _events, _runtime) {
                             result[tag.id] = {
                                 id: tag.id,
                                 value: (tag.memaddress) ? items[tag.memaddress] : items[key],
-                                type: items[key].type,
+                                type: items[key]?.type,
                                 daq: tag.daq,
                                 tagref: tag
                             };


### PR DESCRIPTION
when request value is null, `items[key].type` will go wrong

server\runtime\devices\httprequest\index.js

fuxa-err.log
`2024-11-05T14:10:58.479Z [error] 'https://xxx/test/1' _readRequest error! TypeError: Cannot read properties of null (reading 'type')`