### PR TITLE
Implementation of onOpen and onClose Methods in View

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -24,6 +24,8 @@ export class View {
     svgcontent = '';
     /** Type of view SVG/CARDS */
     type: ViewType;
+    /** Property with events of view like Open or Close */
+    property: ViewProperty;
 
     constructor(id?: string, type?: ViewType, name?: string) {
         this.id = id;
@@ -194,6 +196,9 @@ export class GaugeSettings {
     }
 }
 
+export class ViewProperty {
+    events: GaugeEvent[] = [];
+}
 export class GaugeProperty {
     variableId: string;
     variableValue: string;
@@ -256,6 +261,13 @@ export interface IPropertyVariable {
     variableRaw: Tag;
 }
 export class GaugeEvent {
+    type: string;
+    action: string;
+    actparam: string;
+    actoptions = {};
+}
+
+export class ViewEvent {
     type: string;
     action: string;
     actparam: string;
@@ -349,6 +361,15 @@ export enum GaugeEventActionType {
     onRunScript = 'shapes.event-onrunscript',
     onViewToPanel = 'shapes.event-onViewToPanel',
     onMonitor = 'shapes.event-onmonitor',
+}
+
+export enum ViewEventType {
+    onopen = 'shapes.event-onopen',
+    onclose = 'shapes.event-onclose'
+}
+
+export enum ViewEventActionType {
+    onRunScript = 'shapes.event-onrunscript',
 }
 
 export enum GaugeEventRelativeFromType {

--- a/client/src/app/editor/editor-views-list/editor-views-list.component.ts
+++ b/client/src/app/editor/editor-views-list/editor-views-list.component.ts
@@ -106,7 +106,9 @@ export class EditorViewsListComponent {
         let dialogRef = this.dialog.open(ViewPropertyComponent, {
             position: { top: '60px' },
             disableClose: true,
-            data: <ViewPropertyType> { name: view.name, type: view.type || ViewType.svg, profile: view.profile }
+            data: <ViewPropertyType> { name: view.name, type: view.type || ViewType.svg, 
+                profile: view.profile,
+                property: view.property}
         });
 
         dialogRef.afterClosed().subscribe(result => {
@@ -115,6 +117,10 @@ export class EditorViewsListComponent {
                 if (result.profile.width) {view.profile.width = parseInt(result.profile.width);}
                 if (result.profile.margin >= 0) {view.profile.margin = parseInt(result.profile.margin);}
                 view.profile.bkcolor = result.profile.bkcolor;
+                if (result.property?.events) {
+                    view.property ??= { events: [], actions: [] };
+                    view.property.events = result.property.events;
+                }             
                 this.viewPropertyChanged.emit(view);
                 this.onSelectView(view);
             }

--- a/client/src/app/editor/view-property/view-property.component.html
+++ b/client/src/app/editor/view-property/view-property.component.html
@@ -1,78 +1,102 @@
 <form [formGroup]="formGroup" class="container">
     <h1 mat-dialog-title class="dialog-title" mat-dialog-draggable>{{'dlg.docproperty-title' | translate}}</h1>
     <mat-icon (click)="onNoClick()" class="dialog-close-btn">clear</mat-icon>
-    <div mat-dialog-content>
-        <div class="my-form-field item-block">
-            <span>{{'dlg.docproperty-name' | translate}}</span>
-            <input formControlName="name" type="text">
-        </div>
-        <div class="my-form-field item-block mt5">
-            <span>{{'dlg.docproperty-type' | translate}}</span>
-            <mat-select formControlName="type" placeholder="{{'dlg.doctype' | translate}}">
-                <mat-option *ngFor="let type of viewType | enumToArray" [value]="type.key">
-                    {{ 'editor.view-' + type.value | translate }}
-                </mat-option>
-            </mat-select>
-        </div>
-        <div *ngIf="formGroup.controls.type?.value === viewType.svg">
-            <div class="block mt5">
-                <div class="my-form-field inbk">
-                    <span>{{'dlg.docproperty-width' | translate}}</span>
-                    <input numberOnly formControlName="width" style="width: 120px" type="number">
+    <mat-tab-group style="width: 100%;">
+        <mat-tab label="{{'gauges.property-props' | translate}}">
+            <div class="mat-tab-container">
+
+                <div class="my-form-field item-block">
+                    <span>{{'dlg.docproperty-name' | translate}}</span>
+                    <input formControlName="name" type="text">
                 </div>
-                <div class="my-form-field" style="float: right">
-                    <span>{{'dlg.docproperty-height' | translate}}</span>
-                    <input numberOnly formControlName="height" style="width: 120px" type="number">
+                <div class="my-form-field item-block mt5">
+                    <span>{{'dlg.docproperty-type' | translate}}</span>
+                    <mat-select formControlName="type" placeholder="{{'dlg.doctype' | translate}}">
+                        <mat-option *ngFor="let type of viewType | enumToArray" [value]="type.key">
+                            {{ 'editor.view-' + type.value | translate }}
+                        </mat-option>
+                    </mat-select>
+                </div>
+                <div *ngIf="formGroup.controls.type?.value === viewType.svg">
+                    <div class="block mt5">
+                        <div class="my-form-field inbk">
+                            <span>{{'dlg.docproperty-width' | translate}}</span>
+                            <input numberOnly formControlName="width" style="width: 120px" type="number">
+                        </div>
+                        <div class="my-form-field" style="float: right">
+                            <span>{{'dlg.docproperty-height' | translate}}</span>
+                            <input numberOnly formControlName="height" style="width: 120px" type="number">
+                        </div>
+                    </div>
+                    <div class="my-form-field item-block mt5">
+                        <span>{{'dlg.docproperty-size' | translate}}</span>
+                        <mat-select placeholder="{{'dlg.docproperty-select' | translate}}"
+                            (selectionChange)="onSizeChange($event.value)">
+                            <mat-option *ngFor="let prop of propSizeType" [value]="prop.value">
+                                {{ prop.text }}
+                            </mat-option>
+                        </mat-select>
+                    </div>
+                    <div class="my-form-field item-block mt5">
+                        <span>{{'dlg.docproperty-align' | translate}}</span>
+                        <mat-select formControlName="align"
+                            placeholder="{{'dlg.docproperty-align-placeholder' | translate}}">
+                            <mat-option *ngFor="let align of alignType | enumToArray" [value]="align.key">
+                                {{'dlg.docproperty-align-' + align.value | translate}}
+                            </mat-option>
+                        </mat-select>
+                    </div>
+                </div>
+                <div *ngIf="formGroup.controls.type?.value === viewType.cards">
+                    <div class="my-form-field inbk mt5" style="width: 160px">
+                        <span>{{'dlg.docproperty-gridtype' | translate}}</span>
+                        <mat-select formControlName="gridType"
+                            placeholder="{{'dlg.docproperty-gridtype-placeholder' | translate}}">
+                            <mat-option *ngFor="let type of gridType | enumToArray" [value]="type.value">
+                                {{'dlg.docproperty-gridtype-' + type.value | translate}}
+                            </mat-option>
+                        </mat-select>
+                    </div>
+                    <div class="my-form-field inbk mt5 ftr">
+                        <span>{{'dlg.docproperty-margin' | translate}}</span>
+                        <input numberOnly formControlName="margin" [max]="20" [min]="0" [step]="1" style="width: 100px"
+                            type="number">
+                    </div>
+                </div>
+                <div class="my-form-field item-block mt5">
+                    <span>{{'dlg.docproperty-background' | translate}}</span>
+                    <input style="width: 292px; border: 1px solid rgba(0,0,0,0.2); height:15px !important" readonly
+                        [(colorPicker)]="data.profile.bkcolor" class="input-color" title="Change stroke color"
+                        [style.background]="data.profile.bkcolor" [cpPresetColors]="defaultColor"
+                        [cpAlphaChannel]="'always'" [cpPosition]="'bottom'" [value]="data.profile.bkcolor"
+                        [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'"
+                        [cpCancelButtonText]="'Cancel'" [cpOKButton]="true" [cpOKButtonText]="'OK'"
+                        [cpOKButtonClass]="'cpOKButtonClass'" />
                 </div>
             </div>
-            <div class="my-form-field item-block mt5">
-                <span>{{'dlg.docproperty-size' | translate}}</span>
-                <mat-select placeholder="{{'dlg.docproperty-select' | translate}}" (selectionChange)="onSizeChange($event.value)">
-                    <mat-option *ngFor="let prop of propSizeType" [value]="prop.value">
-                        {{ prop.text }}
-                    </mat-option>
-                </mat-select>
+        </mat-tab>
+
+        <mat-tab label="{{'gauges.property-events' | translate}}">
+            <div class="mat-tab-container">
+                <div class="toolbox">
+                    <button mat-icon-button (click)="onAddEvent()"
+                        matTooltip="{{'gauges.property-tooltip-add-event' | translate}}">
+                        <mat-icon>add_circle_outline</mat-icon>
+                    </button>
+                </div>
+                <div mat-dialog-content style="overflow: visible; width:100%;">
+                    <flex-event [data]="data" [property]="data.property"
+                        [scripts]="scripts" #flexevent style="padding-bottom: 5px"></flex-event>
+                </div>
             </div>
-            <div class="my-form-field item-block mt5">
-                <span>{{'dlg.docproperty-align' | translate}}</span>
-                <mat-select formControlName="align" placeholder="{{'dlg.docproperty-align-placeholder' | translate}}">
-                    <mat-option *ngFor="let align of alignType | enumToArray" [value]="align.key">
-                        {{'dlg.docproperty-align-' + align.value | translate}}
-                    </mat-option>
-                </mat-select>
-            </div>
-        </div>
-        <div *ngIf="formGroup.controls.type?.value === viewType.cards">
-            <div class="my-form-field inbk mt5" style="width: 160px">
-                <span>{{'dlg.docproperty-gridtype' | translate}}</span>
-                <mat-select formControlName="gridType" placeholder="{{'dlg.docproperty-gridtype-placeholder' | translate}}">
-                    <mat-option *ngFor="let type of gridType | enumToArray" [value]="type.value">
-                        {{'dlg.docproperty-gridtype-' + type.value | translate}}
-                    </mat-option>
-                </mat-select>
-            </div>
-            <div class="my-form-field inbk mt5 ftr">
-                <span>{{'dlg.docproperty-margin' | translate}}</span>
-                <input numberOnly formControlName="margin" [max]="20" [min]="0" [step]="1" style="width: 100px" type="number">
-            </div>
-        </div>
-        <div class="my-form-field item-block mt5">
-            <span>{{'dlg.docproperty-background' | translate}}</span>
-            <input style="width: 292px; border: 1px solid rgba(0,0,0,0.2); height:15px !important" readonly [(colorPicker)]="data.profile.bkcolor" class="input-color"
-                title="Change stroke color" [style.background]="data.profile.bkcolor" [cpPresetColors]="defaultColor" [cpAlphaChannel]="'always'" [cpPosition]="'bottom'"
-                [value]="data.profile.bkcolor" [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButton]="true"
-                [cpOKButtonText]="'OK'" [cpOKButtonClass]="'cpOKButtonClass'" />
-        </div>
-    </div>
+        </mat-tab>
+    </mat-tab-group>
+
     <div mat-dialog-actions class="dialog-action">
-        <button mat-raised-button 
-                (click)="onNoClick()">
+        <button mat-raised-button (click)="onNoClick()">
             {{'dlg.cancel' | translate}}
         </button>
-        <button mat-raised-button 
-                [disabled]="formGroup.invalid"
-                color="primary"
-                (click)="onOkClick()">
+        <button mat-raised-button [disabled]="formGroup.invalid" color="primary" (click)="onOkClick()">
             {{'dlg.ok' | translate}}
         </button>
     </div>

--- a/client/src/app/editor/view-property/view-property.component.scss
+++ b/client/src/app/editor/view-property/view-property.component.scss
@@ -1,6 +1,6 @@
 :host {
     .container {
-        width: 300px;
+        width: 700px;
     }
 
     .item-block {
@@ -22,4 +22,36 @@
         background-color: var(--formSliderBackground);
         height: 30px;
     }
+
+    .toolbox {
+        float: right;
+        line-height: 44px;
+    }
+    
+    .toolbox button {
+        /* margin-right: 8px; */
+        margin-left: 10px;
+    }    
+
+    
+}
+
+::ng-deep .mat-dialog-container {
+    display: inline-table !important;
+}
+
+::ng-deep .mat-tab-label {
+  height: 34px !important;
+}
+
+.mat-tab-container {
+  min-height:300px;
+  height:60vmin;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 15px;
+}
+
+.mat-tab-container > div {
+  display: block;
 }

--- a/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
+++ b/client/src/app/gauges/gauge-property/flex-event/flex-event.component.ts
@@ -10,7 +10,9 @@ import {
     GaugeEventType,
     GaugeProperty,
     GaugeSettings,
-    View
+    View,
+    ViewEventActionType,
+    ViewEventType
 } from '../../../_models/hmi';
 import { Script, ScriptParam, SCRIPT_PARAMS_MAP } from '../../../_models/script';
 
@@ -38,8 +40,8 @@ export class FlexEventComponent implements OnInit {
     eventType = {};
     setValueType = GaugeEventSetValueType;
     enterActionType = {};
+    actionType: typeof GaugeEventActionType | typeof ViewEventActionType = GaugeEventActionType;
     relativeFromType = GaugeEventRelativeFromType;
-    actionType = GaugeEventActionType;
     eventActionOnCard = Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onwindow);
     eventWithPosition = [Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.oncard),
                          Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onwindow),
@@ -52,16 +54,25 @@ export class FlexEventComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.data.settings.type === HtmlInputComponent.TypeTag) {
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.enter)] = this.translateService.instant(GaugeEventType.enter);
-        } else if (this.data.settings.type === HtmlSelectComponent.TypeTag) {
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.select)] = this.translateService.instant(GaugeEventType.select);
-        } else {
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.click)] = this.translateService.instant(GaugeEventType.click);
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mousedown)] = this.translateService.instant(GaugeEventType.mousedown);
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseup)] = this.translateService.instant(GaugeEventType.mouseup);
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseover)] = this.translateService.instant(GaugeEventType.mouseover);
-            this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseout)] = this.translateService.instant(GaugeEventType.mouseout);
+
+        // Events for view
+        if (this.data?.type == 'svg') {
+            this.actionType = ViewEventActionType;
+            this.eventType[Utils.getEnumKey(ViewEventType, ViewEventType.onopen)] = this.translateService.instant(ViewEventType.onopen);
+            this.eventType[Utils.getEnumKey(ViewEventType, ViewEventType.onclose)] = this.translateService.instant(ViewEventType.onclose);
+        } else if (this.data.settings) {
+            // Events for another gauges
+            if (this.data.settings.type === HtmlInputComponent.TypeTag) {
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.enter)] = this.translateService.instant(GaugeEventType.enter);
+            } else if (this.data.settings.type === HtmlSelectComponent.TypeTag) {
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.select)] = this.translateService.instant(GaugeEventType.select);
+            } else {
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.click)] = this.translateService.instant(GaugeEventType.click);
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mousedown)] = this.translateService.instant(GaugeEventType.mousedown);
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseup)] = this.translateService.instant(GaugeEventType.mouseup);
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseover)] = this.translateService.instant(GaugeEventType.mouseover);
+                this.eventType[Utils.getEnumKey(GaugeEventType, GaugeEventType.mouseout)] = this.translateService.instant(GaugeEventType.mouseout);
+            }    
         }
         this.viewPanels = <PanelData[]>Object.values(this.data.view?.items ?? [])?.filter((item: any) => item.type === 'svg-ext-own_ctrl-panel');//#issue on build  PanelComponent.TypeTag);
         this.enterActionType[Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onRunScript)] = this.translateService.instant(GaugeEventActionType.onRunScript);
@@ -133,7 +144,7 @@ export class FlexEventComponent implements OnInit {
         let c = Object.values(this.actionType).indexOf(GaugeEventActionType.onwindow);
         let d = Object.values(this.actionType).indexOf(GaugeEventActionType.ondialog);
         let e = Object.values(this.actionType).indexOf(GaugeEventActionType.onViewToPanel);
-        return a === b || a === c || a === d || a === e;
+        return a > -1 && (a === b || a === c || a === d || a === e);
     }
 
     withPosition(eventAction: GaugeEventActionType) {
@@ -143,32 +154,32 @@ export class FlexEventComponent implements OnInit {
     withSetValue(action) {
         let a = Object.keys(this.actionType).indexOf(action);
         let b = Object.values(this.actionType).indexOf(GaugeEventActionType.onSetValue);
-        return a === b;
+        return a > -1 && (a === b);
     }
 
     withToggleValue(action) {
         let a = Object.keys(this.actionType).indexOf(action);
         let b = Object.values(this.actionType).indexOf(GaugeEventActionType.onToggleValue);
-        return a === b;
+        return a > -1 && (a === b);
     }
 
     withSetInput(action) {
         let a = Object.keys(this.actionType).indexOf(action);
         let b = Object.values(this.actionType).indexOf(GaugeEventActionType.onSetInput);
-        return a === b;
+        return a > -1 && (a === b);
     }
 
     withAddress(action) {
         let a = Object.keys(this.actionType).indexOf(action);
         let b = Object.values(this.actionType).indexOf(GaugeEventActionType.oniframe);
         let c = Object.values(this.actionType).indexOf(GaugeEventActionType.oncard);
-        return a === b || a === c;
+        return a > -1 && (a === b || a === c);
     }
 
     withScale(action) {
         let a = Object.keys(this.actionType).indexOf(action);
         let b = Object.values(this.actionType).indexOf(GaugeEventActionType.oniframe);
-        return a === b;
+        return a > -1 && (a === b);
     }
 
     withRunScript(action) {

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -698,6 +698,7 @@
     "shapes.event-ontogglevalue": "Toggle Value",
     "shapes.event-onsetinput": "Set from Input",
     "shapes.event-onclose": "Close",
+    "shapes.event-onopen": "Open",
     "shapes.event-onrunscript": "Run Script",
     "shapes.event-setvalue-set": "set",
     "shapes.event-setvalue-add": "increase",


### PR DESCRIPTION
In this pull request, the `onOpen` and `onClose` methods have been implemented in the View class. This addition enables the execution of scripts and specific logics tied to the interface that will be displayed to the user. These new methods enhance flexibility and control over the application's behavior when views are opened and closed, thereby facilitating the management of states and interactions within the application. 

Introducing these methods adheres to best development practices and aims to improve the experience for both developers and end-users.
