### PR TITLE
Enable Force Reports for disabled reports

### DIFF
--- a/server/runtime/jobs/index.js
+++ b/server/runtime/jobs/index.js
@@ -142,11 +142,15 @@ function JobsManager(_runtime) {
             runtime.project.getReports().then(function (result) {
                 if (result) {
                     result.forEach(rptProperty => {
-                        if (rptProperty.scheduling !== Report.ReportSchedulingType.none) {
-                            var report = Report.create(rptProperty, runtime);
-                            var job = new Job(report, JobType.Report);
-                            jobsList.push(job);
-                        }
+                        var report = Report.create(rptProperty, runtime);
+                        var job = new Job(report, JobType.Report);
+                        jobsList.push(job);
+                        // If we check to create the Job then we won't be able to force the report
+                        // if (rptProperty.scheduling !== Report.ReportSchedulingType.none) {
+                        //     var report = Report.create(rptProperty, runtime);
+                        //     var job = new Job(report, JobType.Report);
+                        //     jobsList.push(job);
+                        // }
                     });
                 }
                 resolve();


### PR DESCRIPTION
Remove scheduling type check in reports in order to be able to force a report without having any schedule asociated.