### PR TITLE
Feature : New SVG Widget function (POSTVIEW) to change view through SVG click e…

### DIFF
--- a/client/src/app/_helpers/svg-utils.ts
+++ b/client/src/app/_helpers/svg-utils.ts
@@ -95,13 +95,20 @@ export class SvgUtils {
         while ((match = functionExprRegex.exec(scriptContent)) !== null) {
             scriptContent += `\n${moduleId}.${match[1]} = ${match[1]};`;
         }
-
+    
         // Regex to search calls of postValue function
         const oldFuncName = 'postValue';
         const newFuncName = `${moduleId}.${oldFuncName}`;
         const functionCallRegex = new RegExp(`(?<!function\\s+)\\b${oldFuncName}\\b(?=\\s*\\()`, 'g');
         // const functionCallRegex = new RegExp(`\\b${oldFuncName}\\s*\\(`, 'g');
         scriptContent = scriptContent.replace(functionCallRegex, `${newFuncName}`);
+    
+        // Add support for postView
+        const oldViewName = 'postView';
+        const newViewName = `${moduleId}.${oldViewName}`;
+        const viewCallRegex = new RegExp(`(?<!function\\s+)\\b${oldViewName}\\b(?=\\s*\\()`, 'g');
+        scriptContent = scriptContent.replace(viewCallRegex, `${newViewName}`);
+    
         return scriptContent;
     }
 

--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -603,6 +603,7 @@ export class Event {
     type?: string;
     ga: GaugeSettings;
     variableId: string;
+    mode?: 'Value' | 'View'; // Added mode
 }
 
 export class DaqQuery {

--- a/client/src/app/_services/hmi.service.ts
+++ b/client/src/app/_services/hmi.service.ts
@@ -29,6 +29,7 @@ export class HmiService {
     @Output() onScriptConsole: EventEmitter<any> = new EventEmitter();
     @Output() onGoTo: EventEmitter<ScriptSetView> = new EventEmitter();
     @Output() onOpen: EventEmitter<ScriptOpenCard> = new EventEmitter();
+    @Output() onViewChange: EventEmitter<SVGSetView> = new EventEmitter();
 
     onServerConnection$ = new BehaviorSubject<boolean>(false);
 
@@ -505,6 +506,13 @@ export class HmiService {
         }
     }
 
+    /**   
+    * @param viewName The name of the view to navigate to
+    */
+      setView(viewName: string) {
+        this.onViewChange.emit(<SVGSetView>{ viewName });
+    }  
+
     private getTagLabel(tag: Tag) {
         if (tag.label) {
             return tag.label;
@@ -677,4 +685,8 @@ export interface EndPointSettings {
     uid: string;
     pwd: string;
     id?: string;
+}
+
+export interface SVGSetView {
+    viewName: string;
 }

--- a/client/src/app/gauges/controls/html-image/html-image.component.ts
+++ b/client/src/app/gauges/controls/html-image/html-image.component.ts
@@ -199,6 +199,7 @@ export class HtmlImageComponent extends GaugeBaseComponent {
                         event.ga = ga;
                         event.value = value;
                         event.variableId = widgetVar.variableId;
+                        event.mode = 'Value'; // Mode for signal update
                         callback(event);
                     } else {
                         console.error(`Variable name (${varName}) not found!`);
@@ -206,6 +207,22 @@ export class HtmlImageComponent extends GaugeBaseComponent {
                 };
             } else {
                 console.error(`Module (${scriptContent.moduleId}) or postValue function not found!`);
+            }
+            if (window[scriptContent.moduleId]?.['postView']) {
+                window[scriptContent.moduleId]['postView'] = (viewName) => {
+                    if (viewName){
+                        const widgetVar = <WidgetPropertyVariable> ga.property.varsToBind?.find((varToBind: WidgetPropertyVariable) => varToBind.name === viewName);
+                        let event = new Event();
+                        event.type = HtmlImageComponent.propertyWidgetType;
+                        event.ga = ga;
+                        event.value = viewName;
+                        event.variableId = widgetVar?.variableId; // Added for consistency
+                        event.mode = 'View'; // Mode for view change
+                        callback(event);
+                    }
+                };
+            } else {
+                console.error(`Module (${scriptContent.moduleId}) or postView function not found!`);
             }
         }
         return null;

--- a/client/src/app/gauges/gauges.component.ts
+++ b/client/src/app/gauges/gauges.component.ts
@@ -594,9 +594,14 @@ export class GaugesManager {
      */
     putEvent(event: Event) {
         if (event.type === HtmlImageComponent.propertyWidgetType) {
-            const value = GaugeBaseComponent.valueBitmask(event.ga.property.bitmask, event.value, this.hmiService.variables[event.variableId]?.value);
-            this.hmiService.putSignalValue(event.variableId, String(value));
-            event.dbg = 'put ' + event.variableId + ' ' + event.value;
+            if (event.mode === 'Value') {
+                const value = GaugeBaseComponent.valueBitmask(event.ga.property.bitmask, event.value, this.hmiService.variables[event.variableId]?.value);
+                this.hmiService.putSignalValue(event.variableId, String(value));
+                event.dbg = 'put ' + event.variableId + ' ' + event.value;
+            }else if (event.mode === 'View') {
+                this.hmiService.setView(event.value);
+                event.dbg = 'navigate to ' + event.value;
+            }
         } else if (event.ga.property && event.ga.property.variableId) {
             const value = GaugeBaseComponent.valueBitmask(event.ga.property.bitmask, event.value, this.hmiService.variables[event.ga.property.variableId]?.value);
             this.hmiService.putSignalValue(event.ga.property.variableId, String(value));

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -10,7 +10,7 @@ import { SidenavComponent } from '../sidenav/sidenav.component';
 import { FuxaViewComponent } from '../fuxa-view/fuxa-view.component';
 import { CardsViewComponent } from '../cards-view/cards-view.component';
 
-import { HmiService, ScriptOpenCard, ScriptSetView } from '../_services/hmi.service';
+import { HmiService, ScriptOpenCard, ScriptSetView, SVGSetView } from '../_services/hmi.service';
 import { ProjectService } from '../_services/project.service';
 import { AuthService } from '../_services/auth.service';
 import { GaugesManager } from '../gauges/gauges.component';
@@ -79,6 +79,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     private subscriptionLoad: Subscription;
     private subscriptionAlarmsStatus: Subscription;
     private subscriptiongoTo: Subscription;
+    private subscriptionViewChange: Subscription; 
     private subscriptionOpen: Subscription;
     private destroy$ = new Subject<void>();
     loggedUser$: Observable<User>;
@@ -115,6 +116,9 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
             });
             this.subscriptiongoTo = this.hmiService.onGoTo.subscribe((viewToGo: ScriptSetView) => {
                 this.onGoToPage(this.projectService.getViewId(viewToGo.viewName), viewToGo.force);
+            });
+            this.subscriptionViewChange = this.hmiService.onViewChange.subscribe((viewToGo: SVGSetView) => {
+                this.onGoToPage(this.projectService.getViewId(viewToGo.viewName), false); 
             });
             this.subscriptionOpen = this.hmiService.onOpen.subscribe((viewToOpen: ScriptOpenCard) => {
                 this.fuxaview.onOpenCard(null, null, this.projectService.getViewId(viewToOpen.viewName), viewToOpen.options);
@@ -176,6 +180,9 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
             }
             if (this.subscriptiongoTo) {
                 this.subscriptiongoTo.unsubscribe();
+            }
+            if (this.subscriptionViewChange) {
+                this.subscriptionViewChange.unsubscribe();
             }
             this.destroy$.next();
             this.destroy$.complete();


### PR DESCRIPTION
This feature will enable SVG widget to change views in FUXA by calling a function (postView) in SVG script with the viewname.

A sample SVG implementation has been attached below.

![set_view_svg](https://github.com/user-attachments/assets/0876d605-37b5-42ee-ab88-da81e95fe3b3)

function usage in SVG:
            function postView(viewName) {  
                console.log(`Script: Calling postView with viewName: ${viewName}`);
            }
            
Demo:

https://github.com/user-attachments/assets/7c06a7b3-ac43-405b-b42b-6768ebceff07



Note:
**Some corrections and optimizations maybe required.**