### PR TITLE
Make view display delay configurable

### DIFF
--- a/client/dist/assets/i18n/en.json
+++ b/client/dist/assets/i18n/en.json
@@ -110,6 +110,7 @@
     "dlg.docproperty-gridtype-fixed": "Fixed",
     "dlg.docproperty-gridtype-verticalFixed": "VerticalFixed",
     "dlg.docproperty-gridtype-horizontalFixed": "HorizontalFixed",
+    "dlg.docproperty-renderDelay": "View rendering delay (ms)",
 
     "dlg.docname-title": "View name",
     "dlg.docname-name": "Name",

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -48,6 +48,6 @@
             </div>
         </div>
     </app-root>
-<script src="runtime.9136a61a9b98f987.js" type="module"></script><script src="polyfills.8df7953530aa56e1.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.30099dac99efb27e.js" type="module"></script></body>
+<script src="runtime.9136a61a9b98f987.js" type="module"></script><script src="polyfills.8df7953530aa56e1.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.392482db10241ffe.js" type="module"></script></body>
 
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa",
-  "version": "1.2.6-2394",
+  "version": "1.2.6-2395",
   "keywords": [],
   "author": "frangoteam <info@frangoteam.org>",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",

--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -187,6 +187,7 @@ export class DocProfile {
     margin = 10;
     align = DocAlignType.topCenter;
     gridType: GridType = GridType.Fixed;
+    viewRenderDelay = 0; // delay in ms to render view after load, used to prevent flickering on load view with many gauges
 }
 
 export enum DocAlignType {

--- a/client/src/app/editor/view-property/view-property.component.html
+++ b/client/src/app/editor/view-property/view-property.component.html
@@ -8,7 +8,7 @@
                     <span>{{'dlg.docproperty-name' | translate}}</span>
                     <input formControlName="name" type="text">
                 </div>
-                <div class="my-form-field item-block mt5">
+                <div class="my-form-field item-block mt10">
                     <span>{{'dlg.docproperty-type' | translate}}</span>
                     <mat-select formControlName="type" placeholder="{{'dlg.doctype' | translate}}">
                         <mat-option [value]="viewType.svg">{{'editor.view-svg' | translate}}</mat-option>
@@ -17,7 +17,7 @@
                     </mat-select>
                 </div>
                 <div *ngIf="formGroup.controls.type?.value === viewType.svg">
-                    <div class="block mt5">
+                    <div class="block mt10">
                         <div class="my-form-field inbk">
                             <span>{{'dlg.docproperty-width' | translate}}</span>
                             <input numberOnly formControlName="width" style="width: 120px" type="number">
@@ -27,7 +27,7 @@
                             <input numberOnly formControlName="height" style="width: 120px" type="number">
                         </div>
                     </div>
-                    <div class="my-form-field item-block mt5">
+                    <div class="my-form-field item-block mt10">
                         <span>{{'dlg.docproperty-size' | translate}}</span>
                         <mat-select placeholder="{{'dlg.docproperty-select' | translate}}"
                             (selectionChange)="onSizeChange($event.value)">
@@ -36,7 +36,7 @@
                             </mat-option>
                         </mat-select>
                     </div>
-                    <div class="my-form-field item-block mt5">
+                    <div class="my-form-field item-block mt10">
                         <span>{{'dlg.docproperty-align' | translate}}</span>
                         <mat-select formControlName="align"
                             placeholder="{{'dlg.docproperty-align-placeholder' | translate}}">
@@ -47,7 +47,7 @@
                     </div>
                 </div>
                 <div *ngIf="formGroup.controls.type?.value === viewType.cards">
-                    <div class="my-form-field inbk mt5" style="width: 160px">
+                    <div class="my-form-field inbk mt10" style="width: 160px">
                         <span>{{'dlg.docproperty-gridtype' | translate}}</span>
                         <mat-select formControlName="gridType"
                             placeholder="{{'dlg.docproperty-gridtype-placeholder' | translate}}">
@@ -56,13 +56,13 @@
                             </mat-option>
                         </mat-select>
                     </div>
-                    <div class="my-form-field inbk mt5 ftr">
+                    <div class="my-form-field inbk mt10 ftr">
                         <span>{{'dlg.docproperty-margin' | translate}}</span>
                         <input numberOnly formControlName="margin" [max]="20" [min]="0" [step]="1" style="width: 100px"
                             type="number">
                     </div>
                 </div>
-                <div *ngIf="formGroup.controls.type?.value !== viewType.maps" class="my-form-field item-block mt5">
+                <div *ngIf="formGroup.controls.type?.value !== viewType.maps" class="my-form-field item-block mt10">
                     <span>{{'dlg.docproperty-background' | translate}}</span>
                     <input style="width: 292px; border: 1px solid rgba(0,0,0,0.2); height:15px !important" readonly
                         [(colorPicker)]="data.profile.bkcolor" class="input-color" title="Change stroke color"
@@ -71,6 +71,10 @@
                         [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'"
                         [cpCancelButtonText]="'Cancel'" [cpOKButton]="true" [cpOKButtonText]="'OK'"
                         [cpOKButtonClass]="'cpOKButtonClass'" />
+                </div>
+                <div class="my-form-field item-block mt10">
+                    <span>{{'dlg.docproperty-renderDelay' | translate}}</span>
+                    <input numberOnly formControlName="viewRenderDelay" [min]="0" type="number">
                 </div>
             </div>
         </mat-tab>

--- a/client/src/app/editor/view-property/view-property.component.ts
+++ b/client/src/app/editor/view-property/view-property.component.ts
@@ -54,6 +54,7 @@ export class ViewPropertyComponent implements OnInit, OnDestroy {
             margin: [this.data.profile.margin],
             align: [this.data.profile.align],
             gridType: [this.data.profile.gridType],
+            viewRenderDelay: [this.data.profile?.viewRenderDelay || 0],
         });
         if (this.data.type !== ViewType.cards && this.data.type !== ViewType.maps) {
             this.formGroup.controls.width.setValidators(Validators.required);
@@ -101,6 +102,7 @@ export class ViewPropertyComponent implements OnInit, OnDestroy {
         this.data.profile.margin = this.formGroup.controls.margin.value;
         this.data.profile.align = this.formGroup.controls.align.value;
         this.data.profile.gridType = this.formGroup.controls.gridType.value;
+        this.data.profile.viewRenderDelay = this.formGroup.controls.viewRenderDelay.value;
         if (!this.data.property) {
 			this.data.property = new ViewProperty();
         }

--- a/client/src/app/fuxa-view/fuxa-view.component.html
+++ b/client/src/app/fuxa-view/fuxa-view.component.html
@@ -1,4 +1,4 @@
-<div #dataContainer class="view-container" id="content">
+<div  [ngStyle]="{ visibility: viewLoaded ? 'visible' : 'hidden' }" #dataContainer class="view-container" id="content">
 </div>
 <div *ngFor="let card of cards; let i = index"
      [style.height]="getCardHeight(card.height) + 'px'"

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -110,6 +110,7 @@
     "dlg.docproperty-gridtype-fixed": "Fixed",
     "dlg.docproperty-gridtype-verticalFixed": "VerticalFixed",
     "dlg.docproperty-gridtype-horizontalFixed": "HorizontalFixed",
+    "dlg.docproperty-renderDelay": "View rendering delay (ms)",
 
     "dlg.docname-title": "View name",
     "dlg.docname-name": "Name",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa-server",
-  "version": "1.2.6-2394",
+  "version": "1.2.6-2395",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This PR introduces a configurable delay for displaying the view after loading, allowing better control over rendering stabilization before showing dynamic content.

Usage (View Property)
![image](https://github.com/user-attachments/assets/8f8f1304-d256-4727-a67d-c7447f2ac6ea)
