### PR TITLE
Fix: allow wildcard IP patterns in CORS origin check  issue #1816

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -296,14 +296,6 @@ const allowCrossDomain = function (req, res, next) {
     return res.sendStatus(204); 
   }
   next();
-  
-  try {
-    const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    console.log("Client IP:", ip);
-  } catch (err) {
-    console.error("IP Logging Error:", err);
-  }
-
 };
 app.use(allowCrossDomain);
 app.use('/', express.static(settings.httpStatic));

--- a/server/main.js
+++ b/server/main.js
@@ -264,27 +264,47 @@ try {
 }
 
 // Http Server for client UI
-var allowCrossDomain = function(req, res, next) {
-    const origin = req.headers.origin;
-    const allowedOrigins = settings.allowedOrigins || ["*"];
+const allowCrossDomain = function (req, res, next) {
+  const origin = req.headers.origin;
+  const allowedOrigins = settings.allowedOrigins || ["*"];
 
-    if (allowedOrigins.includes("*")) {
-        res.header('Access-Control-Allow-Origin', '*');
-    } else if (allowedOrigins.includes(origin)) {
-        res.header('Access-Control-Allow-Origin', origin);
-    }
+  const isOriginAllowed = (origin) => {
+    if (!origin) return false;
+    if (allowedOrigins.includes("*")) return true;
 
-    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-    res.header('Access-Control-Allow-Headers', 'x-access-token, x-auth-user, Origin, Content-Type, Accept');
+    // Convert wildcard-style strings to regex
+    return allowedOrigins.some(pattern => {
+      if (!pattern.includes("*")) return pattern === origin;
 
-    next();
-    try {
-        var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-        // logger.info("Client: " + ip, false);
-    } catch (err) {
+      // Escape dots and replace * with regex
+      const regexPattern = new RegExp(
+        "^" + pattern.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$"
+      );
+      return regexPattern.test(origin);
+    });
+  };
 
-    }
-}
+  if (isOriginAllowed(origin)) {
+    res.header('Access-Control-Allow-Origin', origin || '*');
+  }
+
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'x-access-token, x-auth-user, Origin, Content-Type, Accept');
+
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204); 
+  }
+  next();
+  
+  try {
+    const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+    console.log("Client IP:", ip);
+  } catch (err) {
+    console.error("IP Logging Error:", err);
+  }
+
+};
 app.use(allowCrossDomain);
 app.use('/', express.static(settings.httpStatic));
 app.use('/home', express.static(settings.httpStatic));

--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -59,8 +59,10 @@ module.exports = {
 
     // CORS (Cross-Origin Resource Sharing)
     // Used to enable CORS for all HTTP request
+    // Please use exact origin urls for better and safe CORS (Wild Cards not Recommended)
     // "allowedOrigins": ["https://example.com", "https://dashboard.example.com"]
     // Default: ["http://localhost", "http://127.0.0.1", "http://192.168.*", "http://10.*"]
+
     "allowedOrigins": ["http://localhost", "http://127.0.0.1", "http://192.168.*", "http://10.*"]
 
     // The maximum size of HTTP request that will be accepted by the runtime api.


### PR DESCRIPTION
Browsers require exact origin match in Access-Control-Allow-Origin. Replaced Array.includes with regex matching to support patterns like http://192.168.* and http://10.* in development environments. "


issue fixed #1816 
