### PR TITLE
Fix: Excludes strings from numeric validation

### DIFF
--- a/server/runtime/devices/device-utils.js
+++ b/server/runtime/devices/device-utils.js
@@ -26,7 +26,7 @@ module.exports = {
                 if (tag.scaleReadFunction) {
                     value = await callScaleScript(tag.scaleReadFunction, tag.scaleReadParams ? tag.scaleReadParams : undefined, runtime, true, value);
                 }
-                if (utils.isNumber(value, obj)) {
+                if (!(tag.type === 'String' || tag.type === 'ByteString') && utils.isNumber(value, obj)) {
                     value = obj.value;
                     if (tag.deadband && tag.deadband.value && !utils.isNullOrUndefined(oldValue)) {
                         if (Math.abs(value - oldValue) <= tag.deadband.value) {


### PR DESCRIPTION
Prevents non-numeric types from undergoing numeric validation, specifically excluding 'String' and 'ByteString' types. This ensures that string values are not incorrectly treated as numbers during the scaling process, avoiding potential errors and unexpected behavior.
Fixes #1693 