### PR TITLE
New Device MELSEC (MC Protocol / SLMP) 

### DIFF
--- a/client/dist/assets/i18n/en.json
+++ b/client/dist/assets/i18n/en.json
@@ -77,7 +77,7 @@
     "dlg.menuitem-alarms": "Alarms by Click",
     "dlg.menuitem-address": "Link address",
     "dlg.menuitem-icons-filter": "Icons Filter",
-	
+
     "dlg.menuitem-submenu": "Submenu",
     "dlg.menuitem-add-submenu": "Add Submenu Item",
     "dlg.menuitem-submenu-items": "Submenu Items",
@@ -960,6 +960,9 @@
     "device.template-device": "Template name",
     "device.template-tags": "Template name",
     "device.property-socket-reuse": "Socket Reuse",
+    "device.property-melsec-target": "Address (IP[:port])",
+    "device.property-melsec-ascii": "ASCII",
+    "device.property-melsec-octalIO": "Octal I/O",
 
     "device.browsetopics-property-title": "Broker Topics to subscribe and publish",
     "device.browsetopics-property-sub": "Subscribe",

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -48,6 +48,6 @@
             </div>
         </div>
     </app-root>
-<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.315278feeaac6e2a.js" type="module"></script></body>
+<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.bc739e3421a81250.js" type="module"></script></body>
 
 </html>

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -48,6 +48,6 @@
             </div>
         </div>
     </app-root>
-<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.bc739e3421a81250.js" type="module"></script></body>
+<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.9ef0d56e8dacc388.js" type="module"></script></body>
 
 </html>

--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -48,6 +48,6 @@
             </div>
         </div>
     </app-root>
-<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.9ef0d56e8dacc388.js" type="module"></script></body>
+<script src="runtime.8ef63094e52a66ba.js" type="module"></script><script src="polyfills.c8e7db9850a3ad8b.js" type="module"></script><script src="scripts.40b60f02658462e4.js" defer></script><script src="main.43578214289df850.js" type="module"></script></body>
 
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa",
-  "version": "1.2.7-2491",
+  "version": "1.2.7-2496",
   "keywords": [],
   "author": "frangoteam <info@frangoteam.org>",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa",
-  "version": "1.2.7-2490",
+  "version": "1.2.7-2491",
   "keywords": [],
   "author": "frangoteam <info@frangoteam.org>",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa",
-  "version": "1.2.7-2496",
+  "version": "1.2.7-2497",
   "keywords": [],
   "author": "frangoteam <info@frangoteam.org>",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",

--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -193,6 +193,7 @@ export class DeviceNetProperty {
     /** Modbus TCP socket reuse flag */
     socketReuse?: string;
     /** MELSEC */
+    ascii?: boolean;
     octalIO?: boolean;
 
     static descriptor = {

--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -39,7 +39,7 @@ export class Device {
         id: 'Device id, GUID',
         name: 'Device name',
         enabled: 'Enabled',
-        type: 'Device Type: FuxaServer | SiemensS7 | OPCUA | BACnet | ModbusRTU | ModbusTCP | WebAPI | MQTTclient | internal | EthernetIP | ADSclient | Gpio | WebCam',
+        type: 'Device Type: FuxaServer | SiemensS7 | OPCUA | BACnet | ModbusRTU | ModbusTCP | WebAPI | MQTTclient | internal | EthernetIP | ADSclient | Gpio | WebCam | MELSEC',
         polling: 'Polling interval in millisec., check changed value after ask value, by OPCUA there is a monitor',
         property: 'Connection property depending of type',
         tags: 'Tags list of Tag',
@@ -192,6 +192,8 @@ export class DeviceNetProperty {
     delay: number = 10;
     /** Modbus TCP socket reuse flag */
     socketReuse?: string;
+    /** MELSEC */
+    octalIO?: boolean;
 
     static descriptor = {
         address: 'Device address (IP)',
@@ -242,6 +244,7 @@ export enum DeviceType {
     ADSclient = 'ADSclient',
     GPIO = 'GPIO',
     WebCam = 'WebCam',
+    MELSEC = 'MELSEC'
     // Template: 'template'
 }
 
@@ -300,6 +303,18 @@ export enum AdsClientTagType {
     Number = 'number',
     Boolean = 'boolean',
     String = 'string'
+}
+
+export enum MelsecTagType {
+    BOOL = 'BOOL',
+    BYTE = 'BYTE',
+    WORD = 'WORD',
+    INT = 'INT',
+    UINT = 'UINT',
+    DINT = 'DINT',
+    UDINT = 'UDINT',
+    REAL = 'REAL',
+    STRING = 'STRING'
 }
 
 export enum ModbusOptionType {

--- a/client/src/app/_models/plugin.ts
+++ b/client/src/app/_models/plugin.ts
@@ -15,7 +15,8 @@ export enum PluginType {
     Modbus = 'Modbus',
     Raspberry = 'Raspberry',
     SiemensS7 = 'SiemensS7',
-    EthernetIP = 'EthernetIP'
+    EthernetIP = 'EthernetIP',
+    MELSEC = 'MELSEC'
 }
 
 export enum PluginGroupType {

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -222,6 +222,7 @@ import { TagPropertyEditWebcamComponent } from './device/tag-property/tag-proper
 import { EditPlaceholderComponent } from './gui-helpers/edit-placeholder/edit-placeholder.component';
 import { DeviceAdapterService } from './device-adapter/device-adapter.service';
 import { VideoPropertyComponent } from './gauges/controls/html-video/video-property/video-property.component';
+import { TagPropertyEditMelsecComponent } from './device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component';
 
 export function createTranslateLoader(http: HttpClient) {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -254,6 +255,7 @@ export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
         TagPropertyEditEthernetipComponent,
         TagPropertyEditADSclientComponent,
         TagPropertyEditGpioComponent,
+        TagPropertyEditMelsecComponent,
         TagOptionsComponent,
         TopicPropertyComponent,
         DevicePropertyComponent,

--- a/client/src/app/device/device-list/device-list.component.ts
+++ b/client/src/app/device/device-list/device-list.component.ts
@@ -264,7 +264,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
         if (type === DeviceType.SiemensS7 || type === DeviceType.ModbusTCP || type === DeviceType.ModbusRTU ||
             type === DeviceType.internal || type === DeviceType.EthernetIP || type === DeviceType.FuxaServer ||
             type === DeviceType.OPCUA || type === DeviceType.GPIO || type === DeviceType.ADSclient ||
-            type === DeviceType.WebCam) {
+            type === DeviceType.WebCam || type === DeviceType.MELSEC) {
             return true;
         } else if (type === DeviceType.MQTTclient) {
             if (tag && tag.options && (tag.options.pubs || tag.options.subs)) {
@@ -336,6 +336,14 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
                 this.tagsMap[tag.id] = tag;
                 this.bindToTable(this.deviceSelected.tags);
             });
+            return;
+        }
+        if (this.deviceSelected.type === DeviceType.MELSEC) {
+            this.tagPropertyService.editTagPropertyMelsec(this.deviceSelected, tag, checkToAdd).subscribe(result => {
+                this.tagsMap[tag.id] = tag;
+                this.bindToTable(this.deviceSelected.tags);
+            });
+            return;
         }
     }
 

--- a/client/src/app/device/device-map/device-map.component.ts
+++ b/client/src/app/device/device-map/device-map.component.ts
@@ -511,6 +511,9 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
                         device.property.adpuTimeout = tempdevice.property.adpuTimeout;
                         device.property.local = tempdevice.property.local;
                         device.property.router = tempdevice.property.router;
+                        if (device.type === DeviceType.MELSEC) {
+                            device.property.octalIO = tempdevice.property.octalIO;
+                        }
                         if (tempdevice.property.connectionOption) {
                             device.property.connectionOption = tempdevice.property.connectionOption;
                         }

--- a/client/src/app/device/device-map/device-map.component.ts
+++ b/client/src/app/device/device-map/device-map.component.ts
@@ -512,6 +512,7 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
                         device.property.local = tempdevice.property.local;
                         device.property.router = tempdevice.property.router;
                         if (device.type === DeviceType.MELSEC) {
+                            device.property.ascii = tempdevice.property.ascii;
                             device.property.octalIO = tempdevice.property.octalIO;
                         }
                         if (tempdevice.property.connectionOption) {

--- a/client/src/app/device/device-property/device-property.component.html
+++ b/client/src/app/device/device-property/device-property.component.html
@@ -410,6 +410,22 @@
                 <div *ngSwitchCase="deviceType.Gpio">
                     <!-- property config --->
                 </div>
+                <div *ngSwitchCase="deviceType.MELSEC">
+                    <div class="my-form-field block mb10">
+                        <span>{{'device.property-melsec-target' | translate}}</span>
+                        <input [(ngModel)]="data.device.property.address" placeholder="192.168.0.2:1281" style="width: 350px" type="ip" (click)="onAddressChanged()">
+                    </div>
+                    <div class="mb10 block">
+                        <div class="my-form-field inbk tac" style="width: 100px;">
+                            <span>{{'device.property-melsec-ascii' | translate}}</span>
+                            <mat-slide-toggle color="primary" [(ngModel)]="data.device.property.options"></mat-slide-toggle>
+                        </div>
+                        <div class="my-form-field inbk tac" style="width: 100px;">
+                            <span>{{'device.property-melsec-octalIO' | translate}}</span>
+                            <mat-slide-toggle color="primary" [(ngModel)]="data.device.property.octalIO"></mat-slide-toggle>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/client/src/app/device/device-property/device-property.component.html
+++ b/client/src/app/device/device-property/device-property.component.html
@@ -418,7 +418,7 @@
                     <div class="mb10 block">
                         <div class="my-form-field inbk tac" style="width: 100px;">
                             <span>{{'device.property-melsec-ascii' | translate}}</span>
-                            <mat-slide-toggle color="primary" [(ngModel)]="data.device.property.options"></mat-slide-toggle>
+                            <mat-slide-toggle color="primary" [(ngModel)]="data.device.property.ascii"></mat-slide-toggle>
                         </div>
                         <div class="my-form-field inbk tac" style="width: 100px;">
                             <span>{{'device.property-melsec-octalIO' | translate}}</span>

--- a/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
+++ b/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
@@ -172,6 +172,10 @@ export class DeviceTagSelectionComponent implements OnInit, AfterViewInit, OnDes
             this.tagPropertyService.editTagPropertyWebcam(device, newTag, true).subscribe(result => {
                 this.loadDevicesTags(newTag, device.name);
             });
+        } else if (device.type === DeviceType.MELSEC) {
+            this.tagPropertyService.editTagPropertyMelsec(device, newTag, true).subscribe(result => {
+                this.loadDevicesTags(newTag, device.name);
+            });
         }
     }
 

--- a/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.html
+++ b/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.html
@@ -1,0 +1,37 @@
+<form [formGroup]="formGroup" class="container">
+    <h1 mat-dialog-title class="dialog-title" mat-dialog-draggable>{{'device.tag-property-title' | translate}}</h1>
+    <mat-icon (click)="onNoClick()" class="dialog-close-btn">clear</mat-icon>
+    <div mat-dialog-content>
+        <div class="my-form-field item-block">
+            <span>{{'device.tag-property-device' | translate}}</span>
+            <input formControlName="deviceName" type="text" readonly>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-name' | translate}}</span>
+            <input formControlName="tagName" type="text">
+            <span *ngIf="formGroup.controls.tagName.errors?.name" class="form-input-error">
+                {{formGroup.controls.tagName.errors?.name}}
+            </span>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-type' | translate}}</span>
+            <mat-select formControlName="tagType">
+                <mat-option *ngFor="let type of tagType | enumToArray" [value]="type.key">
+                    {{ type.value }}
+                </mat-option>
+            </mat-select>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-address-sample' | translate}}</span>
+            <input numberOnly formControlName="tagAddress" type="text">
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-description' | translate}}</span>
+            <input formControlName="tagDescription" type="text">
+        </div>
+    </div>
+    <div mat-dialog-actions class="dialog-action">
+        <button mat-raised-button (click)="onNoClick()">{{'dlg.cancel' | translate}}</button>
+        <button mat-raised-button color="primary" (click)="onOkClick()" [disabled]="formGroup.invalid">{{'dlg.ok' | translate}}</button>
+    </div>
+</form>

--- a/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.scss
+++ b/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.scss
@@ -1,0 +1,11 @@
+:host {
+    .container {
+        width: 400px;
+    }
+    .item-block {
+        display: block;
+        mat-select, input, span {
+            width:calc(100% - 5px);
+        }
+    }
+}

--- a/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.ts
+++ b/client/src/app/device/tag-property/tag-property-edit-melsec/tag-property-edit-melsec.component.ts
@@ -1,0 +1,79 @@
+import { Component, EventEmitter, Inject, OnDestroy, OnInit, Output } from '@angular/core';
+import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { MAT_LEGACY_DIALOG_DATA as MAT_DIALOG_DATA, MatLegacyDialogRef as MatDialogRef } from '@angular/material/legacy-dialog';
+import { Subject } from 'rxjs';
+import { Device, MelsecTagType, Tag } from '../../../_models/device';
+
+@Component({
+    selector: 'app-tag-property-edit-melsec',
+    templateUrl: './tag-property-edit-melsec.component.html',
+    styleUrls: ['./tag-property-edit-melsec.component.scss']
+})
+export class TagPropertyEditMelsecComponent implements OnInit, OnDestroy {
+    @Output() result = new EventEmitter<any>();
+    formGroup: UntypedFormGroup;
+    tagType = MelsecTagType;
+    existingNames = [];
+    error: string;
+    private destroy$ = new Subject<void>();
+
+    constructor(private fb: UntypedFormBuilder,
+        private translateService: TranslateService,
+        public dialogRef: MatDialogRef<TagPropertyEditMelsecComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: TagPropertyMelsecData) { }
+
+    ngOnInit() {
+        this.formGroup = this.fb.group({
+            deviceName: [this.data.device.name, Validators.required],
+            tagName: [this.data.tag.name, [Validators.required, this.validateName()]],
+            tagType: [this.data.tag.type, Validators.required],
+            tagAddress: [this.data.tag.address, [Validators.required]],
+            tagDescription: [this.data.tag.description],
+        });
+
+        this.formGroup.updateValueAndValidity();
+        Object.keys(this.data.device.tags).forEach((key) => {
+            let tag = this.data.device.tags[key];
+            if (tag.id) {
+                if (tag.id !== this.data.tag.id) {
+                    this.existingNames.push(tag.name);
+                }
+            } else if (tag.name !== this.data.tag.name) {
+                this.existingNames.push(tag.name);
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.destroy$.next(null);
+        this.destroy$.complete();
+    }
+
+    validateName(): ValidatorFn {
+        return (control: AbstractControl): ValidationErrors | null => {
+            this.error = null;
+            const name = control?.value;
+            if (this.existingNames.indexOf(name) !== -1) {
+                return { name: this.translateService.instant('msg.device-tag-exist') };
+            }
+            if (name?.includes('@')) {
+                return { name: this.translateService.instant('msg.device-tag-invalid-char') };
+            }
+            return null;
+        };
+    }
+
+    onNoClick(): void {
+        this.result.emit();
+    }
+
+    onOkClick(): void {
+        this.result.emit(this.formGroup.getRawValue());
+    }
+}
+
+export interface TagPropertyMelsecData {
+    device: Device;
+    tag: Tag;
+}

--- a/client/src/app/device/tag-property/tag-property.service.ts
+++ b/client/src/app/device/tag-property/tag-property.service.ts
@@ -19,6 +19,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { ToastrService } from 'ngx-toastr';
 import { TagPropertyEditGpioComponent, TagPropertyGpioData } from './tag-property-edit-gpio/tag-property-edit-gpio.component';
 import { TagPropertyEditWebcamComponent, TagPropertyWebcamData } from './tag-property-edit-webcam/tag-property-edit-webcam.component';
+import { TagPropertyEditMelsecComponent } from './tag-property-edit-melsec/tag-property-edit-melsec.component';
 
 @Injectable({
     providedIn: 'root'
@@ -444,6 +445,40 @@ export class TagPropertyService {
                     if (checkToAdd) {
                         this.checkToAdd(tag, device);
                     }else if (tag.id !== oldTagId) {
+                        //remove old tag device reference
+                        delete device.tags[oldTagId];
+                        this.checkToAdd(tag, device);
+                    }
+                    this.projectService.setDeviceTags(device);
+                }
+                dialogRef.close();
+                return result;
+            })
+        );
+    }
+
+    public editTagPropertyMelsec(device: Device, tag: Tag, checkToAdd: boolean): Observable<any> {
+        let oldTagId = tag.id;
+        let tagToEdit: Tag = Utils.clone(tag);
+        let dialogRef = this.dialog.open(TagPropertyEditMelsecComponent, {
+            disableClose: true,
+            data: {
+                device: device,
+                tag: tagToEdit
+            },
+            position: { top: '60px' }
+        });
+
+        return dialogRef.componentInstance.result.pipe(
+            map(result => {
+                if (result) {
+                    tag.name = result.tagName;
+                    tag.address = result.tagAddress;
+                    tag.type = result.tagType;
+                    tag.description = result.tagDescription;
+                    if (checkToAdd) {
+                        this.checkToAdd(tag, device);
+                    } else if (tag.id !== oldTagId) {
                         //remove old tag device reference
                         delete device.tags[oldTagId];
                         this.checkToAdd(tag, device);

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -77,7 +77,7 @@
     "dlg.menuitem-alarms": "Alarms by Click",
     "dlg.menuitem-address": "Link address",
     "dlg.menuitem-icons-filter": "Icons Filter",
-	
+
     "dlg.menuitem-submenu": "Submenu",
     "dlg.menuitem-add-submenu": "Add Submenu Item",
     "dlg.menuitem-submenu-items": "Submenu Items",
@@ -960,6 +960,9 @@
     "device.template-device": "Template name",
     "device.template-tags": "Template name",
     "device.property-socket-reuse": "Socket Reuse",
+    "device.property-melsec-target": "Address (IP[:port])",
+    "device.property-melsec-ascii": "ASCII",
+    "device.property-melsec-octalIO": "Octal I/O",
 
     "device.browsetopics-property-title": "Broker Topics to subscribe and publish",
     "device.browsetopics-property-sub": "Subscribe",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa-server",
-  "version": "1.2.7-2490",
+  "version": "1.2.7-2491",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",
   "main": "main.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa-server",
-  "version": "1.2.7-2491",
+  "version": "1.2.7-2496",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",
   "main": "main.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuxa-server",
-  "version": "1.2.7-2496",
+  "version": "1.2.7-2497",
   "description": "Web-based Process Visualization (SCADA/HMI/Dashboard) software",
   "main": "main.js",
   "scripts": {

--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -16,6 +16,7 @@ var ADSclient = require('./adsclient');
 // var TEMPLATEclient = require('./template');
 var GpioClient = require('./gpio');
 var WebCamClient = require('./webcam');
+var MELSECClient = require('./melsec');
 
 const path = require('path');
 const utils = require('../utils');
@@ -97,18 +98,21 @@ function Device(data, runtime) {
             return null;
         }
         comm = ADSclient.create(data, logger, events, manager, runtime);
-    }
-    else if (data.type === DeviceEnum.GPIO) {
+    } else if (data.type === DeviceEnum.GPIO) {
         if (!GpioClient) {
             return null;
         }
         comm = GpioClient.create(data, logger, events, manager, runtime);
-    }
-    else if (data.type === DeviceEnum.WebCam) {
+    } else if (data.type === DeviceEnum.WebCam) {
         if (!WebCamClient) {
             return null;
         }
         comm = WebCamClient.create(data, logger, events, manager, runtime);
+    } else if (data.type === DeviceEnum.MELSEC) {
+        if (!MELSECClient) {
+            return null;
+        }
+        comm = MELSECClient.create(data, logger, events, manager, runtime);
     }
     // else if (data.type === DeviceEnum.Template) {
     //     if (!TEMPLATEclient) {
@@ -524,6 +528,8 @@ function loadPlugin(type, module) {
         ADSclient = require(module);
     } else if (type === DeviceEnum.GPIO) {
         GpioClient = require(module);
+    } else if (type === DeviceEnum.MELSEC) {
+        MELSECClient = require(module);
     }
 }
 
@@ -563,7 +569,8 @@ var DeviceEnum = {
     ADSclient: 'ADSclient',
     GPIO: 'GPIO',
     internal: 'internal',
-    WebCam: 'WebCam'
+    WebCam: 'WebCam',
+    MELSEC: 'MELSEC',
     // Template: 'template'
 }
 

--- a/server/runtime/devices/melsec/index.js
+++ b/server/runtime/devices/melsec/index.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * Driver MELSEC (MC Protocol / SLMP via TCP) based on 'mcprotocol'
+ * API usate: initiateConnection, setTranslationCB, addItems, readAllItems, writeItems, dropConnection
+ */
+
+const path = require('path');
+const { createRequire } = require('module');
+
+let McProtocol; // costructor
+
+const utils = require('../../utils');
+const deviceUtils = require('../device-utils');
+
+function tryLoadMcprotocol(manager) {
+    // Mok-Protocol to use locally
+    try { return require(path.resolve(process.cwd(), '_pkg/mok-mcprotocol/mcprotocol.cjs')); } catch {}
+    // from node_modules
+    try { return require('mcprotocol'); } catch { }
+    if (manager) {
+        // from _pkg
+        try { return manager.require('mcprotocol'); } catch {}
+    }
+    return null;
+}
+
+function MelsecClient(_data, _logger, _events, _runtime) {
+    let data = JSON.parse(JSON.stringify(_data));
+    const logger = _logger;
+    const events = _events;
+    const runtime = _runtime;
+
+    let conn = null;
+    let connected = false;
+    let working = false;
+    let overloading = 0;
+    let lastStatus = '';
+    let lastTimestampValue = 0;
+
+    let tagMap = {};          // tagId -> definizione (.address in sintax MC)
+    let varsValue = {};       // value to send on frontend
+
+    this.connect = function () {
+        return new Promise((resolve, reject) => {
+            try {
+                if (_checkWorking(true) === false) return reject();
+                if (!data.property || !data.property.address) {
+                    logger.error(`'${data.name}' missing connection data!`);
+                    _emitStatus('connect-failed');
+                    _clearVarsValue();
+                    _checkWorking(false);
+                    return reject(new Error('missing address'));
+                }
+
+                const { host, port, ascii, octal } = _parseAddressOptions(
+                    data.property.address,
+                    data.property.ascii,
+                    data.property.octalInputOutput
+                );
+
+                logger.info(`'${data.name}' try to connect ${host}:${port}`, true);
+
+                if (!McProtocol) {
+                    logger.error(`'${data.name}' mcprotocol not available`);
+                    _emitStatus('connect-error');
+                    _checkWorking(false);
+                    return reject(new Error('mcprotocol ctor missing'));
+                }
+
+                conn = new McProtocol();
+
+                conn.initiateConnection(
+                    { host, port, ascii: !!ascii, octalInputOutput: (typeof octal === 'boolean' ? octal : true) },
+                    (err) => {
+                        if (typeof err !== 'undefined') {
+                            logger.error(`'${data.name}' connect failed! ${err}`);
+                            connected = false;
+                            _emitStatus('connect-error');
+                            _clearVarsValue();
+                            _checkWorking(false);
+                            return reject(err);
+                        }
+
+                        // map tagId -> address MC
+                        conn.setTranslationCB((tagId) => tagMap[tagId] ? tagMap[tagId].address : tagId);
+
+                        // register items
+                        conn.addItems(Object.keys(tagMap));
+
+                        connected = true;
+                        logger.info(`'${data.name}' connected!`, true);
+                        _emitStatus('connect-ok');
+                        _checkWorking(false);
+                        resolve();
+                    }
+                );
+            } catch (err) {
+                logger.error(`'${data.name}' try to connect error! ${err}`);
+                _emitStatus('connect-error');
+                _clearVarsValue();
+                _checkWorking(false);
+                reject(err);
+            }
+        });
+    };
+
+    this.disconnect = function () {
+        return new Promise((resolve, reject) => {
+            try {
+                if (conn) {
+                    try { conn.dropConnection(); } catch { }
+                }
+                connected = false;
+                _emitStatus('connect-off');
+                _clearVarsValue();
+                _checkWorking(false);
+                logger.info(`'${data.name}' disconnected!`, true);
+                resolve(true);
+            } catch (err) {
+                logger.error(`'${data.name}' disconnect failure! ${err}`);
+                reject(err);
+            }
+        });
+    };
+
+    this.polling = async function () {
+        if (_checkWorking(true) === false) {
+            _emitStatus('connect-busy');
+            return;
+        }
+        if (!conn || !connected) {
+            _checkWorking(false);
+            return;
+        }
+        try {
+            conn.readAllItems(async (anythingBad, valuesObj) => {
+                if (anythingBad) {
+                    logger.warn(`'${data.name}' polling returned bad quality`);
+                }
+                const changed = await _updateVarsValue(valuesObj);
+                lastTimestampValue = Date.now();
+                _emitValues(varsValue);
+                if (this.addDaq && changed && !utils.isEmptyObject(changed)) {
+                    this.addDaq(changed, data.name, data.id);
+                }
+                if (lastStatus !== 'connect-ok') {
+                    _emitStatus('connect-ok');
+                }
+                _checkWorking(false);
+            });
+        } catch (err) {
+            logger.error(`'${data.name}' polling error: ${err}`);
+            _checkWorking(false);
+        }
+    };
+
+    this.load = function (_d) {
+        data = JSON.parse(JSON.stringify(_d));
+        varsValue = {};
+        tagMap = {};
+        try {
+            let count = 0;
+            for (const id in data.tags) {
+                const t = data.tags[id];
+                if (!t.address || typeof t.address !== 'string') {
+                    logger.warn(`'${data.name}' tag ${t.name} (${id}) missing MC address`);
+                    continue;
+                }
+                tagMap[id] = { ...t, id };
+                count++;
+            }
+            logger.info(`'${data.name}' data loaded (${count})`, true);
+        } catch (err) {
+            logger.error(`'${data.name}' load error! ${err}`);
+        }
+    };
+
+    this.getValues = function () { return varsValue; };
+
+    this.getValue = function (id) {
+        if (varsValue[id]) return { id, value: varsValue[id].value, ts: lastTimestampValue };
+        return null;
+    };
+
+    this.getStatus = function () { return lastStatus; };
+
+    this.getTagProperty = function (tagId) {
+        const t = tagMap[tagId];
+        return t ? { id: tagId, name: t.name, type: t.type, format: t.format } : null;
+    };
+
+    this.setValue = async function (tagId, value) {
+        if (!tagMap[tagId] || !conn) return false;
+        const addr = tagMap[tagId].address;
+        try {
+            const valueToSend = await deviceUtils.tagRawCalculator(value, tagMap[tagId], runtime);
+            await new Promise((resolve, reject) => {
+                conn.writeItems(addr, valueToSend, (anythingBad) => {
+                    if (anythingBad) return reject(new Error('write error'));
+                    logger.info(`'${tagMap[tagId].name}' setValue(${tagId}, ${valueToSend})`, true, true);
+                    resolve();
+                });
+            });
+            return true;
+        } catch (err) {
+            logger.error(`'${tagMap[tagId]?.name || tagId}' setValue error! ${err}`);
+            return false;
+        }
+    };
+
+    /**
+     * Return if device is connected
+     */
+    this.isConnected = function () {
+        return connected;
+    }
+
+    this.bindAddDaq = function (fnc) { this.addDaq = fnc; };
+    this.addDaq = null;
+
+    this.lastReadTimestamp = () => lastTimestampValue;
+
+    this.getTagDaqSettings = (tagId) => (data.tags[tagId] ? data.tags[tagId].daq : null);
+    this.setTagDaqSettings = (tagId, settings) => {
+        if (data.tags[tagId]) utils.mergeObjectsValues(data.tags[tagId].daq, settings);
+    };
+
+    function _parseAddressOptions(address, ascii, octal) {
+        let host = address;
+        let port = 1281; // default comune MC/SLMP
+        const i = address.indexOf(':');
+        if (i !== -1) {
+            host = address.substring(0, i);
+            port = parseInt(address.substring(i + 1), 10);
+        }
+        return { host, port, ascii, octal };
+    }
+
+    function _clearVarsValue() {
+        for (const id in varsValue) varsValue[id].value = null;
+        _emitValues(varsValue);
+    }
+
+    async function _updateVarsValue(valuesObj) {
+        let some = false;
+        const ts = Date.now();
+        const toDaq = {};
+        const temp = {};
+
+        for (const id in tagMap) {
+            const raw = valuesObj[id]; // key = tagId via setTranslationCB
+            if (typeof raw === 'undefined') continue;
+            const tagDef = tagMap[id];
+            temp[id] = {
+                id,
+                rawValue: raw,
+                type: tagDef.type,
+                daq: tagDef.daq,
+                changed: true,
+                tagref: tagDef
+            };
+            some = true;
+        }
+        if (!some) return null;
+
+        for (const id in temp) {
+            if (!utils.isNullOrUndefined(temp[id].rawValue)) {
+                temp[id].value = await deviceUtils.tagValueCompose(
+                    temp[id].rawValue,
+                    varsValue[id] ? varsValue[id].value : null,
+                    temp[id].tagref,
+                    runtime
+                );
+                temp[id].timestamp = ts;
+                if (deviceUtils.tagDaqToSave(temp[id], ts)) toDaq[id] = temp[id];
+            }
+            varsValue[id] = temp[id];
+            varsValue[id].changed = false;
+        }
+        return toDaq;
+    }
+
+    function _emitValues(values) {
+        events.emit('device-value:changed', { id: data.id, values });
+    }
+
+    function _emitStatus(status) {
+        lastStatus = status;
+        events.emit('device-status:changed', { id: data.id, status });
+    }
+
+    function _checkWorking(check) {
+        if (check && working) {
+            overloading++;
+            logger.warn(`'${data.name}' working (connection || polling) overload! ${overloading}`);
+            if (overloading >= 3) {
+                try { if (conn) conn.dropConnection(); } catch { }
+            } else {
+                return false;
+            }
+        }
+        working = check;
+        overloading = 0;
+        return true;
+    }
+}
+
+module.exports = {
+    init: function () { },
+    create: function (data, logger, events, manager, runtime) {
+        if (!McProtocol) McProtocol = tryLoadMcprotocol(manager);
+        if (!McProtocol) return null;
+        return new MelsecClient(data, logger, events, runtime);
+    }
+};

--- a/server/runtime/devices/melsec/index.js
+++ b/server/runtime/devices/melsec/index.js
@@ -56,7 +56,7 @@ function MelsecClient(_data, _logger, _events, _runtime) {
                 const { host, port, ascii, octal } = _parseAddressOptions(
                     data.property.address,
                     data.property.ascii,
-                    data.property.octalInputOutput
+                    data.property.octalIO
                 );
 
                 logger.info(`'${data.name}' try to connect ${host}:${port}`, true);

--- a/server/runtime/plugins/index.js
+++ b/server/runtime/plugins/index.js
@@ -36,6 +36,7 @@ plugins['chart.js'] = new Plugin('chart.js', './chartjs', 'Chart', '2.9.4', Plug
 plugins['chartjs-node-canvas'] = new Plugin('chartjs-node-canvas', 'chartjs-canvas', 'Chart', '3.2.0', PluginGroupType.chartReport);
 plugins['onoff'] = new Plugin('onoff', './onoff', 'GPIO', '6.0.3', PluginGroupType.connectionDevice);
 plugins['node-webcam'] = new Plugin('node-webcam', './node-webcam', 'WebCam', '0.8.2', PluginGroupType.connectionDevice, true);
+plugins['mcprotocol'] = new Plugin('mcprotocol', './mcprotocol', 'MELSEC', '0.1.2', PluginGroupType.connectionDevice, true);
 
 
 /**


### PR DESCRIPTION
# New Feature: MELSEC (MC Protocol / SLMP) Support

## Description
This update introduces a **new device type: MELSEC (Mitsubishi PLC via MC Protocol/SLMP)**.  
It allows direct read and write access to Mitsubishi PLCs (Q-Series, L-Series, FX, …).

⚠️ **Note**: The MELSEC driver is provided as a **plugin**.  

## Device Configuration
- **Address (IP[:Port])**: PLC IP address and optional port.  
  Example: `192.168.0.2:1281`  
  (Default port: `1281`)
- **ASCII**: Enable only if the PLC is configured in ASCII mode (default: disabled).
- **Octal I/O**: Keep enabled for octal addressing on `X`/`Y` devices (default: enabled).
- **Polling**: Read cycle interval in ms.

## Example Tags
- Bit devices: M0, M10, M0,16
- I/O devices: X0, Y10
- Word devices: D100, D200, D100,10