### PR TITLE
Feature: Support for touch/click event in Chart with Show Mode: Custom

### DIFF
--- a/client/src/app/_models/script.ts
+++ b/client/src/app/_models/script.ts
@@ -275,6 +275,31 @@ if (paramLines && Array.isArray(paramLines)) {
 }`
     },
     {
+        name: 'chart-data-touch', mode: null, text: 'script.template-chart-data-touch-text', tooltip: 'script.template-chart-data-touch-tooltip',
+        code: `// Add script parameters 'paramLines' as Chart lines (array), 'xVal' as X axis touch point, 'yVal' as Y axis touch point
+if (paramLines && Array.isArray(paramLines)) {
+    const count = 10;
+    paramLines.forEach(line => {
+        var y = [];
+        var x = [];
+        for (var i = 0; i < count; i++) {
+            const randomNumber = Math.floor(Math.random() * 21);
+            y.push(randomNumber);
+            x.push(i);
+        }
+      	if (typeof xVal === 'number' && typeof yVal === 'number') {
+       		x.push(Math.round(xVal));
+       		y.push(Math.round(yVal));
+      	}
+        line['y'] = y;
+        line['x'] = x;
+    });
+    return paramLines;
+} else {
+    return 'Missing chart lines';
+}`
+    },
+    {
         name: 'invoke-chart-update-options', mode: ScriptMode.CLIENT, text: 'script.template-invoke-chart-update-options-text', tooltip: 'script.template-invoke-chart-update-options-tooltip',
         code: `let opt = $invokeObject('chart_1', 'getOptions');
 if (opt) {

--- a/client/src/app/_models/script.ts
+++ b/client/src/app/_models/script.ts
@@ -254,7 +254,7 @@ export class TemplatesCode {
         this.functions = this.allFunctions.filter(sf => !sf.mode || !mode || sf.mode === mode);
     }
     allFunctions = <SystemFunction[]>[{
-        name: 'chart-data', mode: ScriptMode.CLIENT, text: 'script.template-chart-data-text', tooltip: 'script.template-chart-data-tooltip',
+        name: 'chart-data', mode: null, text: 'script.template-chart-data-text', tooltip: 'script.template-chart-data-tooltip',
         code: `// Add script parameter 'paramLines' as Chart lines (array)
 if (paramLines && Array.isArray(paramLines)) {
     const count = 10;

--- a/client/src/app/_services/script.service.ts
+++ b/client/src/app/_services/script.service.ts
@@ -4,7 +4,7 @@ import { Observable, lastValueFrom } from 'rxjs';
 
 import { EndPointApi } from '../_helpers/endpointapi';
 import { environment } from '../../environments/environment';
-import { Script, ScriptMode, SystemFunctions } from '../_models/script';
+import { Script, ScriptMode, ScriptParamType, SystemFunctions } from '../_models/script';
 import { ProjectService } from './project.service';
 import { HmiService, ScriptCommandEnum, ScriptCommandMessage } from './hmi.service';
 import { Utils } from '../_helpers/utils';
@@ -86,9 +86,12 @@ export class ScriptService {
                         parameterToAdd += `let ${param.name} = ${param.value};`;
                     } else if (Utils.isObject(param.value)) {
                         parameterToAdd += `let ${param.name} = ${JSON.stringify(param.value)};`;
+                    } else if (param.type === ScriptParamType.value && !param.value) {
+                        parameterToAdd += `let ${param.name} = ${param.value};`;
                     } else {
                         parameterToAdd += `let ${param.name} = '${param.value}';`;
                     }
+                    parameterToAdd += `\n`;
                 });
                 (async () => {
                     try {

--- a/client/src/app/_services/script.service.ts
+++ b/client/src/app/_services/script.service.ts
@@ -90,18 +90,20 @@ export class ScriptService {
                         parameterToAdd += `let ${param.name} = '${param.value}';`;
                     }
                 });
-                try {
-                    const code = `${parameterToAdd}${script.code}`;
-                    const asyncText = script.sync ? 'function' : 'async function';
-                    const callText = `${asyncText} ${script.name}() {\n${this.addSysFunctions(code)} \n }\n${script.name}.call(this);\n`;
-                    const result = eval(callText);
-                    observer.next(result);
-                } catch (err) {
-                    console.error(err);
-                    observer.error(err);
-                } finally {
-                    observer.complete();
-                }
+                (async () => {
+                    try {
+                        const code = `${parameterToAdd}${script.code}`;
+                        const asyncText = script.sync ? 'function' : 'async function';
+                        const callText = `${asyncText} ${script.name}() {\n${this.addSysFunctions(code)} \n }\n${script.name}.call(this);\n`;
+                        const result = await eval(callText);
+                        observer.next(result);
+                    } catch (err) {
+                        console.error(err);
+                        observer.error(err);
+                    } finally {
+                        observer.complete();
+                    }
+                })();
             }
         });
     }

--- a/client/src/app/gauges/controls/html-chart/chart-property/chart-property.component.ts
+++ b/client/src/app/gauges/controls/html-chart/chart-property/chart-property.component.ts
@@ -49,7 +49,7 @@ export class ChartPropertyComponent implements OnInit, OnDestroy {
     autoScala = { enabled: true, min: 0, max: 10 };
     scripts$: Observable<Script[]>;
     property: GaugeChartProperty;
-    eventType = [Utils.getEnumKey(GaugeEventType, GaugeEventType.onLoad)];
+    eventType = [Utils.getEnumKey(GaugeEventType, GaugeEventType.click), Utils.getEnumKey(GaugeEventType, GaugeEventType.onLoad)];
     actionRunScript = Utils.getEnumKey(GaugeEventActionType, GaugeEventActionType.onRunScript);
     selectActionType = {};
 

--- a/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
+++ b/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewInit, OnDestroy, ViewChild, Input, Output, EventEmitter, ElementRef } from '@angular/core';
 
-import { ChartLegendMode, ChartRangeType, ChartRangeConverter, ChartLine, ChartViewType, ChartLineZone } from '../../../../_models/chart';
+import { ChartLegendMode, ChartRangeType, ChartRangeConverter, ChartLine, ChartViewType, ChartLineZone, Chart } from '../../../../_models/chart';
 import { NgxUplotComponent, NgxSeries, ChartOptions } from '../../../../gui-helpers/ngx-uplot/ngx-uplot.component';
 import { DaqQuery, DateFormatType, TimeFormatType, IDateRange, GaugeChartProperty, DaqChunkType, GaugeEventType } from '../../../../_models/hmi';
 import { Utils } from '../../../../_helpers/utils';
@@ -229,7 +229,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         }
         this.nguplot.init(this.options, (this.property?.type === ChartViewType.custom) ? true : false);
         this.updateDomOptions(this.nguplot);
-        if (this.property.events.find(ev => ev.type === this.eventChartClick)) {
+        if (this.property?.events?.find(ev => ev.type === this.eventChartClick)) {
             this.nguplot.onChartClick = this.handleChartClick.bind(this);
         }
     }
@@ -611,11 +611,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
             let scriptToRun = Utils.clone(script);
             let chart = this.hmiService.getChart(this.property.id);
             this.reloadActive = true;
-            scriptToRun.parameters = [<ScriptParam>{
-                type: ScriptParamType.chart,
-                value: chart?.lines,
-                name: script.parameters[0]?.name
-            }];
+            scriptToRun.parameters = this.getCustomParameters(script.parameters, chart);
             this.scriptService.runScript(scriptToRun).pipe(
                 delay(200)
             ).subscribe(customData => {
@@ -674,21 +670,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
             let scriptToRun = Utils.clone(script);
             let chart = this.hmiService.getChart(this.property.id);
             this.reloadActive = true;
-            scriptToRun.parameters = <ScriptParam[]>[{
-                type: ScriptParamType.chart,
-                value: chart?.lines,
-                name: script.parameters[0]?.name
-            },
-            {
-                type: ScriptParamType.value,
-                value: x,
-                name: script.parameters[1]?.name
-            },
-            {
-                type: ScriptParamType.value,
-                value: y,
-                name: script.parameters[2]?.name
-            }];
+            scriptToRun.parameters = this.getCustomParameters(script.parameters, chart, x, y);
             this.scriptService.runScript(scriptToRun).pipe(
                 delay(200)
             ).subscribe(customData => {
@@ -699,6 +681,34 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.reloadActive = false;
             });
         }
+    }
+
+    getCustomParameters(params: ScriptParam[], chart: Chart, x: number = null, y: number = null): ScriptParam[] {
+        let result = [];
+        for (let param of params) {
+            if (param.type === ScriptParamType.chart) {
+                result.push(<ScriptParam>{
+                        type: ScriptParamType.chart,
+                        value: chart?.lines,
+                        name: param?.name
+                });
+            } else if (param.type === ScriptParamType.value) {
+                let scriptParam = <ScriptParam>{
+                    type: param.type,
+                    value: param.value,
+                    name: param.name
+                };
+                if (param.name.toLocaleLowerCase().indexOf('x') !== -1) {
+                    scriptParam.value = x;
+                } else if (param.name.toLocaleLowerCase().indexOf('y') !== -1) {
+                    scriptParam.value = y;
+                }
+                result.push(scriptParam);
+            } else {
+                result.push(param);
+            }
+        }
+        return result;
     }
 }
 

--- a/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
+++ b/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
@@ -229,7 +229,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         }
         this.nguplot.init(this.options, (this.property?.type === ChartViewType.custom) ? true : false);
         this.updateDomOptions(this.nguplot);
-        if (this.property?.events?.find(ev => ev.type === this.eventChartClick)) {
+        if (!this.isEditor && this.property?.events?.find(ev => ev.type === this.eventChartClick)) {
             this.nguplot.onChartClick = this.handleChartClick.bind(this);
         }
     }

--- a/client/src/app/gauges/gauges.component.ts
+++ b/client/src/app/gauges/gauges.component.ts
@@ -30,7 +30,6 @@ import { HtmlIframeComponent } from './controls/html-iframe/html-iframe.componen
 import { HtmlTableComponent } from './controls/html-table/html-table.component';
 import { DataTableComponent } from './controls/html-table/data-table/data-table.component';
 import { HtmlSchedulerComponent } from './controls/html-scheduler/html-scheduler.component';
-import { SchedulerComponent } from './controls/html-scheduler/scheduler/scheduler.component';
 import { ChartOptions } from '../gui-helpers/ngx-uplot/ngx-uplot.component';
 import { GaugeBaseComponent } from './gauge-base/gauge-base.component';
 import { HtmlImageComponent } from './controls/html-image/html-image.component';

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1510,6 +1510,8 @@
 
     "script.template-chart-data-text": "Customized chart data",
     "script.template-chart-data-tooltip": "Code template of customized chart data to return",
+    "script.template-chart-data-touch-text": "Customized chart data with touch event",
+    "script.template-chart-data-touch-tooltip": "Code template of customized chart data to return and set value with coordinate(x/y) of touch event",
     "script.template-invoke-chart-update-options-text": "Update Chart options",
     "script.template-invoke-chart-update-options-tooltip": "Code template to update Chart options (Y-axis scale range). CLIENT mode only!",
     "script.template-getHistoricalTagsoptions-text": "Get Historical Tags values",


### PR DESCRIPTION
## 🚀 Feature: Support for `touch/click` event in Chart with 'Show mode: Custom'

### ✨ Description
This PR adds a new feature for **charts using `Show Mode: Custom`**, enabling the ability to:
- **Capture the `x` and `y` coordinates** when the user performs a **touch** or **click** on the chart area.
- **Pass these coordinates to a custom script**, which can then dynamically generate the data to be displayed on the chart.

This enhances the flexibility and interactivity of custom charts, allowing for use cases like simulations, interactive analysis, or manual data input.

---

### 🔧 Implementation
- Added **event listener for `click`/`touch` events** on the chart canvas.
- Captured coordinates are converted into numeric `x` and `y` values and passed as arguments to the **custom chart script**.
- The script receives:
  - `paramLines`: an array of chart lines.
  - `x`, `y`: the numeric coordinates of the user interaction.

> 🔁 The script is responsible for **generating or modifying the chart data** based on these inputs.

---

### 🧪 Example Project
An **example project** is included to demonstrate:
- A chart configured with `Show Mode: Custom`.
- A script that generates random data and inserts the clicked point at the appropriate position.
- A practical use case of this feature for testing and validation.

[custom_chart.json](https://github.com/user-attachments/files/22992558/custom_chart.json)
