### PR TITLE
OPC UA - UInt32 Syntax Error

### DIFF
--- a/server/runtime/devices/opcua/index.js
+++ b/server/runtime/devices/opcua/index.js
@@ -723,7 +723,7 @@ function OpcUAclient(_data, _logger, _events, _runtime) {
             case opcua.DataType.Int16:
             case opcua.DataType.UInt16:
             case opcua.DataType.Int32:
-            case opcua.DataType.UInt3:
+            case opcua.DataType.UInt32:
             case opcua.DataType.Int64:
             case opcua.DataType.UInt64:
                 return parseInt(value);


### PR DESCRIPTION
There is a syntax error on the opcua device regarding UInt32.