### PR TITLE
Chart: add “Points only (no interpolation)” render mode

### DIFF
--- a/client/src/app/editor/chart-config/chart-config.component.ts
+++ b/client/src/app/editor/chart-config/chart-config.component.ts
@@ -31,7 +31,8 @@ export class ChartConfigComponent implements OnInit {
     lineColor = Utils.lineColor;
 
     lineInterpolationType = [{ text: 'chart.config-interpo-linear', value: 0 }, { text: 'chart.config-interpo-stepAfter', value: 1 },
-                    { text: 'chart.config-interpo-stepBefore', value: 2 }, { text: 'chart.config-interpo-spline', value: 3 }];
+                    { text: 'chart.config-interpo-stepBefore', value: 2 }, { text: 'chart.config-interpo-spline', value: 3 },
+                    { text: 'chart.config-interpo-none', value: 4 }];
 
     constructor(
         public dialog: MatDialog,

--- a/client/src/app/editor/chart-config/chart-line-property/chart-line-property.component.html
+++ b/client/src/app/editor/chart-config/chart-line-property/chart-line-property.component.html
@@ -31,7 +31,7 @@
         <div class="block mt10">
             <div class="my-form-field" style="width: 140px;">
                 <span>{{'chart.config-line-width' | translate}}</span>
-                <input numberOnly formControlName="lineWidth" style="width:140px" type="number" min="1" max="5">
+                <input numberOnly formControlName="lineWidth" style="width:140px" type="number" min="1">
             </div>
             <div class="my-form-field inbk ml20 tac">
                 <span>{{'chart.config-line-gap' | translate}}</span>

--- a/client/src/app/gui-helpers/ngx-uplot/ngx-uplot.component.ts
+++ b/client/src/app/gui-helpers/ngx-uplot/ngx-uplot.component.ts
@@ -25,6 +25,7 @@ export class NgxUplotComponent implements OnInit, OnDestroy {
         stepAfter: 1,
         stepBefore: 2,
         spline: 3,
+        none: 4
     };
 
     rawData = false;
@@ -294,6 +295,10 @@ export class NgxUplotComponent implements OnInit, OnDestroy {
             attribute.paths = uPlot.paths.stepped({ align: -1 });
         } else if (attribute.lineInterpolation === this.lineInterpolations.spline) {
             attribute.paths = uPlot.paths.spline();
+        } else if (attribute.lineInterpolation === this.lineInterpolations.none) {
+            attribute.points = { show: true, size: attribute.width ?? 5, width: 1, stroke: attribute.stroke, fill: attribute.fill };
+            attribute.stroke = null;
+            attribute.fill = null;
         }
         this.uplot.addSeries(attribute, index);
         this.uplot.setData(this.data);

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -272,6 +272,7 @@
     "chart.config-interpo-stepAfter": "step after",
     "chart.config-interpo-stepBefore": "step before",
     "chart.config-interpo-spline": "spline",
+    "chart.config-interpo-none": "none (points)",
     "chart.config-line-width": "Line Width",
     "chart.config-line-gap": "Fill Gaps",
     "chart.config-line-add-zone": "Add Zone",


### PR DESCRIPTION
### ✨ Description
Adds a new chart option to render series as points only (no line interpolation). When enabled, the line path is suppressed and only markers are drawn for each data sample.

<img width="393" height="417" alt="image" src="https://github.com/user-attachments/assets/0751a7c6-3180-491c-8f05-fa7c655e84b7" />

<img width="774" height="526" alt="image" src="https://github.com/user-attachments/assets/19fd6ac2-caaa-4076-888a-531d2817a92d" />

