### PR TITLE
History charts: progressive chunked DAQ streaming for uPlot

### DIFF
--- a/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
+++ b/client/src/app/gauges/controls/html-chart/chart-uplot/chart-uplot.component.ts
@@ -8,8 +8,8 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { DaterangeDialogComponent } from '../../../../gui-helpers/daterange-dialog/daterange-dialog.component';
 import { MatLegacyDialog as MatDialog } from '@angular/material/legacy-dialog';
-import { Subject, interval, timer } from 'rxjs';
-import { delay, takeUntil } from 'rxjs/operators';
+import { Subject, from, interval, merge, of, timer } from 'rxjs';
+import { catchError, concatMap, delay, finalize, takeUntil, tap } from 'rxjs/operators';
 import { ScriptService } from '../../../../_services/script.service';
 import { ProjectService } from '../../../../_services/project.service';
 import { ScriptParam, ScriptParamType } from '../../../../_models/script';
@@ -22,8 +22,8 @@ import { HmiService } from '../../../../_services/hmi.service';
 })
 export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
 
-    @ViewChild('chartPanel', {static: false}) public chartPanel: ElementRef;
-    @ViewChild('nguplot', {static: false}) public nguplot: NgxUplotComponent;
+    @ViewChild('chartPanel', { static: false }) public chartPanel: ElementRef;
+    @ViewChild('nguplot', { static: false }) public nguplot: NgxUplotComponent;
 
     @Input() options: ChartOptions;
     @Output() onTimeRange: EventEmitter<DaqQuery> = new EventEmitter();
@@ -39,12 +39,17 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
     range: ZoomRangeType = { from: Date.now(), to: Date.now(), zoomStep: 0 };
     mapData: MapDataDictionary = {};
     pauseMemoryValue: ValueDictionary = {};
-    private destroy$ = new Subject<void>();
     property: GaugeChartProperty;
     chartName: string;
     addValueInterval = 0;
     zoomSize = 0;
     eventChartClick = Utils.getEnumKey(GaugeEventType, GaugeEventType.click);
+
+    private destroy$ = new Subject<void>();
+    private daqCancel$ = new Subject<void>();
+    private cancel$() {
+        return merge(this.daqCancel$, this.destroy$);
+    }
 
     constructor(
         private projectService: ProjectService,
@@ -144,14 +149,49 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     onDaqQuery(daqQuery?: DaqQuery) {
+        this.daqCancel$.next();
         if (daqQuery) {
             this.lastDaqQuery = <DaqQuery>Utils.mergeDeep(this.lastDaqQuery, daqQuery);
         }
-        this.lastDaqQuery.chunked = true;
-        this.onTimeRange.emit(this.lastDaqQuery);
-        if (this.withToolbar) {
-            this.setLoading(true);
+        const TIME_CHUNK_SIZE = 60 * 60 * 1000 * 12;    // 12 hours in ms
+        const chunks = ChartUplotComponent.splitRangeIntoChunks(this.lastDaqQuery.from, this.lastDaqQuery.to, TIME_CHUNK_SIZE);
+        if (!chunks.length) {
+            return;
         }
+        this.setLoading(true);
+
+        from(chunks).pipe(
+            concatMap(c =>
+                this.hmiService.getDaqValues({ sids: this.lastDaqQuery.sids, from: c.from, to: c.to }).pipe(
+                    takeUntil(this.cancel$()),
+                    tap(values => {
+                        this.setValues(values, { index: c.idx + 1, of: c.total });
+                    }),
+                    catchError(err => {
+                        console.error('DAQ chunk error', err);
+                        return of(null as any);
+                    })
+                )
+            ),
+            takeUntil(this.daqCancel$),
+            finalize(() => {
+                this.setLoading(false);
+            })
+        ).subscribe();
+    }
+
+    private static splitRangeIntoChunks(fromMs: number, toMs: number, chunkMs: number) {
+        const chunks: { from: number; to: number; idx: number; total: number }[] = [];
+        if (toMs <= fromMs) return chunks;
+
+        const total = Math.ceil((toMs - fromMs) / chunkMs);
+        let end = toMs;
+        for (let i = 0; i < total; i++) {
+            const start = Math.max(fromMs, end - chunkMs);
+            chunks.push({ from: start, to: end, idx: i, total });
+            end = start;
+        }
+        return chunks;
     }
 
     onRefresh(fromRefresh?: boolean) {
@@ -202,7 +242,9 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
             this.options.height -= size;    // title
 
             size = Utils.getDomTextHeight(this.options.axisLabelFontSize, this.options.fontFamily);
-            if (size < 10) {size = 10;}
+            if (size < 10) {
+                size = 10;
+            }
             this.options.height -= size;    // axis
             this.nguplot.resize(this.options.height, this.options.width);
         }
@@ -280,8 +322,9 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
     public addLine(id: string, name: string, line: ChartLine, addYaxisToLabel: boolean) {
         if (!this.mapData[id]) {
             let linelabel = line.label || name;
-            if (addYaxisToLabel)
-                {linelabel = `Y${line.yaxis} - ${linelabel}`;}
+            if (addYaxisToLabel) {
+                linelabel = `Y${line.yaxis} - ${linelabel}`;
+            }
             let serie = <NgxSeries>{ label: linelabel, stroke: line.color, spanGaps: true };
             if (line.yaxis > 1) {
                 serie.scale = line.yaxis.toString();
@@ -345,10 +388,10 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
 
             const nextMin = sorted[i + 1]?.min;
             if (nextMin !== undefined && r.max < nextMin) {
-            result.push([r.max, color]);
+                result.push([r.max, color]);
             } else if (nextMin === undefined) {
-            // last zone – we’ll add +∞ after the loop
-            result.push([r.max, color]);
+                // last zone – we’ll add +∞ after the loop
+                result.push([r.max, color]);
             }
         });
 
@@ -357,7 +400,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         result.push([Infinity, lastColor]);
 
         return result;
-        }
+    }
 
     /**
      * add value to a realtime chart
@@ -439,18 +482,17 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         this.chunkBuffer.set(chunk.index, values);
         this.processedChunks.add(chunk.index);
 
-        // If all expected chunks have been received
-        if (this.chunkBuffer.size === this.totalChunks) {
-            const sortedChunks = Array.from(this.chunkBuffer.entries())
-                .sort((a, b) => a[0] - b[0])
-                .map(entry => entry[1]);
+        const partialSorted = Array.from(this.chunkBuffer.entries())
+            .sort((a, b) => a[0] - b[0])
+            .map(entry => entry[1]);
 
-            const mergedData = this.buildUnifiedData(sortedChunks);
+        const mergedData = this.buildUnifiedData(partialSorted);
+        this.nguplot.setData(mergedData);
+        this.nguplot.setXScala(this.range.from / 1e3, this.range.to / 1e3);
 
-            this.nguplot.setData(mergedData);
-            this.nguplot.setXScala(this.range.from / 1e3, this.range.to / 1e3);
-
-            setTimeout(() => this.setLoading(false), 300);
+        const done = this.chunkBuffer.size === this.totalChunks;
+        if (done) {
+            setTimeout(() => this.setLoading(false), 200);
         }
     }
 
@@ -538,6 +580,8 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     private setLoading(load: boolean) {
+        if (!this.withToolbar) { return; }
+
         if (load) {
             timer(10000).pipe(
                 takeUntil(this.destroy$)
@@ -561,7 +605,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
             if (this.options.axisLabelFontSize) {
                 font = this.options.axisLabelFontSize + 'px';
             }
-            if (this.options.fontFamily) {font += ' ' + this.options.fontFamily;}
+            if (this.options.fontFamily) { font += ' ' + this.options.fontFamily; }
             this.options.axes[i].font = font;
             this.options.axes[i].labelFont = font;
             this.options.axes[i].ticks = { width: 1 / devicePixelRatio };
@@ -569,7 +613,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.options.axes[i].grid.stroke = this.options.gridLineColor;
                 this.options.axes[i].ticks.stroke = this.options.gridLineColor;
             }
-            if (this.options.axisLabelColor) {this.options.axes[i].stroke = this.options.axisLabelColor;}
+            if (this.options.axisLabelColor) { this.options.axes[i].stroke = this.options.axisLabelColor; }
         }
 
         let always = Utils.getEnumKey(ChartLegendMode, ChartLegendMode.always);
@@ -578,11 +622,11 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         this.options.legend = { show: (this.options.legendMode === always || this.options.legendMode === bottom), width: 1 };
         this.options.tooltip = { show: (this.options.legendMode === always || this.options.legendMode === follow) };
         // Axes label
-        if (this.options.axisLabelX) {this.options.axes[0].label = this.options.axisLabelX;}
-        if (this.options.axisLabelY1) {this.options.axes[1].label = this.options.axisLabelY1;}
-        if (this.options.axisLabelY2) {this.options.axes[2].label = this.options.axisLabelY2;}
-        if (this.options.axisLabelY3) {this.options.axes[3].label = this.options.axisLabelY3;}
-        if (this.options.axisLabelY4) {this.options.axes[4].label = this.options.axisLabelY4;}
+        if (this.options.axisLabelX) { this.options.axes[0].label = this.options.axisLabelX; }
+        if (this.options.axisLabelY1) { this.options.axes[1].label = this.options.axisLabelY1; }
+        if (this.options.axisLabelY2) { this.options.axes[2].label = this.options.axisLabelY2; }
+        if (this.options.axisLabelY3) { this.options.axes[3].label = this.options.axisLabelY3; }
+        if (this.options.axisLabelY4) { this.options.axes[4].label = this.options.axisLabelY4; }
     }
 
     private updateDomOptions(ngup: NgxUplotComponent) {
@@ -590,16 +634,18 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         if (ele) {
             let title = ele[0];
             if (this.options.titleHeight) {
-                if (this.options.axisLabelColor) {title.style.color = this.options.axisLabelColor;}
-                if (this.options.titleHeight) {title.style.fontSize = this.options.titleHeight + 'px';}
-                if (this.options.fontFamily) {title.style.fontFamily = this.options.fontFamily;}
+                if (this.options.axisLabelColor) { title.style.color = this.options.axisLabelColor; }
+                if (this.options.titleHeight) { title.style.fontSize = this.options.titleHeight + 'px'; }
+                if (this.options.fontFamily) { title.style.fontFamily = this.options.fontFamily; }
             } else {
                 title.style.display = 'none';
             }
         }
         let legend = this.chartPanel.nativeElement.querySelector('.u-legend');
         if (legend) {
-            if (this.options.axisLabelColor) {legend.style.color = this.options.axisLabelColor;}
+            if (this.options.axisLabelColor) {
+                legend.style.color = this.options.axisLabelColor;
+            }
             legend.style.lineHeight = 0;
         }
         this.chartPanel.nativeElement.style.backgroundColor = this.options.colorBackground;
@@ -663,7 +709,7 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         }, 500);
     }
 
-    handleChartClick(x: number, y: number ) {
+    handleChartClick(x: number, y: number) {
         const eventClick = this.property?.events?.find(ev => ev.type === this.eventChartClick);
         const script = this.projectService.getScripts()?.find(script => script.id === eventClick?.actparam);
         if (eventClick && script) {
@@ -688,9 +734,9 @@ export class ChartUplotComponent implements OnInit, AfterViewInit, OnDestroy {
         for (let param of params) {
             if (param.type === ScriptParamType.chart) {
                 result.push(<ScriptParam>{
-                        type: ScriptParamType.chart,
-                        value: chart?.lines,
-                        name: param?.name
+                    type: ScriptParamType.chart,
+                    value: chart?.lines,
+                    name: param?.name
                 });
             } else if (param.type === ScriptParamType.value) {
                 let scriptParam = <ScriptParam>{


### PR DESCRIPTION
### ✨ Description
Implements progressive rendering of history data by requesting and displaying DAQ results in chunks (e.g., 6-hour windows), starting from the most recent range. The chart updates after each chunk, giving a streaming/animated fill instead of waiting for the full dataset.

This change keeps impact minimal and reuses existing formatting/merge utilities already present in the frontend.

### Why
Large history ranges caused long wait times and UI “freeze”.
Users should see data as it arrives, with safe cancellation when they refresh, zoom, or navigate.