### PR TITLE
Add copy functionality to alarms

### DIFF
--- a/client/src/app/alarms/alarm-list/alarm-list.component.html
+++ b/client/src/app/alarms/alarm-list/alarm-list.component.html
@@ -73,6 +73,9 @@
             <ng-container matColumnDef="remove">
                 <mat-header-cell *matHeaderCellDef> </mat-header-cell>
                 <mat-cell *matCellDef="let element">
+                    <button mat-icon-button (click)="$event.stopPropagation();onCopyAlarm(element)" class="remove">
+                        <mat-icon>content_copy</mat-icon>
+                    </button>
                     <button mat-icon-button (click)="$event.stopPropagation();onRemoveAlarm(element)" class="remove">
                         <mat-icon>clear</mat-icon>
                     </button>

--- a/client/src/app/alarms/alarm-list/alarm-list.component.ts
+++ b/client/src/app/alarms/alarm-list/alarm-list.component.ts
@@ -59,6 +59,12 @@ export class AlarmListComponent implements OnInit, AfterViewInit, OnDestroy {
 		this.editAlarm(alarm, 0);
     }
 
+    onCopyAlarm(alarm: Alarm) {
+        let copy = JSON.parse(JSON.stringify(alarm));
+        copy.name = copy.name + ' (copy)';
+        this.editAlarm(copy, 1);
+    }
+
     onRemoveAlarm(alarm: Alarm) {
 		this.editAlarm(alarm, -1);
     }


### PR DESCRIPTION
## Add Copy Alarm Feature

### Description
Added a copy button to the alarms list in the settings dialog. Users can now duplicate existing alarms by clicking the copy next to the delete button.
