### PR TITLE
Add opc support for unsupported data types such as TIME

### DIFF
--- a/server/runtime/devices/opcua/index.js
+++ b/server/runtime/devices/opcua/index.js
@@ -23,7 +23,7 @@ function OpcUAclient(_data, _logger, _events, _runtime) {
     var client = opcua.OPCUAClient.create(options);
     const attributeKeys = Object.keys(opcua.AttributeIds).filter((x) => x === 'DataType' || x === 'AccessLevel' || x === 'UserAccessLevel');//x !== "INVALID" && x[0].match(/[a-zA-Z]/));
 
-    var varsValue = [];                 // Signale to send to frontend { id, type, value }
+    var varsValue = {};                 // Signals to send to frontend { id, type, value }
     var getProperty = null;             // Function to ask property (security)
     var lastTimestampValue;             // Last Timestamp of asked values
     var tagsIdMap = {};                 // Map of tag id with opc nodeId
@@ -370,6 +370,9 @@ function OpcUAclient(_data, _logger, _events, _runtime) {
     this.setValue = async function (tagId, value) {
         if (the_session && data.tags[tagId]) {
             let opcType = _toDataType(data.tags[tagId].type);
+            if (data.tags[tagId].dataType) {
+                opcType = data.tags[tagId].dataType; // use the actual dataType from read
+            }
             let valueToSend = _toValue(opcType, value);
             valueToSend = await deviceUtils.tagRawCalculator(valueToSend, data.tags[tagId], runtime);
             if (opcType === opcua.DataType.String || opcType === opcua.DataType.ByteString) {
@@ -537,7 +540,14 @@ function OpcUAclient(_data, _logger, _events, _runtime) {
                 // console.log(nodeId.toString(), '\t value : ', dataValue.value.value.toString());
                 let id = tagsIdMap[nodeId];
                 if (data.tags[id]) {
-                    data.tags[id].rawValue = dataValue.value.value;
+                    let rawVal = dataValue.value.value;
+                    let parsed = false;
+                    if (Array.isArray(rawVal) && rawVal.length > 0) {
+                        rawVal = rawVal[rawVal.length - 1];
+                        parsed = true;
+                    }
+                    data.tags[id].rawValue = rawVal;
+                    data.tags[id].dataType = dataValue.value.dataType;
                     data.tags[id].serverTimestamp = dataValue.serverTimestamp.toString();
                     data.tags[id].timestamp = new Date().getTime();
                     data.tags[id].changed = true;


### PR DESCRIPTION
Fuxa would receive unsupported formats such as TIME, DATE etc the values received were an array [ 0, 5000 ] where 5000 is the actual value in ms for TIME, this PR extracts the value from the array so the TIME type can be used as a TAG in Fuxa.

Node-OPC doesn't support the TIME data types directly and they come through as having no opc type, so to send data back we get the type directly from Node-OPC to send back as a direct value, the underlying data type for TIME etc is just an int32 and the time is in ms

 