### PR TITLE
Fix days offset and add all day switch option

### DIFF
--- a/client/src/app/gauges/controls/html-scheduler/scheduler/scheduler.component.html
+++ b/client/src/app/gauges/controls/html-scheduler/scheduler/scheduler.component.html
@@ -154,7 +154,7 @@
                             <!-- Main schedule info row -->
                             <div class="schedule-main-row">
                                 <span class="schedule-number">{{getDeviceSchedules().indexOf(schedule) + 1}}</span>
-                                <span class="start-time" [innerHTML]="formatTime(schedule.startTime)"></span>
+                                <span class="start-time" [innerHTML]="formatStartTime(schedule)"></span>
                                 <span class="end-time" [innerHTML]="formatScheduleMode(schedule)"></span>
                                 <span class="duration">{{calculateDuration(schedule)}}</span>
                                 <div class="status-switch" (click)="$event.stopPropagation()">
@@ -219,7 +219,7 @@
                             <!-- Main schedule info row -->
                             <div class="schedule-main-row">
                                 <span class="schedule-number">{{getDeviceSchedules().indexOf(schedule) + 1}}</span>
-                                <span class="start-time" [innerHTML]="formatTime(schedule.startTime)"></span>
+                                <span class="start-time" [innerHTML]="formatStartTime(schedule)"></span>
                                 <span class="end-time" [innerHTML]="formatScheduleMode(schedule)"></span>
                                 <span class="duration">{{getRemainingTime(schedule.deviceName || selectedDevice, getDeviceSchedules().indexOf(schedule))}}</span>
 
@@ -312,7 +312,7 @@
                                     <!-- Main schedule info row -->
                                     <div class="schedule-main-row">
                                         <span class="schedule-number">{{deviceGroup.allSchedules.indexOf(schedule) + 1}}</span>
-                                        <span class="start-time" [innerHTML]="formatTime(schedule.startTime)"></span>
+                                        <span class="start-time" [innerHTML]="formatStartTime(schedule)"></span>
                                         <span class="end-time" [innerHTML]="formatScheduleMode(schedule)"></span>
                                         <span class="duration">{{calculateDuration(schedule)}}</span>
 
@@ -380,7 +380,7 @@
                                     <!-- Main schedule info row -->
                                     <div class="schedule-main-row">
                                         <span class="schedule-number">{{deviceGroup.allSchedules.indexOf(schedule) + 1}}</span>
-                                        <span class="start-time" [innerHTML]="formatTime(schedule.startTime)"></span>
+                                        <span class="start-time" [innerHTML]="formatStartTime(schedule)"></span>
                                         <span class="end-time" [innerHTML]="formatScheduleMode(schedule)"></span>
                                         <span class="duration">{{getRemainingTime(schedule.deviceName, deviceGroup.allSchedules.indexOf(schedule))}}</span>
 
@@ -473,6 +473,9 @@
                                (click)="openTimePicker('start')"
                                (focus)="openTimePicker('start')"
                                (blur)="validateTimeInput('start', $event)"
+                               [disabled]="formTimer.allDay"
+                               [style.cursor]="formTimer.allDay ? 'not-allowed' : 'auto'"
+                               [style.pointer-events]="formTimer.allDay ? 'none' : 'auto'"
                                required>
                         <span class="material-icons time-icon">schedule</span>
                     </div>
@@ -552,6 +555,9 @@
                                (click)="openTimePicker('end')"
                                (focus)="openTimePicker('end')"
                                (blur)="validateTimeInput('end', $event)"
+                               [disabled]="formTimer.allDay"
+                               [style.cursor]="formTimer.allDay ? 'not-allowed' : 'auto'"
+                               [style.pointer-events]="formTimer.allDay ? 'none' : 'auto'"
                                required>
                         <span class="material-icons time-icon">schedule</span>
                     </div>
@@ -731,6 +737,17 @@
                             <div class="toggle-switch-container">
                                 <label class="switch">
                                     <input type="checkbox" [(ngModel)]="formTimer.monthMode" name="monthMode">
+                                    <span class="slider"></span>
+                                </label>
+                            </div>
+                        </label>
+                    </div>
+                    <div class="toggle-item">
+                        <label class="toggle-label">
+                            <span class="toggle-text">{{ 'scheduler.all-day' | translate }}</span>
+                            <div class="toggle-switch-container">
+                                <label class="switch">
+                                    <input type="checkbox" [(ngModel)]="formTimer.allDay" name="allDay" (change)="onAllDayChange()">
                                     <span class="slider"></span>
                                 </label>
                             </div>

--- a/client/src/app/gauges/controls/html-scheduler/scheduler/scheduler.component.ts
+++ b/client/src/app/gauges/controls/html-scheduler/scheduler/scheduler.component.ts
@@ -82,10 +82,11 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
         startTime: '08:00',
         endTime: '18:00',
         event: true,
-        days: [false, true, true, true, true, true, false],
+        days: [false, true, true, true, true, true, true],
         months: Array(12).fill(false),
         daysOfMonth: Array(31).fill(false),
         monthMode: false,
+        allDay: false,
         disabled: false,
         deviceName: '',
         recurring: true,
@@ -108,6 +109,17 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
     toggleDayOfMonth(index: number) {
         if (!this.formTimer.daysOfMonth) this.formTimer.daysOfMonth = Array(31).fill(false);
         this.formTimer.daysOfMonth[index] = !this.formTimer.daysOfMonth[index];
+    }
+    onAllDayChange() {
+        if (this.formTimer.allDay) {
+            // Set to full 24 hours
+            this.formTimer.startTime = '00:00';
+            this.formTimer.endTime = '23:59';
+        } else {
+            // Reset to default working hours
+            this.formTimer.startTime = '08:00';
+            this.formTimer.endTime = '18:00';
+        }
     }
     showCalendarPopup(schedule?: any) {
         if (!schedule) return;
@@ -882,10 +894,11 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
             startTime: '08:00',
             endTime: '18:00',
             event: true,
-            days: [false, true, true, true, true, true, false],
+            days: [false, true, true, true, true, true, true],
             months: Array(12).fill(false),
             daysOfMonth: Array(31).fill(false),
             monthMode: false,
+            allDay: false,
             disabled: false,
             deviceName: this.selectedDevice === 'OVERVIEW' ? (this.deviceList[0]?.name || '') : this.selectedDevice,
             recurring: true,
@@ -915,6 +928,7 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
             months: this.formTimer.months,
             daysOfMonth: this.formTimer.daysOfMonth,
             monthMode: this.formTimer.monthMode,
+            allDay: this.formTimer.allDay,
             disabled: this.formTimer.disabled,
             deviceName: deviceName,
             variableId: device.variableId,
@@ -1031,6 +1045,7 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
             months: [...(schedule.months || new Array(12).fill(false))],
             daysOfMonth: [...(schedule.daysOfMonth || new Array(31).fill(false))],
             monthMode: schedule.monthMode || false,
+            allDay: schedule.allDay || (schedule.startTime === '00:00' && schedule.endTime === '23:59'),
             disabled: schedule.disabled || false,
             deviceName: deviceName,
             recurring: schedule.recurring !== undefined ? schedule.recurring : true,
@@ -1944,8 +1959,18 @@ export class SchedulerComponent implements OnInit, OnDestroy, OnChanges, AfterVi
             if (seconds > 0) parts.push(`${seconds}s`);
             return 'Event: ' + (parts.join(' ') || '0s');
         } else {
+            if (schedule.allDay) {
+                return this.translateService.instant('scheduler.all-day');
+            }
             return this.formatTime(schedule.endTime);
         }
+    }
+
+    formatStartTime(schedule: any): string {
+        if (schedule.allDay) {
+            return this.translateService.instant('scheduler.all-day');
+        }
+        return this.formatTime(schedule.startTime);
     }
 
     hasEventMode(): boolean {

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -195,8 +195,8 @@
     "general.sunday-short": "Sun",
     "general.save-template": "Save as template",
     "general.import-template": "Import from template",
-    "general.weekdays": ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],
-    "general.weekdays-short": ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"],
+    "general.weekdays": ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],
+    "general.weekdays-short": ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],
     "general.months": ["January","February","March","April","May","June","July","August","September","October","November","December"],
     "general.months-short": ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],
 
@@ -651,6 +651,7 @@
     "scheduler.event-mode": "Event Mode",
     "scheduler.time-mode": "Time Mode",
     "scheduler.month-mode": "Month Mode",
+    "scheduler.all-day": "All Day",
     "scheduler.months-active": "Months Active",
     "scheduler.days-of-month": "Days of Month",
     "scheduler.days-active": "Days Active",


### PR DESCRIPTION
## Scheduler Day Indexing Fix and All Day Toggle Feature

### **Fixed Issues:**
- **Day Indexing Bug**: Fixed incorrect day scheduling, mismatched indexing (Monday=0 vs Sunday=0)
- **Day Labels**: Reordered day labels to follow JavaScript standards (Sunday=0)

### **New Features:**
- **All Day Toggle**: Added toggle switch that automatically sets 24-hour time range (00:00-23:59)
- **Time Input Control**: Time inputs are disabled and show "not-allowed" cursor when All Day is active
- **Display Logic**: Schedule lists now show "All Day" text instead of specific times for all-day schedules
- **Format Compatibility**: Works with both 12-hour and 24-hour time format settings

**Resolves:** Day offset bug and adds All Day scheduling functionality