### PR TITLE
Optional Node-RED Integration via Settings Flag

### DIFF
--- a/client/src/app/_models/settings.ts
+++ b/client/src/app/_models/settings.ts
@@ -23,6 +23,8 @@ export class AppSettings {
     logFull = false;
     /** User role enabled (default group) */
     userRole = false;
+    /** Enable Node-Red */
+    nodeRedEnabled = true;
 }
 
 export class SmtpSettings {

--- a/client/src/app/_services/app.service.ts
+++ b/client/src/app/_services/app.service.ts
@@ -40,6 +40,10 @@ export class AppService {
         this.onShowLoading.emit(show);
     }
 
+    nodeRedEnabled(): boolean {
+        return this.settingsService.getSettings()?.nodeRedEnabled;
+    }
+
     get isDemoApp() {
         return (environment.type === AppService.APP_DEMO);
     }

--- a/client/src/app/_services/settings.service.ts
+++ b/client/src/app/_services/settings.service.ts
@@ -92,6 +92,10 @@ export class SettingsService {
             this.appSettings.userRole = settings.userRole;
             dirty = true;
         }
+        if (settings.nodeRedEnabled !== this.appSettings.nodeRedEnabled) {
+            this.appSettings.nodeRedEnabled = settings.nodeRedEnabled;
+            dirty = true;
+        }
         return dirty;
     }
 

--- a/client/src/app/editor/app-settings/app-settings.component.css
+++ b/client/src/app/editor/app-settings/app-settings.component.css
@@ -36,3 +36,7 @@
 .system-input {
     width: 320px;
 }
+
+.node-red-info {
+
+}

--- a/client/src/app/editor/app-settings/app-settings.component.html
+++ b/client/src/app/editor/app-settings/app-settings.component.html
@@ -53,6 +53,16 @@
                             <mat-option [value]="true">{{'dlg.app-settings-user-roles' | translate}}</mat-option>
                         </mat-select>
                     </div>
+                    <div class="my-form-field block mt15 system-input">
+                        <span>{{'dlg.app-settings-node-red' | translate}}</span>
+                        <mat-select [(value)]="settings.nodeRedEnabled">
+                            <mat-option [value]="true">{{'general.enabled' | translate}}</mat-option>
+                            <mat-option [value]="false">{{'general.disabled' | translate}}</mat-option>
+                        </mat-select>
+                        <div *ngIf="settings.nodeRedEnabled !== originalNodeRedEnabled" class="node-red-info">
+                            {{ 'dlg.app-settings-node-red-info' | translate }}
+                        </div>
+                    </div>
                 </div>
             </mat-tab>
             <mat-tab label="{{'dlg.app-settings-smtp' | translate}}">

--- a/client/src/app/editor/app-settings/app-settings.component.ts
+++ b/client/src/app/editor/app-settings/app-settings.component.ts
@@ -41,6 +41,7 @@ export class AppSettingsComponent implements OnInit {
 	];
 
     settings = new AppSettings();
+    originalNodeRedEnabled = false;
     authentication = '';
     authenticationTooltip = '';
     smtpTesting = false;
@@ -91,6 +92,10 @@ export class AppSettingsComponent implements OnInit {
         if (!this.settings.logs) {
             this.settings.logs = new LogsSettings();
         }
+        if (Utils.isNullOrUndefined(this.settings.nodeRedEnabled)) {
+            this.settings.nodeRedEnabled = false;
+        }
+        this.originalNodeRedEnabled = this.settings.nodeRedEnabled;
     }
 
     onNoClick() {

--- a/client/src/app/editor/setup/setup.component.html
+++ b/client/src/app/editor/setup/setup.component.html
@@ -167,7 +167,7 @@
                 </button>
             </div>
             <div class="btn-card">
-                <button mat-button (click)="goTo('/flows')" class="card-btn" [disabled]="isToDisable('scripts') || (nodeRedExists$ | async) === false" >
+                <button mat-button (click)="goTo('/flows')" class="card-btn" [disabled]="isToDisable('node-red') || (nodeRedExists$ | async) === false" >
                     <div class="card-btn-content">
                         <mat-icon svgIcon="nodered-flows" style="width: 50px;"></mat-icon>
                         <span>{{'dlg.setup-node-red-flows' | translate}}</span>

--- a/client/src/app/editor/setup/setup.component.ts
+++ b/client/src/app/editor/setup/setup.component.ts
@@ -130,6 +130,8 @@ export class SetupComponent {
     isToDisable(section: string) {
         if (clientOnlyToDisable.indexOf(section) !== -1) {
             return this.appService.isClientApp;
+        } else if (section === 'node-red') {
+            return !(this.appService.nodeRedEnabled() && !this.appService.isClientApp);
         }
         return false;
     }

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -186,6 +186,7 @@ function mergeUserSettings(settings) {
     runtime.settings.secureEnabled = settings.secureEnabled;
     runtime.settings.logFull = settings.logFull;
     runtime.settings.userRole = settings.userRole;
+    runtime.settings.nodeRedEnabled = settings.nodeRedEnabled;
     if (settings.secureEnabled) {
         runtime.settings.tokenExpiresIn = settings.tokenExpiresIn;
     }

--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -108,4 +108,6 @@ module.exports = {
     webcamSnapShotsRetain: 7,
 
     swaggerEnabled: false,
+
+    nodeRedEnabled: false,
 }


### PR DESCRIPTION
# 🔁 Feature: Optional Node-RED Integration via Settings Flag

This PR introduces a configurable mechanism to **enable or disable Node-RED integration** in FUXA using a dedicated settings flag, aligning its behavior with other optional backend features (e.g. Swagger).

---

## 🔧 What’s New

### **1. Node-RED Enable Flag (`nodeRedEnabled`)**
Node-RED is now conditionally enabled via `settings.js`.

- Disabled by default
- Enabled explicitly using `nodeRedEnabled`
- No automatic startup unless configured

Example:
```js
{
  nodeRedEnabled: true
}