### PR TITLE
External SVG Widgets Storage (Community Repository)

### DIFF
--- a/client/src/app/resources/kiosk-widgets/kiosk-widgets.service.ts
+++ b/client/src/app/resources/kiosk-widgets/kiosk-widgets.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { forkJoin, map, Observable, of, switchMap } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { WidgetsResource } from '../../_models/resources';
+import { WidgetsResource, WidgetsResourceType } from '../../_models/resources';
 import { MyFileService, TransferResult } from '../../_services/my-file.service';
 
 @Injectable({
@@ -9,9 +9,12 @@ import { MyFileService, TransferResult } from '../../_services/my-file.service';
 })
 export class KioskWidgetsService {
 
-    endPointWidgetResources = 'https://frangoteam.org/api/list-widgets.php';
+    repoOwner = 'frangoteam';
+    repoName = 'FUXA-SVG-Widgets';
+    repoBranch = 'main';
+    githubApiBaseUrl = `https://api.github.com/repos/${this.repoOwner}/${this.repoName}/contents`;
     resourceWidgets$: Observable<WidgetsResource[]>;
-    widgetAssetBaseUrl = 'https://frangoteam.org/widgets/';
+    widgetAssetBaseUrl = `https://raw.githubusercontent.com/${this.repoOwner}/${this.repoName}/${this.repoBranch}/`;
 
     constructor(
         private http: HttpClient,
@@ -21,14 +24,11 @@ export class KioskWidgetsService {
     }
 
     getWidgetsResource(): Observable<WidgetsResource[]> {
-        const headers = new HttpHeaders({ 'Skip-Auth': 'true' });
-        return this.http.get<WidgetsResource[]>(this.endPointWidgetResources, { headers: headers });
+        return this.getWidgetsFromRepo('', true);
     }
 
     getWidgetsGroupContent(path: string): Observable<WidgetsResource[]> {
-        const headers = new HttpHeaders({ 'Skip-Auth': 'true' });
-        return this.http.get<WidgetsResource[]>(
-            `${this.endPointWidgetResources}?path=${encodeURIComponent(path)}`, { headers });
+        return this.getWidgetsFilesRecursive(path);
     }
 
     uploadWidgetFromUrl(fullUrl: string, filePath: string, filename?: string): Observable<TransferResult> {
@@ -52,5 +52,40 @@ export class KioskWidgetsService {
                 })
                 .catch(err => observer.error(err));
         });
+    }
+
+    private getWidgetsFromRepo(path: string, onlyDirs = false): Observable<WidgetsResource[]> {
+        const headers = new HttpHeaders({
+            'Skip-Auth': 'true',
+            'Accept': 'application/vnd.github+json'
+        });
+        const safePath = path
+            ? path.split('/').map(segment => encodeURIComponent(segment)).join('/')
+            : '';
+        const url = safePath ? `${this.githubApiBaseUrl}/${safePath}` : this.githubApiBaseUrl;
+        return this.http.get<any[]>(url, { headers }).pipe(
+            map(items => (items || [])
+                .filter(item => !onlyDirs || item.type === 'dir')
+                .map(item => ({
+                    name: item.name,
+                    type: item.type === 'dir' ? WidgetsResourceType.dir : WidgetsResourceType.file,
+                    path: item.path
+                } as WidgetsResource)))
+        );
+    }
+
+    private getWidgetsFilesRecursive(path: string): Observable<WidgetsResource[]> {
+        return this.getWidgetsFromRepo(path).pipe(
+            switchMap(items => {
+                const files = items.filter(item => item.type === WidgetsResourceType.file);
+                const dirs = items.filter(item => item.type === WidgetsResourceType.dir);
+                if (dirs.length === 0) {
+                    return of(files);
+                }
+                return forkJoin(dirs.map(dir => this.getWidgetsFilesRecursive(dir.path))).pipe(
+                    map(children => files.concat(...children))
+                );
+            })
+        );
     }
 }

--- a/server/api/resources/index.js
+++ b/server/api/resources/index.js
@@ -270,10 +270,13 @@ module.exports = {
                         var group = { name: resourcesDirs[i], items: [] };
                         var dirPath = path.resolve(runtime.settings.widgetsFileDir, resourcesDirs[i]);
                         var wwwSubDir = path.join('_widgets', resourcesDirs[i]);
-                        var files = getFiles(dirPath, ['.svg']);
+                        var files = getFilesRecursive(dirPath, ['.svg']);
                         for (var x = 0; x < files.length; x++) {
                             var filename = files[x];
-                            group.items.push({ path: path.join(wwwSubDir, files[x]).split(path.sep).join(path.posix.sep), name: filename });
+                            group.items.push({
+                                path: path.join(wwwSubDir, files[x]).split(path.sep).join(path.posix.sep),
+                                name: filename
+                            });
                         }
                         result.groups.push(group);
                     }
@@ -353,4 +356,18 @@ function getFiles(pathDir, extensions) {
     const filesInDIrectory = fs.readdirSync(pathDir)
         .filter((item) => extensions.indexOf(path.extname(item).toLowerCase()) !== -1);
     return filesInDIrectory;
+}
+
+function getFilesRecursive(pathDir, extensions, baseDir = pathDir) {
+    const entries = fs.readdirSync(pathDir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const entryPath = path.join(pathDir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...getFilesRecursive(entryPath, extensions, baseDir));
+        } else if (extensions.indexOf(path.extname(entry.name).toLowerCase()) !== -1) {
+            files.push(path.relative(baseDir, entryPath));
+        }
+    }
+    return files;
 }


### PR DESCRIPTION
# 🧩 Feature: External SVG Widgets Storage (Community Repository)

This PR moves the **SVG widgets source/storage** out of the main FUXA repository into a **dedicated public repository**, making it easier for the community to contribute and extend the widget library.

**New widgets repository:**  
https://github.com/frangoteam/FUXA-SVG-Widgets

---

## 🔧 What’s Changed

### 1) Widgets Storage Relocation
- The source of downloadable SVG widgets is no longer hosted by frangoteam.org
- Widgets are now fetched from a **dedicated external repository**
- The new repository acts as the single source of truth for widget assets

---

### 2) Community Contribution Enabled
By hosting widgets in a separate repository:
- Anyone can submit **PRs with new widgets**
- Widget improvements and fixes are decoupled from FUXA core releases
- The widget library can grow independently and faster

---

## ⚙️ Runtime Behavior

- FUXA continues to download and use widgets as before
- No change in widget usage or configuration inside the UI
- Only the **storage/source location** has changed
