### PR TITLE
feat(node-red): enhance tag handling with optional tagId for backward compatibility

### DIFF
--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-daq.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-daq.html
@@ -4,7 +4,8 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true},
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""},         // New: unique identifier (optional, for backward compatibility)
             from: {value:""},
             to: {value:""}
         },
@@ -12,17 +13,65 @@
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"get daq";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "get daq";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-tags-daq');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
 
             // Convert timestamp format for datetime-local inputs
@@ -64,10 +113,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-tags-daq" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-tags-daq" placeholder="Select Tag">
         <datalist id="fuxa-tags-daq"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
     <div class="form-row">
         <label for="node-input-from"><i class="fa fa-clock-o"></i> From (timestamp)</label>
         <input type="datetime-local" id="node-input-from" placeholder="From timestamp (optional)">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-daq.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-daq.js
@@ -6,7 +6,13 @@ module.exports = function(RED) {
 
         this.on('input', async function(msg) {
             try {
-                var tagId = fuxa.getTagId(config.tag, null);
+                // Prefer config.tagId, fallback to config.tag for backward compatibility
+                var tagId = config.tagId;
+                if (!tagId && config.tag) {
+                    // Backward compatibility: old nodes use tag.name, need to convert to tagId
+                    tagId = fuxa.getTagId(config.tag, null);
+                }
+                
                 if (tagId) {
                     var fromts = config.from || msg.from || Date.now() - 3600000; // default 1 hour ago
                     var tots = config.to || msg.to || Date.now();
@@ -14,7 +20,7 @@ module.exports = function(RED) {
                     msg.payload = data;
                     node.send(msg);
                 } else {
-                    node.error('Tag not found: ' + config.tag, msg);
+                    node.error('Tag not found: ' + (config.tag || config.tagId), msg);
                 }
             } catch (err) {
                 node.error(err, msg);

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-change.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-change.html
@@ -4,23 +4,72 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true}
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""}          // New: unique identifier (optional, for backward compatibility)
         },
         inputs:0,
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"get tag change";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "get tag change";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-change-tags');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
         }
     });
@@ -32,10 +81,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-change-tags" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-change-tags" placeholder="Select Tag">
         <datalist id="fuxa-change-tags"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
 </script>
 
 <script type="text/x-red" data-help-name="get-tag-change">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-change.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-change.js
@@ -7,26 +7,26 @@ module.exports = function(RED) {
         // Store previous values to detect actual changes
         var previousValues = {};
 
+        // Prefer config.tagId, fallback to config.tag for backward compatibility
+        var configuredTagId = config.tagId;
+        if (!configuredTagId && config.tag) {
+            // Backward compatibility: old nodes use tag.name, need to convert to tagId
+            configuredTagId = fuxa.getTagId(config.tag, null);
+        }
+
         // Initialize previous value for the configured tag
-        if (config.tag) {
-            var tagId = fuxa.getTagId(config.tag, null);
-            if (tagId) {
-                // Initialize previous value
-                var initialValue = fuxa.getTag(tagId);
-                if (initialValue !== undefined) {
-                    previousValues[tagId] = initialValue;
-                }
+        if (configuredTagId) {
+            var initialValue = fuxa.getTag(configuredTagId);
+            if (initialValue !== undefined) {
+                previousValues[configuredTagId] = initialValue;
             }
         }
 
-                        // Event listener for device value changes (raw events from devices)
+        // Event listener for device value changes (raw events from devices)
         var deviceEventListener = function(deviceEvent) {
             try {
                 // deviceEvent format: { id: deviceId, values: { tagId: tagObject, ... } }
                 if (deviceEvent && deviceEvent.values) {
-                    // Check if any of the changed values match our configured tag
-                    var configuredTagId = fuxa.getTagId(config.tag, null);
-                    
                     if (configuredTagId && deviceEvent.values[configuredTagId]) {
                         var tagData = deviceEvent.values[configuredTagId];
                         

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-daq-settings.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-daq-settings.html
@@ -4,23 +4,72 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true}
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""}          // New: unique identifier (optional, for backward compatibility)
         },
         inputs:1,
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"get tag daq settings";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "get tag daq settings";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-tags-daq-settings');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
         }
     });
@@ -32,10 +81,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-tags-daq-settings" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-tags-daq-settings" placeholder="Select Tag">
         <datalist id="fuxa-tags-daq-settings"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
 </script>
 
 <script type="text/x-red" data-help-name="get-tag-daq-settings">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-daq-settings.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag-daq-settings.js
@@ -6,18 +6,22 @@ module.exports = function(RED) {
 
         this.on('input', async function(msg) {
             try {
-                var tagName = config.tag || msg.tag;
-                if (tagName) {
-                    var tagId = fuxa.getTagId(tagName, null);
-                    if (tagId) {
-                        var settings = await fuxa.getTagDaqSettings(tagId);
-                        msg.payload = settings;
-                        node.send(msg);
-                    } else {
-                        node.error('Tag not found: ' + tagName, msg);
+                // Prefer config.tagId, fallback to config.tag or msg.tag for backward compatibility
+                var tagId = config.tagId;
+                if (!tagId) {
+                    var tagName = config.tag || msg.tag;
+                    if (tagName) {
+                        // Backward compatibility: old nodes use tag.name, need to convert to tagId
+                        tagId = fuxa.getTagId(tagName, null);
                     }
+                }
+                
+                if (tagId) {
+                    var settings = await fuxa.getTagDaqSettings(tagId);
+                    msg.payload = settings;
+                    node.send(msg);
                 } else {
-                    node.error('Tag name not specified', msg);
+                    node.error('Tag not found: ' + (config.tag || msg.tag || config.tagId), msg);
                 }
             } catch (err) {
                 node.error(err, msg);

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag.html
@@ -4,23 +4,72 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true}
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""}          // New: unique identifier (optional, for backward compatibility)
         },
         inputs:1,
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"get tag";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "get tag";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-tags');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
         }
     });
@@ -32,10 +81,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-tags" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-tags" placeholder="Select Tag">
         <datalist id="fuxa-tags"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
 </script>
 
 <script type="text/x-red" data-help-name="get-tag">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-get-tag.js
@@ -7,14 +7,20 @@ module.exports = function(RED) {
 
         this.on('input', function(msg) {
             try {
-                var tagId = fuxa.getTagId(config.tag, null);
+                // Prefer config.tagId, fallback to config.tag for backward compatibility
+                var tagId = config.tagId;
+                if (!tagId && config.tag) {
+                    // Backward compatibility: old nodes use tag.name, need to convert to tagId
+                    tagId = fuxa.getTagId(config.tag, null);
+                }
+                
                 if (tagId) {
                     var value = fuxa.getTag(tagId);
                     msg.payload = value;
                     msg.topic = config.tag;  // Set topic to tag name for join operations
                     node.send(msg);
                 } else {
-                    node.error('Tag not found: ' + config.tag, msg);
+                    node.error('Tag not found: ' + (config.tag || config.tagId), msg);
                 }
             } catch (err) {
                 node.error(err, msg);

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag-daq-settings.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag-daq-settings.html
@@ -4,7 +4,8 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true},
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""},         // New: unique identifier (optional, for backward compatibility)
             enabled: {value:true},
             interval: {value:1000},
             deadband: {value:0}
@@ -13,17 +14,65 @@
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"set tag daq settings";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "set tag daq settings";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-tags-set-daq-settings');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
         }
     });
@@ -35,10 +84,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-tags-set-daq-settings" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-tags-set-daq-settings" placeholder="Select Tag">
         <datalist id="fuxa-tags-set-daq-settings"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
     <div class="form-row">
         <label for="node-input-enabled">&nbsp;</label>
         <input type="checkbox" id="node-input-enabled" style="display:inline-block; width:15px; vertical-align:baseline;">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag-daq-settings.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag-daq-settings.js
@@ -6,29 +6,33 @@ module.exports = function(RED) {
 
         this.on('input', async function(msg) {
             try {
-                var tagName = config.tag || msg.tag;
-                if (tagName) {
-                    var tagId = fuxa.getTagId(tagName, null);
-                    if (tagId) {
-                        var settings = {
-                            enabled: config.enabled,
-                            interval: config.interval,
-                            deadband: config.deadband
-                        };
-
-                        // Override with message properties if provided
-                        if (msg.enabled !== undefined) settings.enabled = msg.enabled;
-                        if (msg.interval !== undefined) settings.interval = msg.interval;
-                        if (msg.deadband !== undefined) settings.deadband = msg.deadband;
-
-                        var result = await fuxa.setTagDaqSettings(tagId, settings);
-                        msg.payload = result;
-                        node.send(msg);
-                    } else {
-                        node.error('Tag not found: ' + tagName, msg);
+                // Prefer config.tagId, fallback to config.tag or msg.tag for backward compatibility
+                var tagId = config.tagId;
+                if (!tagId) {
+                    var tagName = config.tag || msg.tag;
+                    if (tagName) {
+                        // Backward compatibility: old nodes use tag.name, need to convert to tagId
+                        tagId = fuxa.getTagId(tagName, null);
                     }
+                }
+                
+                if (tagId) {
+                    var settings = {
+                        enabled: config.enabled,
+                        interval: config.interval,
+                        deadband: config.deadband
+                    };
+
+                    // Override with message properties if provided
+                    if (msg.enabled !== undefined) settings.enabled = msg.enabled;
+                    if (msg.interval !== undefined) settings.interval = msg.interval;
+                    if (msg.deadband !== undefined) settings.deadband = msg.deadband;
+
+                    var result = await fuxa.setTagDaqSettings(tagId, settings);
+                    msg.payload = result;
+                    node.send(msg);
                 } else {
-                    node.error('Tag name not specified', msg);
+                    node.error('Tag not found: ' + (config.tag || msg.tag || config.tagId), msg);
                 }
             } catch (err) {
                 node.error(err, msg);

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag.html
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag.html
@@ -4,23 +4,72 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            tag: {value:"", required:true}
+            tag: {value:""},           // Keep: tag name for display and backward compatibility
+            tagId: {value:""}          // New: unique identifier (optional, for backward compatibility)
         },
         inputs:1,
         outputs:1,
         icon: "white-globe.png",
         label: function() {
-            return this.name||this.tag||"set tag";
+            if (this.name) {
+                return this.name;
+            }
+            // Display tag name or tagId
+            return this.tag || this.tagId || "set tag";
         },
         oneditprepare: function() {
+            var node = this;
+            var tagMap = {}; // Use tag.id as key to avoid tag.name duplication issues
+            
             $.getJSON('/nodered/fuxa/devices', function(data) {
                 var datalist = $('#fuxa-tags-set');
                 datalist.empty();
+                
                 data.forEach(function(device) {
                     device.tags.forEach(function(tag) {
-                        datalist.append('<option value="' + tag.name + '">' + device.name + ' - ' + tag.name + '</option>');
+                        var fullName = device.name + ' - ' + tag.name;
+                        // datalist option value format: tag.name(tag.id)
+                        var optionValue = tag.name + '(' + tag.id + ')';
+                        datalist.append('<option value="' + optionValue + '">' + fullName + '</option>');
+                        tagMap[tag.id] = {
+                            name: tag.name,
+                            deviceName: device.name,
+                            fullName: fullName
+                        };
                     });
                 });
+                
+                // Listen for tagSelected input changes
+                $('#node-input-tagSelected').on('change', function() {
+                    var selectedValue = $(this).val();
+                    // Parse format: tag.name(tag.id)
+                    var match = selectedValue.match(/^(.+)\(([^)]+)\)$/);
+                    if (match) {
+                        var tagName = match[1];
+                        var tagId = match[2];
+                        
+                        // Set the actual stored fields
+                        $('#node-input-tag').val(tagName);
+                        $('#node-input-tagId').val(tagId);
+                    }
+                });
+                
+                // Initialize display (when editing existing node)
+                if (node.tagId && tagMap[node.tagId]) {
+                    // Has tagId, construct tagSelected value
+                    var tagName = node.tag || tagMap[node.tagId].name;
+                    $('#node-input-tagSelected').val(tagName + '(' + node.tagId + ')');
+                } else if (node.tag && !node.tagId) {
+                    // Old node: only has tag (tag.name), need to find corresponding tagId
+                    // Note: if there are duplicate names, only the first match will be found
+                    for (var tagId in tagMap) {
+                        if (tagMap[tagId].name === node.tag) {
+                            $('#node-input-tagSelected').val(node.tag + '(' + tagId + ')');
+                            $('#node-input-tagId').val(tagId);
+                            break;
+                        }
+                    }
+                }
             });
         }
     });
@@ -32,10 +81,12 @@
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
     <div class="form-row">
-        <label for="node-input-tag"><i class="fa fa-tag"></i> Tag</label>
-        <input type="text" id="node-input-tag" list="fuxa-tags-set" placeholder="Tag Name">
+        <label for="node-input-tagSelected"><i class="fa fa-tag"></i> Tag</label>
+        <input type="text" id="node-input-tagSelected" list="fuxa-tags-set" placeholder="Select Tag">
         <datalist id="fuxa-tags-set"></datalist>
     </div>
+    <input type="hidden" id="node-input-tag">
+    <input type="hidden" id="node-input-tagId">
 </script>
 
 <script type="text/x-red" data-help-name="set-tag">

--- a/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag.js
+++ b/server/integrations/node-red/node-red-contrib-fuxa/nodes/fuxa-set-tag.js
@@ -7,12 +7,18 @@ module.exports = function(RED) {
 
         this.on('input', async function(msg) {
             try {
-                var tagId = fuxa.getTagId(config.tag, null);
+                // Prefer config.tagId, fallback to config.tag for backward compatibility
+                var tagId = config.tagId;
+                if (!tagId && config.tag) {
+                    // Backward compatibility: old nodes use tag.name, need to convert to tagId
+                    tagId = fuxa.getTagId(config.tag, null);
+                }
+                
                 if (tagId) {
                     await fuxa.setTag(tagId, msg.payload);
                     node.send(msg);
                 } else {
-                    node.error('Tag not found: ' + config.tag, msg);
+                    node.error('Tag not found: ' + (config.tag || config.tagId), msg);
                 }
             } catch (err) {
                 node.error(err, msg);


### PR DESCRIPTION
sometimes, we have the same tag name and device name, but getTagId return first tag.

- Added a new optional field `tagId` to various nodes for unique identifier support.
- Updated UI elements to allow selection of tags in the format `tag.name(tag.id)`.
- Improved backward compatibility by allowing nodes to function with either `tag` or `tagId`.
- Adjusted error messages to reflect the new tag handling logic.