### PR TITLE
Morgan disable

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -39,8 +39,11 @@ function init(_server, _runtime) {
     return new Promise(function (resolve, reject) {
         if (runtime.settings.disableServer !== false) {
             apiApp = express();
-            apiApp.use(morgan(['combined', 'common', 'dev', 'short', 'tiny'].
-                includes(runtime.settings.logApiLevel) ? runtime.settings.logApiLevel : 'combined'));
+            
+			if (runtime.settings.logApiLevel !== 'none') {
+				apiApp.use(morgan(['combined', 'common', 'dev', 'short', 'tiny'].
+				includes(runtime.settings.logApiLevel) ? runtime.settings.logApiLevel : 'combined'));
+			}
 
             var maxApiRequestSize = runtime.settings.apiMaxLength || '100mb';
             apiApp.use(bodyParser.json({limit:maxApiRequestSize}));

--- a/server/main.js
+++ b/server/main.js
@@ -339,22 +339,24 @@ app.use('/_widgets', express.static(settings.widgetsFileDir));
 app.use('/snapshots', express.static(settings.webcamSnapShotsDir))
 
 var accessLogStream = fs.createWriteStream(settings.logDir + '/api.log', { flags: 'a' });
-app.use(morgan('combined', {
-    stream: accessLogStream,
-    skip: function (req, res) { return res.statusCode < 400 }
-}));
-
-app.use(morgan('dev', {
-    skip: function (req, res) {
-        return res.statusCode < 400
-    }, stream: process.stderr
-}));
-
-app.use(morgan('dev', {
-    skip: function (req, res) {
-        return res.statusCode >= 400
-    }, stream: process.stdout
-}));
+if (runtime.settings.logApiLevel !== 'none') {
+	app.use(morgan('combined', {
+		stream: accessLogStream,
+		skip: function (req, res) { return res.statusCode < 400 }
+	}));
+	
+	app.use(morgan('dev', {
+		skip: function (req, res) {
+			return res.statusCode < 400
+		}, stream: process.stderr
+	}));
+	
+	app.use(morgan('dev', {
+		skip: function (req, res) {
+			return res.statusCode >= 400
+		}, stream: process.stdout
+	}));
+}
 
 function mountSwaggerIfEnabled() {
     const swaggerEnabled = settings.swagger || settings.swaggerEnabled;

--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -24,6 +24,7 @@ module.exports = {
     // - 'common': Less detailed than 'combined', omitting the referrer and user-agent.
     // - 'short': Shorter format that includes the remote address and request details.
     // - 'tiny': Minimalist format, showing just the method, URL, status, response length, and response time.
+	// - 'none': Completely disables HTTP request logging to clean the console for custom debugging scripts and reduce I/O overhead.
     //
     // Default Value:
     // - 'combined': By default, logApiLevel is set to 'combined', providing detailed logs suitable for thorough tracking and analysis.


### PR DESCRIPTION
Added option to completely disable HTTP request logging to clean the console for custom debugging scripts and to reduce I/O overhead.