### PR TITLE
Node-RED Auth Bypass + Unsafe Modules Hardening

### DIFF
--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -111,4 +111,8 @@ module.exports = {
     swaggerEnabled: false,
 
     nodeRedEnabled: false,
+
+    // Node-RED: allow unsafe stdlib modules in functionGlobalContext
+    // WARNING: Enabling this exposes modules like child_process/net to flows.
+    nodeRedUnsafeModules: false,
 }


### PR DESCRIPTION
# Security Fix: Node-RED Auth Bypass + Unsafe Modules Hardening

## Summary
This PR fixes an unauthenticated RCE path in the Node-RED integration by:
- Removing unauthenticated/Referer-based access to Node-RED admin and flows APIs.
- Enforcing authentication (JWT or API key) when `secureEnabled=true`.
- Making dangerous Node.js modules (`child_process`, `net`) opt-in.
- Preserving the embedded Node-RED editor by moving JWT from query → HttpOnly cookie.

## Key Changes
### 1) Authentication enforcement for Node-RED
- Requests to `/nodered/*` (admin/editor/flows) now require a valid JWT or API key.
- Public dashboard UI and `socket.io` remain accessible.

### 2) JWT handling for embedded editor
- The iframe URL includes `?token=...` only for same-origin.
- Backend stores the token in an HttpOnly cookie (`nodered_auth`) and redirects to a clean URL.

### 3) Unsafe modules are opt-in
- `child_process` and `net` are removed from `functionGlobalContext` by default.
- They can be re-enabled only with `nodeRedUnsafeModules: true`.

## Files Changed
- `server/integrations/node-red/index.js`
- `server/settings.default.js`
- `client/src/app/integrations/node-red/node-red-flows/node-red-flows.component.ts`

## Configuration
### Default (safe)
```json
{
  "secureEnabled": true,
  "nodeRedUnsafeModules": false
}
```

### Opt-in unsafe modules
```json
{
  "nodeRedUnsafeModules": true
}
```

### External Access (API Key)
When secureEnabled=true, external systems can call Node‑RED HTTP endpoints using:
```
x-api-key: <api-key>
```

API keys are managed in FUXA under **Editor → Setup → API Keys**.

## Compatibility / Behavior
- If `secureEnabled=false`, Node‑RED behaves as before (open access).
- The Node‑RED editor in `/flows` continues to work with auth enabled.
- Existing flows that rely on `child_process`/`net` must set `nodeRedUnsafeModules=true`.
