### PR TITLE
Block guest access to scheduler mutations

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -39,7 +39,7 @@ function init(_server, _runtime) {
     return new Promise(function (resolve, reject) {
         if (runtime.settings.disableServer !== false) {
             apiApp = express();
-            
+
 			if (runtime.settings.logApiLevel !== 'none') {
 				apiApp.use(morgan(['combined', 'common', 'dev', 'short', 'tiny'].
 				includes(runtime.settings.logApiLevel) ? runtime.settings.logApiLevel : 'combined'));
@@ -171,11 +171,11 @@ function init(_server, _runtime) {
              * GET Heartbeat to check token
              */
             apiApp.post('/api/heartbeat', authMiddleware, function (req, res) {
+
                 if (!runtime.settings.secureEnabled) {
-                    res.end();
-                } else if (res.statusCode === 403) {
-                    runtime.logger.error("api post heartbeat: Tocken Expired");
+                    return res.end();
                 }
+
                 if (req.body.params) {
 
                     if (!req.isAuthenticated) {
@@ -199,6 +199,7 @@ function init(_server, _runtime) {
                         token: authJwt.getGuestToken()
                     });
                 }
+
                 return res.end();
             });
 

--- a/server/api/jwt-helper.js
+++ b/server/api/jwt-helper.js
@@ -132,6 +132,16 @@ function getGuestToken() {
     return token;
 }
 
+function isGuestUser(userId, userGroups) {
+    if (userId === 'guest') {
+        return true;
+    }
+    if (Array.isArray(userGroups) && userGroups.includes('guest')) {
+        return true;
+    }
+    return false;
+}
+
 function haveAdminPermission(permission) {
     if (permission === null || permission === undefined) {
         return false;
@@ -156,5 +166,6 @@ module.exports = {
     get secretCode() { return secretCode },
     get tokenExpiresIn() { return tokenExpiresIn },
     haveAdminPermission: haveAdminPermission,
-    adminGroups: adminGroups
+    adminGroups: adminGroups,
+    isGuestUser: isGuestUser
 };

--- a/server/api/scheduler/index.js
+++ b/server/api/scheduler/index.js
@@ -51,6 +51,16 @@ module.exports = {
 
         // POST scheduler data
         schedulerApp.post("/api/scheduler", secureFnc, function(req, res) {
+            if (res.statusCode === 403) {
+                runtime.logger.error("api post scheduler: Tocken Expired");
+                return;
+            }
+            const isGuest = authJwt.isGuestUser(req.userId, req.userGroups);
+            if (runtime.settings?.secureEnabled && isGuest) {
+                res.status(401).json({error:"unauthorized_error", message: "Unauthorized!"});
+                runtime.logger.error("api post scheduler: Unauthorized guest");
+                return;
+            }
             try {
                 if (req.body && req.body.id && req.body.data !== undefined) {
                     var schedulerId = req.body.id;
@@ -90,6 +100,16 @@ module.exports = {
 
         // DELETE scheduler data
         schedulerApp.delete("/api/scheduler", secureFnc, function(req, res) {
+            if (res.statusCode === 403) {
+                runtime.logger.error("api delete scheduler: Tocken Expired");
+                return;
+            }
+            const isGuest = authJwt.isGuestUser(req.userId, req.userGroups);
+            if (runtime.settings?.secureEnabled && isGuest) {
+                res.status(401).json({error:"unauthorized_error", message: "Unauthorized!"});
+                runtime.logger.error("api delete scheduler: Unauthorized guest");
+                return;
+            }
             try {
                 if (req.query && req.query.id) {
                     var schedulerId = req.query.id;


### PR DESCRIPTION
## Block guest access to scheduler mutations

## Summary
- Add a centralized `isGuestUser` helper in `jwt-helper` to detect guest sessions
- Deny guest `POST` / `DELETE` requests to `/api/scheduler` when security is enabled
- Keep authenticated non-admin users allowed (only guest users are blocked)

## Motivation
The scheduler endpoint allowed guest users to create, modify, and delete schedules.  
This change prevents guest access while preserving existing behavior for authenticated users, aligning the scheduler authorization with the intended security model.