### PR TITLE
Improve BACnet robustness and InfluxDB DAQ handling

### DIFF
--- a/server/runtime/storage/influxdb/index.js
+++ b/server/runtime/storage/influxdb/index.js
@@ -123,7 +123,7 @@ function Influx(_settings, _log, _currentStorate) {
             } else {
                 const point = new Point(tag.id)
                     .tag('id', tag.id)
-                    .tag('name', tag.name || tag.tagref.name)
+                    .tag('name', tag.name || tag.tagref?.name)
                     .tag('type', tag.type)
                     .timestamp(new Date(tag.timestamp || new Date().getTime()));
                 if (deviceName) {


### PR DESCRIPTION
# Improve BACnet robustness and InfluxDB DAQ handling

## Summary
- Reduce BACnet readPropertyMultiple log noise by logging only on state changes.
- Keep browsing resilient by returning partial results and warning when incomplete.
- Add BACnet safeguards/logging for readProperty errors and missing device addresses.
- Improve InfluxDB DAQ writes for tags without a name.

## Changes
- BACnet: state-change RPM error logging, partial browse warnings, safer device address handling, explicit readProperty error logging.
- InfluxDB: allow DAQ for tags with missing `name` (use fallback).