### PR TITLE
feat(daq): add QuestDB storage backend (ILP ingest + PGWire query).

### DIFF
--- a/client/src/app/_models/settings.ts
+++ b/client/src/app/_models/settings.ts
@@ -64,6 +64,9 @@ export class DaqStore {
     type = DaqStoreType.SQlite;
     varsion?: string;
     url?: string;
+    host = '127.0.0.1';
+    tableName = 'meters';
+    configurationString = 'http::addr=localhost:9000;';
     organization?: string;
     credentials?: StoreCredentials;
     bucket?: string;
@@ -74,6 +77,9 @@ export class DaqStore {
         if (daqstore) {
             this.type = daqstore.type;
             this.url = daqstore.url;
+            this.host = daqstore.host;
+            this.tableName = daqstore.tableName || 'meters';
+            this.configurationString = daqstore.configurationString;
             this.organization = daqstore.organization;
             this.credentials = daqstore.credentials;
             this.bucket = daqstore.bucket;
@@ -84,6 +90,7 @@ export class DaqStore {
 
     isEquals(store: DaqStore) {
         if (this.type === store.type && this.bucket === store.bucket && this.url === store.url &&
+            this.host === store.host && this.tableName === store.tableName && this.configurationString === store.configurationString &&
             this.organization === store.organization && this.database === store.database &&
             (this.credentials && StoreCredentials.isEquals(this.credentials, store.credentials)) && this.retention === store.retention) {
             return true;
@@ -115,6 +122,7 @@ export enum DaqStoreType {
     influxDB = 'influxDB',
     influxDB18 = 'influxDB 1.8',
     TDengine = 'TDengine' ,
+    questDB = 'questDB',
 }
 
 export enum influxDBVersionType {

--- a/client/src/app/editor/app-settings/app-settings.component.html
+++ b/client/src/app/editor/app-settings/app-settings.component.html
@@ -203,6 +203,34 @@
                                     <input [(ngModel)]="settings.daqstore.credentials.password" placeholder="taosdata" class="input-row" type="text">
                                 </div>
                             </div>
+                            <div *ngSwitchCase="daqstoreType.questDB">
+                                <div class="block mt20 w100">
+                                    <span>{{'dlg.app-settings-daqstore-queryconn' | translate}}</span>
+                                </div>
+                                <div class="my-form-field block mt15 w100">
+                                    <span>{{'dlg.app-settings-smtp-host' | translate}}</span>
+                                    <input [(ngModel)]="settings.daqstore.host" placeholder="127.0.0.1" class="input-row" type="text">
+                                </div>
+                                <div class="my-form-field block mt15 w100">
+                                    <span>{{'dlg.app-settings-daqstore-database' | translate}}</span>
+                                    <input [(ngModel)]="settings.daqstore.tableName" placeholder="meters" class="input-row" type="text">
+                                </div>
+                                <div class="my-form-field block mt15 w100">
+                                    <span>{{'dlg.app-settings-daqstore-username' | translate}}</span>
+                                    <input [(ngModel)]="settings.daqstore.credentials.username" placeholder="admin" class="input-row" type="text">
+                                </div>
+                                <div class="my-form-field block mt15 w100">
+                                    <span>{{'dlg.app-settings-daqstore-password' | translate}}</span>
+                                    <input [(ngModel)]="settings.daqstore.credentials.password" placeholder="quest" class="input-row" type="text">
+                                </div>
+                                <div class="block mt20 w100">
+                                    <span>{{'dlg.app-settings-daqstore-ingestconn' | translate}}</span>
+                                </div>
+                                <div class="my-form-field block mt15 w100">
+                                    <span>{{'dlg.app-settings-daqstore-configurl' | translate}}</span>
+                                    <input [(ngModel)]="settings.daqstore.configurationString" placeholder="http::addr=localhost:9000;" class="input-row" type="text">
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/client/src/assets/i18n/de.json
+++ b/client/src/assets/i18n/de.json
@@ -1240,6 +1240,9 @@
     "dlg.app-settings-daqstore": "DAQ-Speicher",
     "dlg.app-settings-daqstore-type": "Datenbanktyp",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token": "Token",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "Organisation",
@@ -1306,3 +1309,6 @@
     "msg.report-build-error": "Senden zum Erstellen des Berichts fehlgeschlagen!",
     "msg.device-tags-request-result": "Lade {{value}} von {{current}}"
 }
+
+
+

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1812,6 +1812,9 @@
     "dlg.app-settings-daqstore": "DAQ storage",
     "dlg.app-settings-daqstore-type": "Database type",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token": "Token",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "Organization",
@@ -1931,3 +1934,6 @@
     "msg.operation-unauthorized": "Operation Unauthorized!",
     "msg.secret-code-required": "Secret code required to sign authentication tokens"
 }
+
+
+

--- a/client/src/assets/i18n/es.json
+++ b/client/src/assets/i18n/es.json
@@ -736,6 +736,10 @@
     "dlg.app-settings-server-port": "Servidor esta escuchando el puerto",
     "dlg.app-settings-alarms-clear": "Borrar todas las alarmas y el historias",
     "dlg.app-settings-auth-token": "Autenticación con token",
+    "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-auth-disabled": "Deshabilitado",
     "dlg.app-auth-expiration-15m": "Habilitado con token expira en 15 min.",
     "dlg.app-auth-expiration-1h": "Habilitado con token expira en 1 hora.",
@@ -774,3 +778,6 @@
     "msg.editor-mode-locked": "El editor ya esta abierto!",
     "msg.alarms-clear-success": "Todas las alarmas han sido canceladas!"
   }
+
+
+

--- a/client/src/assets/i18n/fr.json
+++ b/client/src/assets/i18n/fr.json
@@ -1618,6 +1618,9 @@
   "dlg.app-settings-daqstore": "Stockage DAQ",
   "dlg.app-settings-daqstore-type": "Type de base de données",
   "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
   "dlg.app-settings-daqstore-token": "Jeton",
   "dlg.app-settings-daqstore-bucket": "Seau",
   "dlg.app-settings-daqstore-organization": "Organisation",
@@ -1715,3 +1718,6 @@
   "msg.texts-text-remove": "Souhaitez-vous supprimer le texte '{{value}}' ?",
   "msg.operation-unauthorized": "Opération non autorisée !"
 }
+
+
+

--- a/client/src/assets/i18n/ja.json
+++ b/client/src/assets/i18n/ja.json
@@ -1652,6 +1652,9 @@
     "dlg.app-settings-daqstore": "DAQストレージ",
     "dlg.app-settings-daqstore-type": "データベースタイプ",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token": "トークン",
     "dlg.app-settings-daqstore-bucket": "バケット",
     "dlg.app-settings-daqstore-organization": "組織",
@@ -1749,3 +1752,5 @@
     "msg.texts-text-remove": "テキスト '{{value}}' を削除しますか？",
     "msg.operation-unauthorized": "操作が許可されていません！"
 }
+
+

--- a/client/src/assets/i18n/ko.json
+++ b/client/src/assets/i18n/ko.json
@@ -734,6 +734,10 @@
     "dlg.app-settings-server-port": "서버가 포팅 수신 대기중",
     "dlg.app-settings-alarms-clear": "모든 알림과 기록 삭제",
     "dlg.app-settings-auth-token": "토큰 권한",
+    "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-auth-disabled": "비활성화",
     "dlg.app-auth-expiration-15m": "15분 후 토큰 만료로 활성화.",
     "dlg.app-auth-expiration-1h": "1시간 후 토큰 만료로 활성화.",
@@ -772,3 +776,6 @@
     "msg.editor-mode-locked": "편집자가 이미 열려있습니다!",
     "msg.alarms-clear-success": "모든 알림이 취소되었습니다!"
 }
+
+
+

--- a/client/src/assets/i18n/pt.json
+++ b/client/src/assets/i18n/pt.json
@@ -625,6 +625,10 @@
     "dlg.app-language-zh-cn": "Chinês",
     "dlg.app-settings-server-port": "Servidor está à escuta no porto",
     "dlg.app-settings-auth-token": "Autentificar com Token",
+    "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-auth-disabled": "Desativado",
     "dlg.app-auth-expiration-15m": "Ativar token com expiração em 15 minutos.",
     "dlg.app-auth-expiration-1h": "Ativar token com expiração em 1 horas.",
@@ -658,3 +662,6 @@
     "msg.login-password-required": "Entra uma palavra-passe",
     "msg.signin-failed": "Não autorizado"
 }
+
+
+

--- a/client/src/assets/i18n/ru.json
+++ b/client/src/assets/i18n/ru.json
@@ -1170,6 +1170,9 @@
     "dlg.app-settings-daqstore": "Хранилище данных",
     "dlg.app-settings-daqstore-type": "СУБД",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token": "Token",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "Организация",
@@ -1226,3 +1229,6 @@
     "msg.report-build-error": "Send to build Report failed!",
     "msg.device-tags-request-result": "Загружено {{value}} из {{current}}"
 }
+
+
+

--- a/client/src/assets/i18n/sv.json
+++ b/client/src/assets/i18n/sv.json
@@ -1599,6 +1599,9 @@
     "dlg.app-settings-daqstore": "DAQ-lagring",
     "dlg.app-settings-daqstore-type": "Databastyp",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token": "Token",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "Organisation",
@@ -1694,3 +1697,5 @@
     "msg.texts-text-remove": "Vill du ta bort texten '{{value}}'?",
     "msg.operation-unauthorized": "Operation obehörig!"
 }
+
+

--- a/client/src/assets/i18n/tr.json
+++ b/client/src/assets/i18n/tr.json
@@ -638,6 +638,10 @@
 	"dlg.app-language-tr": "Turkish",
 	"dlg.app-settings-server-port": "Sunucuya erişmek için port",
 	"dlg.app-settings-auth-token": "Anahtar şifre işe yetkilendir",
+	"dlg.app-settings-daqstore-url": "URL",
+	"dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
 
 	"dlg.app-auth-disabled": "Etkisiz",
 	"dlg.app-auth-expiration-15m": "Anahtar şifre 15dk içinde geçerliliğini yitirecek.",
@@ -671,3 +675,5 @@
 	"msg.login-password-required": "Şifre girin",
 	"msg.signin-failed": "Yetkisiz giriş."
 }
+
+

--- a/client/src/assets/i18n/ua.json
+++ b/client/src/assets/i18n/ua.json
@@ -578,6 +578,10 @@
     "dlg.app-language-ua": "Ukrainian",
     "dlg.app-settings-server-port": "Порт сервера",
     "dlg.app-settings-auth-token": "Авторизація з токеном",
+    "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-auth-disabled": "Вимкнено",
     "dlg.app-auth-expiration-15m": "Увімкнено. Автоматичний вихід через 15хв.",
     "dlg.app-auth-expiration-1h": "Увімкнено. Автоматичний вихід через 1год.",
@@ -612,3 +616,6 @@
     "msg.login-password-required": "Пароль",
     "msg.signin-failed": "Не авторизований"
 }
+
+
+

--- a/client/src/assets/i18n/zh-cn.json
+++ b/client/src/assets/i18n/zh-cn.json
@@ -1621,6 +1621,9 @@
     "dlg.app-settings-daqstore": "DAQ存储",
     "dlg.app-settings-daqstore-type": "数据库类型",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token":"令牌",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "组织",
@@ -1718,3 +1721,6 @@
     "msg.texts-text-remove": "您是否想删除文本'{{value}}'?",
     "msg.operation-unauthorized": "操作未经授权！"
 }
+
+
+

--- a/client/src/assets/i18n/zh-tw.json
+++ b/client/src/assets/i18n/zh-tw.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "with param": "示例 {{value}}",
 
     "app.home": "首頁",
@@ -1619,6 +1619,9 @@
     "dlg.app-settings-daqstore": "DAQ 儲存",
     "dlg.app-settings-daqstore-type": "資料庫類型",
     "dlg.app-settings-daqstore-url": "URL",
+    "dlg.app-settings-daqstore-configurl": "Config URL",
+    "dlg.app-settings-daqstore-queryconn": "Query connection (PGWire)",
+    "dlg.app-settings-daqstore-ingestconn": "Ingestion connection (ILP)",
     "dlg.app-settings-daqstore-token":"權杖",
     "dlg.app-settings-daqstore-bucket": "Bucket",
     "dlg.app-settings-daqstore-organization": "組織",
@@ -1716,3 +1719,6 @@
     "msg.texts-text-remove": "您是否要刪除文字 '{{value}}'？",
     "msg.operation-unauthorized": "操作未授權！"
 }
+
+
+

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "fuxa-server",
-  "version": "1.3.0-2700",
+  "version": "1.3.0-2727",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fuxa-server",
-      "version": "1.3.0-2700",
+      "version": "1.3.0-2727",
       "license": "MIT",
       "dependencies": {
         "@influxdata/influxdb-client": "1.25.0",
+        "@questdb/nodejs-client": "^3.0.0",
         "@tdengine/rest": "3.0.2",
         "ads-client": "2.1.0",
         "app-root-path": "2.2.1",
@@ -40,6 +41,7 @@
         "nopt": "5.0.0",
         "odbc": "2.4.9",
         "pdfmake": "0.2.5",
+        "pg": "^8.18.0",
         "socket.io": "4.8.1",
         "sqlite3": "5.1.5",
         "swagger-ui-express": "^5.0.1",
@@ -1196,6 +1198,12 @@
         "tslib": "^2.7.0",
         "tsyringe": "^4.8.0"
       }
+    },
+    "node_modules/@questdb/nodejs-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@questdb/nodejs-client/-/nodejs-client-3.0.0.tgz",
+      "integrity": "sha512-lBKd732rRpS/pqyWgCJFVXi9N1YoWDAUZzp6BngBVxH92As/NDXigZmCYKQVKpAEGYx14606CH5AoJ23qf3oqA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@scarf/scarf": {
       "version": "1.4.0",
@@ -3531,6 +3539,7 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7541,6 +7550,105 @@
       "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
+    "node_modules/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.11.0",
+        "pg-pool": "^3.11.0",
+        "pg-protocol": "^1.11.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
+      "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+      "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+      "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgpass/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://mirrors.cloud.tencent.com/npm/picomatch/-/picomatch-2.3.1.tgz",
@@ -7564,6 +7672,45 @@
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/precond": {
@@ -8839,6 +8986,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@influxdata/influxdb-client": "1.25.0",
+    "@questdb/nodejs-client": "^3.0.0",
     "@tdengine/rest": "3.0.2",
     "ads-client": "2.1.0",
     "app-root-path": "2.2.1",
@@ -46,6 +47,7 @@
     "nopt": "5.0.0",
     "odbc": "2.4.9",
     "pdfmake": "0.2.5",
+    "pg": "^8.18.0",
     "socket.io": "4.8.1",
     "sqlite3": "5.1.5",
     "swagger-ui-express": "^5.0.1",

--- a/server/runtime/storage/daqstorage.js
+++ b/server/runtime/storage/daqstorage.js
@@ -9,6 +9,7 @@ const path = require('path');
 const SqliteDB = require("./sqlite");
 const InfluxDB = require("./influxdb");
 const TDengine  =require("./tdengine");
+const QuestDB = require("./questdb");
 const CurrentStorage = require("./sqlite/currentstorage");
 // var DaqNode = require('./daqnode');
 var calculator = require('./calculator');
@@ -42,7 +43,7 @@ function reset() {
 function addDaqNode(_id, fncgetprop) {
     var id = _id;
     const dbType = _getDbType();
-    if (dbType === DaqStoreTypeEnum.influxDB || dbType === DaqStoreTypeEnum.influxDB18 || dbType === DaqStoreTypeEnum.TDengine) {
+    if (dbType === DaqStoreTypeEnum.influxDB || dbType === DaqStoreTypeEnum.influxDB18 || dbType === DaqStoreTypeEnum.TDengine || dbType === DaqStoreTypeEnum.questDB) {
         id = dbType;
     }
     if (!daqDB[id]) {
@@ -50,6 +51,8 @@ function addDaqNode(_id, fncgetprop) {
             daqDB[id] = InfluxDB.create(settings, logger, currentStorateDB);
         } else if(id === DaqStoreTypeEnum.TDengine){
             daqDB[id] = TDengine.create(settings, logger, currentStorateDB);
+        } else if(id === DaqStoreTypeEnum.questDB){
+            daqDB[id] = QuestDB.create(settings, logger, currentStorateDB);
         } else {
             daqDB[id] = SqliteDB.create(settings, logger, id, currentStorateDB);
         }
@@ -160,6 +163,9 @@ function _getDaqNode(tagid) {
 
 function _getDbType() {
     if (settings.daqstore && settings.daqstore.type) {
+        if (settings.daqstore.type === 'QuestDB') {
+            return DaqStoreTypeEnum.questDB;
+        }
         return settings.daqstore.type;
     }
     return DaqStoreTypeEnum.SQlite;
@@ -170,6 +176,7 @@ var DaqStoreTypeEnum = {
     influxDB: 'influxDB',
     influxDB18: 'influxDB18',
     TDengine: 'TDengine',
+    questDB: 'questDB',
 }
 
 function _getValue(value) {

--- a/server/runtime/storage/questdb/index.js
+++ b/server/runtime/storage/questdb/index.js
@@ -1,0 +1,211 @@
+'use strict'
+
+const { Pool } = require('pg');
+const { Sender } = require('@questdb/nodejs-client');
+let utils = require('../../utils');
+
+function QuestDB(_settings, _log, _currentStorage) {
+    let settings = _settings;               // Application settings
+    const logger = _log;                    // Application logger
+    const currentStorage = _currentStorage; // Database to set the last value (current)
+    let pool = null;
+    let sender = null;
+    const tableName = getTableName();
+    let writeQueue = Promise.resolve();
+    let initPromise = Promise.resolve();
+
+    this.setCall = function (_fncGetProp) {
+        fncGetTagProp = _fncGetProp;
+        return this.addDaqValues;
+    }
+    var fncGetTagProp = null;
+
+    this.init = async function () {
+        try {
+            pool = new Pool(getQueryClientConfig());
+            sender = await Sender.fromConfig(getIngestConfigString());
+            await ensureSchema();
+            logger.info('QuestDB connected');
+        } catch (error) {
+            logger.error(`questdb-init failed! ${error}`);
+        }
+    }
+
+    this.addDaqValues = function (tagsValues, deviceName, deviceId) {
+        var dataToRestore = [];
+        var rowsToWrite = [];
+
+        for (const tagid in tagsValues) {
+            let tag = tagsValues[tagid];
+            if (!tag.daq || utils.isNullOrUndefined(tag.value) || Number.isNaN(tag.value)) {
+                if (tag.daq && tag.daq.restored) {
+                    dataToRestore.push({ id: tag.id, deviceId: deviceId, value: tag.value });
+                }
+                if (tag.daq && !tag.daq.enabled) {
+                    continue;
+                }
+            }
+
+            rowsToWrite.push({
+                tagid,
+                deviceId,
+                deviceName: deviceName || '',
+                value: tag.value,
+                timestamp: tag.timestamp || Date.now(),
+            });
+        }
+
+        if (rowsToWrite.length) {
+            writeQueue = writeQueue.then(async () => {
+                await initPromise;
+                if (!sender) {
+                    return;
+                }
+
+                for (const row of rowsToWrite) {
+                    const parsedValue = normalizeValue(row.value);
+                    let line = sender
+                        .table(tableName)
+                        .symbol('tag_id', row.tagid)
+                        .symbol('device_id', row.deviceId)
+                        .stringColumn('device_name', row.deviceName);
+
+                    if (!utils.isNullOrUndefined(parsedValue.numberValue)) {
+                        line = line.floatColumn('number_value', parsedValue.numberValue);
+                    }
+                    if (!utils.isNullOrUndefined(parsedValue.stringValue)) {
+                        line = line.stringColumn('string_value', parsedValue.stringValue);
+                    }
+                    await line.at(Number(row.timestamp), 'ms');
+                }
+                await sender.flush();
+            }).catch((error) => {
+                logger.error(`questdb-addDaqValues failed! ${error}`);
+            });
+        }
+
+        if (dataToRestore.length && currentStorage) {
+            currentStorage.setValues(dataToRestore);
+        }
+    }
+
+    this.getDaqValue = function (tagid, fromts, tots) {
+        return new Promise(function (resolve, reject) {
+            initPromise.then(() => {
+                if (!pool) {
+                    resolve([]);
+                    return;
+                }
+
+                const query = `SELECT timestamp, number_value, string_value
+                               FROM ${tableName}
+                               WHERE tag_id = $1
+                                 AND timestamp >= $2
+                                 AND timestamp < $3
+                               ORDER BY timestamp`;
+                const params = [tagid, new Date(fromts), new Date(tots)];
+
+                pool.query(query, params)
+                    .then((result) => {
+                        let data = [];
+                        result.rows.forEach((row) => {
+                            const value = !utils.isNullOrUndefined(row.number_value) ? Number(row.number_value) : row.string_value;
+                            data.push({ dt: new Date(row.timestamp).getTime(), value });
+                        });
+                        resolve(data)
+                    })
+                    .catch((error) => {
+                        logger.error(`questdb-getDaqValue failed! ${error}`)
+                        reject(error)
+                    })
+            }).catch((error) => {
+                logger.error(`questdb-getDaqValue failed! ${error}`)
+                reject(error)
+            });
+        })
+    }
+
+    this.close = function () {
+        if (sender) {
+            sender.close().catch((error) => {
+                logger.error(`questdb-close sender failed! ${error}`);
+            });
+            sender = null;
+        }
+        if (pool) {
+            pool.end().catch((error) => {
+                logger.error(`questdb-close pool failed! ${error}`);
+            });
+            pool = null;
+        }
+    }
+
+    this.getDaqMap = function (tagid) {
+        var dummy = {};
+        dummy[tagid] = true;
+        return dummy;
+    }
+
+    async function ensureSchema() {
+        if (!pool) {
+            return;
+        }
+        await pool.query(`CREATE TABLE IF NOT EXISTS ${tableName} (
+            timestamp TIMESTAMP,
+            tag_id SYMBOL,
+            number_value FLOAT,
+            string_value STRING,
+            device_id SYMBOL,
+            device_name STRING
+        ) TIMESTAMP(timestamp) PARTITION BY DAY`);
+    }
+
+    function getIngestConfigString() {
+        return settings.daqstore.configurationString || 'http::addr=localhost:9000;';
+    }
+
+    function getQueryClientConfig() {
+        return {
+            host: settings.daqstore.host || '127.0.0.1',
+            port: 8812, // Standard port
+            database: 'qdb', // Standard database
+            user: settings.daqstore.credentials?.username || 'admin',
+            password: settings.daqstore.credentials?.password || 'quest',
+            max: 10, // Pool with 10 connections
+            idleTimeoutMillis: 30000, // 30s
+        };
+    }
+
+    function getTableName() {
+        const name = (settings.daqstore.tableName || 'meters').trim();
+        if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+            return name.toLowerCase();
+        }
+        logger.warn(`questdb invalid tableName "${name}", fallback to meters`);
+        return 'meters';
+    }
+
+    function normalizeValue(value) {
+        if (utils.isNullOrUndefined(value)) {
+            return { numberValue: null, stringValue: null };
+        }
+        if (utils.isBoolean(value)) {
+            return {
+                numberValue: value ? 1 : 0,
+                stringValue: null
+            };
+        }
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return { numberValue: value, stringValue: null };
+        }
+        return { numberValue: null, stringValue: String(value) };
+    }
+
+    initPromise = this.init();
+}
+
+module.exports = {
+    create: function (data, logger, currentStorage) {
+        return new QuestDB(data, logger, currentStorage);
+    }
+};


### PR DESCRIPTION
## 📌 Description

This PR adds QuestDB support as a DAQ storage backend.

- What problem does this solve?
  - FUXA had no QuestDB storage adapter.
  - QuestDB-specific configuration in the app settings was missing/unclear.
  - UI labels for QuestDB sender/query connections were not explicit.

- What was changed?
  - Added `server/runtime/storage/questdb/index.js` backend.
  - Wired `questDB` into `server/runtime/storage/daqstorage.js`.
  - Implemented QuestDB dual-path access:
    - Ingestion via ILP (`@questdb/nodejs-client`)
    - Querying via PGWire (`pg` Pool)
  - Added typed value handling in QuestDB storage:
    - `number_value` for numeric/bool(0/1)
    - `string_value` for string values
  - Added configurable QuestDB table name (`tableName`, default `meters`).
  - Extended frontend DAQ settings model for QuestDB fields:
    - `host`, `tableName`, `configurationString`
  - Updated app settings UI:
    - Added QuestDB-specific configuration section
    - Added separate labels for query vs ingestion connection
  - Added/updated i18n keys in all locale files:
    - `dlg.app-settings-daqstore-configurl`
    - `dlg.app-settings-daqstore-queryconn`
    - `dlg.app-settings-daqstore-ingestconn`

- Why is this needed?
  - Enables first-class QuestDB usage in FUXA.
  - Aligns with QuestDB protocol usage (ILP for writes, PGWire for reads).
  - Makes DAQ configuration clearer and safer for users.

---

## 🧪 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

- `questDB` type key remains lowercase for compatibility with existing settings flow.
- Existing/legacy `QuestDB` value handling is normalized in runtime where needed.
- No generated frontend build artifacts were intentionally included.
