### PR TITLE
feat: improved layered dockerfile and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,30 +1,7 @@
-# Dependency directories
-# We want the container to run its own 'npm install'
-node_modules/
-npm-debug.log
-yarn-error.log
-
-# Git metadata
 .git
-.gitignore
-
-# Local build artifacts and caches
-dist/
-build/
-.cache/
-.npm/
-
-# OS-specific files
-.DS_Store
-Thumbs.db
-
-# Docker-related files
-Dockerfile
-.dockerignore
-docker-compose.yml
-
-# Large data or temp files
-*.tar
-*.zip
-*.log
-tmp/
+.angular
+**/node_modules
+**/dist
+app/electron
+docs
+screenshot

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Dependency directories
+# We want the container to run its own 'npm install'
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Git metadata
+.git
+.gitignore
+
+# Local build artifacts and caches
+dist/
+build/
+.cache/
+.npm/
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Docker-related files
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Large data or temp files
+*.tar
+*.zip
+*.log
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,78 @@
-# --- STAGE 1: The Builder ---
-FROM node:18-bookworm AS builder
+# --- STAGE 1: Angular Client Builder ---
+FROM node:18-bookworm AS client-builder
+WORKDIR /usr/src/app/client
+COPY client/package*.json ./
+RUN npm install --no-audit --no-fund
+COPY client/ ./
+RUN npm run build -- --configuration production
 
-ARG NODE_SNAP=false
+# --- STAGE 2: Server & Native Dependencies Builder ---
+FROM node:18-bookworm AS server-builder
+# Define build arguments with defaults
+ARG INSTALL_SNAP=false
+ARG INSTALL_ODBC=true
+
 WORKDIR /usr/src/app/FUXA
 
-# Install ONLY what is needed to compile
+# Base build tools (always needed for SQLite)
 RUN apt-get update && apt-get install -y \
-    dos2unix build-essential unixodbc-dev sqlite3 libsqlite3-dev \
+    python3 build-essential libsqlite3-dev dos2unix \
+    $( [ "$INSTALL_ODBC" = "true" ] && echo "unixodbc-dev" ) \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy only dependency files first to leverage caching
+# Install Server dependencies
 COPY server/package*.json ./server/
 WORKDIR /usr/src/app/FUXA/server
+RUN npm install --no-audit --no-fund
 
-# Optimized NPM for speed
-RUN npm config set audit false && npm config set fund false
-RUN npm install --no-audit --no-fund --network-timeout=600000
+# Optional Snap7 installation
+RUN if [ "$INSTALL_SNAP" = "true" ]; then npm install node-snap7; fi
 
-# Install snap7 if requested
-RUN if [ "$NODE_SNAP" = "true" ]; then npm install node-snap7; fi
-
-# Rebuild sqlite3 for the container architecture
+# Force rebuild of SQLite for the container
 RUN npm install --build-from-source --sqlite=/usr/bin sqlite3
 
-# Now copy the rest of the source code
-WORKDIR /usr/src/app/FUXA
-COPY . .
+# Optional ODBC driver preparation
+WORKDIR /usr/src/app/FUXA/odbc
+COPY odbc/ ./
+RUN if [ "$INSTALL_ODBC" = "true" ]; then \
+    dos2unix install_odbc_drivers.sh && chmod +x install_odbc_drivers.sh && ./install_odbc_drivers.sh; \
+    fi
 
-# Run the driver scripts (only needed for the setup files they generate)
-RUN dos2unix odbc/install_odbc_drivers.sh && \
-    chmod +x odbc/install_odbc_drivers.sh
+# 3. Copy server source, build, then cleanup
+WORKDIR /usr/src/app/FUXA/server
+COPY server/ ./
+RUN npm run build
+# Remove unecessary runtime stuff
+RUN rm -rf test docs
 
-# --- STAGE 2: The Runner (Final Image) ---
+# --- STAGE 3: Runner ---
 FROM node:18-bookworm-slim
-
+ARG INSTALL_ODBC=true
 WORKDIR /usr/src/app/FUXA
 
-# Install ONLY the runtime libraries (no compilers/build-essential)
+# Install ONLY runtime libraries
 RUN apt-get update && apt-get install -y \
-    unixodbc sqlite3 libsqlite3-dev \
+    sqlite3 libsqlite3-0 \
+    $( [ "$INSTALL_ODBC" = "true" ] && echo "unixodbc" ) \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy ONLY the necessary artifacts from the builder
-COPY --from=builder /usr/src/app/FUXA/server ./server
-COPY --from=builder /usr/src/app/FUXA/app ./app
-COPY --from=builder /usr/src/app/FUXA/client ./client
-COPY --from=builder /usr/src/app/FUXA/node-red ./node-red
-COPY --from=builder /usr/src/app/FUXA/odbc ./odbc
-COPY --from=builder /usr/src/app/FUXA/odbc/odbcinst.ini /etc/odbcinst.ini
+# 1. Copy Server
+COPY --from=server-builder /usr/src/app/FUXA/server ./server
 
-# Set environment and expose
+# 2. Copy Client
+COPY --from=client-builder /usr/src/app/client/dist ./client/dist
+
+# 3. Conditional ODBC Config
+COPY --from=server-builder /usr/src/app/FUXA/odbc ./odbc
+RUN if [ "$INSTALL_ODBC" = "true" ]; then cp odbc/odbcinst.ini /etc/odbcinst.ini; fi
+
+# 4. Copy static app files
+COPY node-red/ ./node-red/
+
+# Final cleanup
 WORKDIR /usr/src/app/FUXA/server
+RUN npm prune --production
+
 ENV NODE_ENV=production
 EXPOSE 1881
-
-CMD [ "npm", "start" ]
+CMD [ "node", "main.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,57 @@
-FROM node:18-bookworm
+# --- STAGE 1: The Builder ---
+FROM node:18-bookworm AS builder
 
 ARG NODE_SNAP=false
+WORKDIR /usr/src/app/FUXA
 
-RUN apt-get update && apt-get install -y dos2unix
+# Install ONLY what is needed to compile
+RUN apt-get update && apt-get install -y \
+    dos2unix build-essential unixodbc-dev sqlite3 libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Change working directory
-WORKDIR /usr/src/app
-
-# Clone FUXA repository
-RUN git clone https://github.com/frangoteam/FUXA.git
-
-# Install build dependencies for node-odbc
-RUN apt-get update && apt-get install -y build-essential unixodbc unixodbc-dev
-
-# Convert the script to Unix format and make it executable
-RUN dos2unix FUXA/odbc/install_odbc_drivers.sh && chmod +x FUXA/odbc/install_odbc_drivers.sh
-
-WORKDIR /usr/src/app/FUXA/odbc
-RUN ./install_odbc_drivers.sh
-
-# Change working directory
-WORKDIR /usr/src/app
-
-# Copy odbcinst.ini to /etc
-RUN cp FUXA/odbc/odbcinst.ini /etc/odbcinst.ini
-
-# Install Fuxa server
+# Copy only dependency files first to leverage caching
+COPY server/package*.json ./server/
 WORKDIR /usr/src/app/FUXA/server
 
-# More tolerant npm config
-ENV NODE_OPTIONS=--dns-result-order=ipv4first
-RUN npm config set registry https://registry.npmjs.org/ \
- && npm config set fetch-retries 8 \
- && npm config set fetch-retry-factor 2 \
- && npm config set fetch-retry-mintimeout 30000 \
- && npm config set fetch-retry-maxtimeout 300000 \
- && npm config set audit false \
- && npm config set fund false
+# Optimized NPM for speed
+RUN npm config set audit false && npm config set fund false
+RUN npm install --no-audit --no-fund --network-timeout=600000
 
-# Retry loop con backoff + timeout alto
-RUN bash -lc '\
-  for i in 1 2 3 4 5 6 7 8; do \
-    echo "npm install - attempt $i/8"; \
-    npm install --no-audit --no-fund --prefer-offline --network-timeout=600000 && exit 0; \
-    echo "Failed, wait $((10*i))s and try again..."; \
-    sleep $((10*i)); \
-  done; \
-  echo "npm install failed after 8 attempts"; \
-  exit 1'
+# Install snap7 if requested
+RUN if [ "$NODE_SNAP" = "true" ]; then npm install node-snap7; fi
 
+# Rebuild sqlite3 for the container architecture
+RUN npm install --build-from-source --sqlite=/usr/bin sqlite3
 
-# Install options snap7
-RUN if [ "$NODE_SNAP" = "true" ]; then \
-    npm install node-snap7; \
-    fi
+# Now copy the rest of the source code
+WORKDIR /usr/src/app/FUXA
+COPY . .
 
-# Workaround for sqlite3 https://stackoverflow.com/questions/71894884/sqlite3-err-dlopen-failed-version-glibc-2-29-not-found
-RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev && \
-    apt-get autoremove -yqq --purge && \
-    apt-get clean  && \
-    rm -rf /var/lib/apt/lists/*  && \
-    npm install --build-from-source --sqlite=/usr/bin sqlite3
+# Run the driver scripts (only needed for the setup files they generate)
+RUN dos2unix odbc/install_odbc_drivers.sh && \
+    chmod +x odbc/install_odbc_drivers.sh
 
-# Add project files
-ADD . /usr/src/app/FUXA
+# --- STAGE 2: The Runner (Final Image) ---
+FROM node:18-bookworm-slim
 
-# Set working directory
+WORKDIR /usr/src/app/FUXA
+
+# Install ONLY the runtime libraries (no compilers/build-essential)
+RUN apt-get update && apt-get install -y \
+    unixodbc sqlite3 libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy ONLY the necessary artifacts from the builder
+COPY --from=builder /usr/src/app/FUXA/server ./server
+COPY --from=builder /usr/src/app/FUXA/app ./app
+COPY --from=builder /usr/src/app/FUXA/client ./client
+COPY --from=builder /usr/src/app/FUXA/node-red ./node-red
+COPY --from=builder /usr/src/app/FUXA/odbc ./odbc
+COPY --from=builder /usr/src/app/FUXA/odbc/odbcinst.ini /etc/odbcinst.ini
+
+# Set environment and expose
 WORKDIR /usr/src/app/FUXA/server
-
-# Expose port
+ENV NODE_ENV=production
 EXPOSE 1881
 
-# Start the server
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN npm run build -- --configuration production
 # --- STAGE 2: Server & Native Dependencies Builder ---
 FROM node:18-bookworm AS server-builder
 # Define build arguments with defaults
-ARG INSTALL_SNAP=false
+ARG NODE_SNAP=false
 ARG INSTALL_ODBC=true
 
 WORKDIR /usr/src/app/FUXA
 
-# Base build tools (always needed for SQLite)
+# Base build tools
 RUN apt-get update && apt-get install -y \
     python3 build-essential libsqlite3-dev dos2unix \
     $( [ "$INSTALL_ODBC" = "true" ] && echo "unixodbc-dev" ) \
@@ -26,7 +26,7 @@ WORKDIR /usr/src/app/FUXA/server
 RUN npm install --no-audit --no-fund
 
 # Optional Snap7 installation
-RUN if [ "$INSTALL_SNAP" = "true" ]; then npm install node-snap7; fi
+RUN if [ "$NODE_SNAP" = "true" ]; then npm install node-snap7; fi
 
 # Force rebuild of SQLite for the container
 RUN npm install --build-from-source --sqlite=/usr/bin sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
 COPY server/package*.json ./server/
 WORKDIR /usr/src/app/FUXA/server
 RUN npm install --no-audit --no-fund
+RUN npm prune --production
 
 # Optional Snap7 installation
 RUN if [ "$NODE_SNAP" = "true" ]; then npm install node-snap7; fi
@@ -41,9 +42,8 @@ RUN if [ "$INSTALL_ODBC" = "true" ]; then \
 # 3. Copy server source, build, then cleanup
 WORKDIR /usr/src/app/FUXA/server
 COPY server/ ./
+RUN rm -rf test
 RUN npm run build
-# Remove unecessary runtime stuff
-RUN rm -rf test docs
 
 # --- STAGE 3: Runner ---
 FROM node:18-bookworm-slim
@@ -71,7 +71,6 @@ COPY node-red/ ./node-red/
 
 # Final cleanup
 WORKDIR /usr/src/app/FUXA/server
-RUN npm prune --production
 
 ENV NODE_ENV=production
 EXPOSE 1881


### PR DESCRIPTION
## 📌 Description

This PR refactors the dockerfile in order to build a much smaller image (2.4gb -> 540 MB), and to also make use of build layer caching for faster repeated builds. 

The git repository is no longer cloned into the image and it is assumed it is being built from within the repo. 
This allows building from different tags and branches as well, and should still work in CI.

This is needed because the image was way too large before and took ages to build.

---

## 🧪 Type of Change

Please mark the relevant option:

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [x] Documentation updated if required
- [x] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

Add any other context or screenshots here.