### PR TITLE
Fix/project import 413 error feedback

### DIFF
--- a/client/src/app/_services/project.service.ts
+++ b/client/src/app/_services/project.service.ts
@@ -145,14 +145,7 @@ export class ProjectService {
             }
             subject.next(true);
         }, err => {
-            console.error(err);
-            var msg = '';
-            this.translateService.get('msg.project-save-error').subscribe((txt: string) => { msg = txt; });
-            this.toastr.error(msg, '', {
-                timeOut: 3000,
-                closeButton: true,
-                disableTimeOut: true
-            });
+            this.notifySaveError(err);
             subject.next(false);
         });
         return subject;
@@ -933,6 +926,8 @@ export class ProjectService {
             msg = this.translateService.instant('msg.project-save-unauthorized');
         } else if (err.status === 413) {
             msg = err.error?.message || err.message || err.statusText;
+        } else if (err.status === 0 && this.serverSettings?.apiMaxLength) {
+            msg = `Upload failed: project size may exceed the server limit (${this.serverSettings.apiMaxLength})`;
         }
         if (msg) {
             this.toastr.error(msg, '', {
@@ -1332,6 +1327,7 @@ export class ProjectService {
 export class ServerSettings {
     version: string;
     secureEnabled: boolean;
+    apiMaxLength?: string;
 }
 
 export enum SaveMode {

--- a/client/src/theme.scss
+++ b/client/src/theme.scss
@@ -9,21 +9,21 @@
 
 // tipografie
 $app-font-family: '"Segoe UI","Helvetica Neue","Arial",sans-serif';
-$my-typography: mat.m2-define-typography-config(
+$my-typography: mat.define-typography-config(
   $font-family: $app-font-family,
-  $body-1:  mat.m2-define-typography-level($font-size: 13px, $line-height: 18px, $font-weight: 400),
-  $body-2:  mat.m2-define-typography-level($font-size: 14px, $line-height: 20px, $font-weight: 400),
-  $button:  mat.m2-define-typography-level($font-size: 12px, $line-height: 20px, $font-weight: 600),
-  $caption: mat.m2-define-typography-level($font-size: 12px, $line-height: 16px, $font-weight: 400)
+  $body-1:  mat.define-typography-level($font-size: 13px, $line-height: 18px, $font-weight: 400),
+  $body-2:  mat.define-typography-level($font-size: 14px, $line-height: 20px, $font-weight: 400),
+  $button:  mat.define-typography-level($font-size: 12px, $line-height: 20px, $font-weight: 600),
+  $caption: mat.define-typography-level($font-size: 12px, $line-height: 16px, $font-weight: 400)
 );
 
 @include mat.typography-hierarchy($my-typography);
 
 // Header theme
-$my-header-primary: mat.m2-define-palette(mat.$m2-grey-palette, 100);
-$my-header-accent: mat.m2-define-palette(mat.$m2-pink-palette);
-$my-header-warn: mat.m2-define-palette(mat.$m2-red-palette);
-$my-header-theme: mat.m2-define-light-theme((
+$my-header-primary: mat.define-palette(mat.$grey-palette, 100);
+$my-header-accent: mat.define-palette(mat.$pink-palette);
+$my-header-warn: mat.define-palette(mat.$red-palette);
+$my-header-theme: mat.define-light-theme((
   color: (
     primary: $my-header-primary,
     accent: $my-header-accent,
@@ -35,10 +35,10 @@ $my-header-theme: mat.m2-define-light-theme((
 @include mat.menu-theme($my-header-theme);
 
 // Checkbox theme
-$my-checkbox-primary: mat.m2-define-palette(mat.$m2-grey-palette, 800);
-$my-checkbox-accent: mat.m2-define-palette(mat.$m2-grey-palette, 800);
-$my-checkbox-warn: mat.m2-define-palette(mat.$m2-red-palette);
-$my-checkbox-theme: mat.m2-define-light-theme((
+$my-checkbox-primary: mat.define-palette(mat.$grey-palette, 800);
+$my-checkbox-accent: mat.define-palette(mat.$grey-palette, 800);
+$my-checkbox-warn: mat.define-palette(mat.$red-palette);
+$my-checkbox-theme: mat.define-light-theme((
   color: (
     primary: $my-checkbox-primary,
     accent: $my-checkbox-accent,
@@ -51,10 +51,10 @@ $my-checkbox-theme: mat.m2-define-light-theme((
 @include mat.pseudo-checkbox-theme($my-checkbox-theme);
 
 // Radio theme
-$my-radio-primary: mat.m2-define-palette(mat.$m2-grey-palette, 800);
-$my-radio-accent: mat.m2-define-palette(mat.$m2-grey-palette, 800);
-$my-radio-warn: mat.m2-define-palette(mat.$m2-red-palette);
-$my-radio-theme: mat.m2-define-light-theme((
+$my-radio-primary: mat.define-palette(mat.$grey-palette, 800);
+$my-radio-accent: mat.define-palette(mat.$grey-palette, 800);
+$my-radio-warn: mat.define-palette(mat.$red-palette);
+$my-radio-theme: mat.define-light-theme((
   color: (
     primary: $my-radio-primary,
     accent: $my-radio-accent,
@@ -66,10 +66,10 @@ $my-radio-theme: mat.m2-define-light-theme((
 @include mat.radio-theme($my-radio-theme);
 
 // Button theme
-$my-button-primary: mat.m2-define-palette(mat.$m2-blue-palette, A200);
-$my-button-accent: mat.m2-define-palette(mat.$m2-red-palette, 600);
-$my-button-warn: mat.m2-define-palette(mat.$m2-red-palette, 600);
-$my-button-theme: mat.m2-define-light-theme((
+$my-button-primary: mat.define-palette(mat.$blue-palette, A200);
+$my-button-accent: mat.define-palette(mat.$red-palette, 600);
+$my-button-warn: mat.define-palette(mat.$red-palette, 600);
+$my-button-theme: mat.define-light-theme((
   color: (
     primary: $my-button-primary,
     accent: $my-button-accent,
@@ -81,10 +81,10 @@ $my-button-theme: mat.m2-define-light-theme((
 @include mat.button-theme($my-button-theme);
 
 // Slide-toggle theme
-$my-slide-toggle-primary: mat.m2-define-palette(mat.$m2-blue-palette, 700);
-$my-slide-toggle-accent: mat.m2-define-palette(mat.$m2-green-palette, 600);
-$my-slide-toggle-warn: mat.m2-define-palette(mat.$m2-red-palette, 600);
-$my-slide-toggle-theme: mat.m2-define-light-theme((
+$my-slide-toggle-primary: mat.define-palette(mat.$blue-palette, 700);
+$my-slide-toggle-accent: mat.define-palette(mat.$green-palette, 600);
+$my-slide-toggle-warn: mat.define-palette(mat.$red-palette, 600);
+$my-slide-toggle-theme: mat.define-light-theme((
   color: (
     primary: $my-slide-toggle-primary,
     accent: $my-slide-toggle-accent,
@@ -96,10 +96,10 @@ $my-slide-toggle-theme: mat.m2-define-light-theme((
 @include mat.slide-toggle-theme($my-slide-toggle-theme);
 
 // Slider theme
-$my-slider-primary: mat.m2-define-palette(mat.$m2-blue-palette, 700);
-$my-slider-accent: mat.m2-define-palette(mat.$m2-green-palette, 600);
-$my-slider-warn: mat.m2-define-palette(mat.$m2-red-palette, 600);
-$my-slider-theme: mat.m2-define-light-theme((
+$my-slider-primary: mat.define-palette(mat.$blue-palette, 700);
+$my-slider-accent: mat.define-palette(mat.$green-palette, 600);
+$my-slider-warn: mat.define-palette(mat.$red-palette, 600);
+$my-slider-theme: mat.define-light-theme((
   color: (
     primary: $my-slider-primary,
     accent: $my-slider-accent,
@@ -111,10 +111,10 @@ $my-slider-theme: mat.m2-define-light-theme((
 @include mat.slider-theme($my-slider-theme);
 
 // Define a dark theme
-$dark-primary: mat.m2-define-palette(mat.$m2-blue-palette);
-$dark-accent: mat.m2-define-palette(mat.$m2-amber-palette, A200, A100, A400);
-$dark-warn: mat.m2-define-palette(mat.$m2-deep-orange-palette);
-$dark-theme: mat.m2-define-dark-theme((
+$dark-primary: mat.define-palette(mat.$blue-palette);
+$dark-accent: mat.define-palette(mat.$amber-palette, A200, A100, A400);
+$dark-warn: mat.define-palette(mat.$deep-orange-palette);
+$dark-theme: mat.define-dark-theme((
   color: (
     primary: $dark-primary,
     accent: $dark-accent,

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -89,9 +89,9 @@ function init(_server, _runtime) {
 
             apiApp.use((err, req, res, next) => {
                 if (err?.type === 'entity.too.large') {
-                    return res.status(413).json({
-                        message: `The submitted content exceeds the maximum allowed size (${maxApiRequestSize})`
-                    });
+                    const msg = `The submitted content exceeds the maximum allowed size (${maxApiRequestSize})`;
+                    runtime.logger.error(`api request rejected: ${msg}`);
+                    return res.status(413).json({ message: msg });
                 }
                 next(err);
             });


### PR DESCRIPTION
## 📌 Description

Problem: Importing a large project file (≥ 184 MB in the reported case) through the FUXA UI failed silently. The interface showed only a generic notification with `Project save failed!` with no indication of the actual cause, and the server logs contained no application-level error entry — only the raw HTTP access log line `POST /api/project 413`.

Three separate issues combined to produce this behaviour:

1. **Server silent on 413**: In `server/api/index.js` the Express error handler for `entity.too.large` returned the 413 response but never called `runtime.logger.error()`. The rejection was invisible in application logs.

2. **Frontend discarded HTTP status**: In `client/src/app/_services/project.service.ts`, the `save()` method had its own inline error handler that always showed the translated `msg.project-save-error` string, ignoring the HTTP status code entirely. The existing `notifySaveError()` helper already handled 401 and 413 correctly (surfacing the server message for 413, and a hint for status 0 / connection abort), but `save()` bypassed it.

3. **Angular client could not be rebuilt**: `client/src/theme.scss` used `mat.m2-define-*` functions and `mat.$m2-*` palette variables introduced in Angular Material 17, while the installed package is 16.2.13. This caused an "Undefined function" Sass compilation error that prevented any rebuild of the client bundle.

Changes:
- `server/api/index.js`: added `runtime.logger.error()` in the 413 error handler so the rejection appears in application logs alongside the HTTP access log entry.
- `client/src/app/_services/project.service.ts`: replaced the inline error handler in `save()` with a call to `notifySaveError(err)`. Added a `status === 0` branch in `notifySaveError()` for browsers that abort the connection mid-upload rather than receiving the 413 cleanly. Extended `ServerSettings` with `apiMaxLength` so the configured limit is available for that message.
- `client/src/theme.scss`: replaced all `m2-` prefixed Sass identifiers with their Angular Material 16 equivalents (`mat.define-*` / `mat.$*-palette`) to restore the ability to build the client. I keep these change in a separate commit because I do not know if you are in a transition phase from Angular Material 16 to Angular Material 17, but without this fix I was not able to test it locally. So in case let me know and I rebase it without this last commit.


---

## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [x] Documentation updated if required
- [ ] Issue opened (for major changes)


---

## 📝 Additional Notes

The immediate trigger for the 413 is the default `apiMaxLength` of `100mb` defined in `server/api/index.js`. To import a project larger than 100 MB without changing source code, add the following line to `server/_appdata/settings.js`:

```js
apiMaxLength: '256mb',
```

Browser behaviour for large uploads is not standardised. Chrome typically receives the 413 response cleanly (the `status === 413` branch fires and shows the server message verbatim). Firefox and some other clients abort the TCP connection before receiving the response (the `status === 0` branch fires and shows the configured limit as a hint). Both paths now produce an actionable message instead of the generic fallback.

The server log will now show:

```log
[ERR] api request rejected: The submitted content exceeds the maximum allowed size (100mb)
```

The final result on the ui is:
<img width="347" height="119" alt="error_max_size" src="https://github.com/user-attachments/assets/4a5d5361-8292-477e-92a2-40fec674e148" />

