### PR TITLE
fix(editor): observe SVG DOM mutations to keep view.items in sync on undo

### DIFF
--- a/client/src/app/editor/editor.component.ts
+++ b/client/src/app/editor/editor.component.ts
@@ -117,6 +117,7 @@ export class EditorComponent implements OnInit, AfterViewInit, OnDestroy {
     mapsViewType = ViewType.maps;
     shapesGrps = [];
     private gaugesRef = {};
+    private _svgMutationObserver?: MutationObserver;
 
     private subscriptionSave: Subscription;
     private subscriptionLoad: Subscription;
@@ -197,6 +198,8 @@ export class EditorComponent implements OnInit, AfterViewInit, OnDestroy {
         } catch (e) {
             console.error(e);
         }
+        this._svgMutationObserver?.disconnect();
+        this._svgMutationObserver = undefined;
         this.onSaveProject();
         this.destroy$.next(null);
         this.destroy$.complete();
@@ -534,6 +537,35 @@ export class EditorComponent implements OnInit, AfterViewInit, OnDestroy {
                     this.winRef.nativeWindow.svgEditor.refreshCanvas();
                     this.checkSvgElementsMap(true);
                     this.winRef.nativeWindow.svgEditor.resetUndoStack();
+
+                    // Observe gauge element removals (delete, cut, undo) so that
+                    // view.items stays in sync with svgcontent without requiring
+                    // a manual "Clean View" or Play-button press.
+                    const svgLayer = document.querySelector('#svgcanvas g');
+                    if (svgLayer) {
+                        this._svgMutationObserver = new MutationObserver((records: MutationRecord[]) => {
+                            const removed: { id: string }[] = [];
+                            records.forEach(record => {
+                                record.removedNodes.forEach((node: Node) => {
+                                    if (!(node instanceof Element)) { return; }
+                                    if (node.getAttribute('type')?.startsWith('svg-ext') && node.id) {
+                                        // Direct gauge element removed (delete, cut, or undo).
+                                        removed.push({ id: node.id });
+                                    } else {
+                                        // Container removed (e.g. a group holding gauges).
+                                        // Collect any gauge descendants inside it.
+                                        node.querySelectorAll('[type^="svg-ext"]').forEach((child: Element) => {
+                                            if (child.id) { removed.push({ id: child.id }); }
+                                        });
+                                    }
+                                });
+                            });
+                            if (removed.length > 0) {
+                                this.onRemoveElement(removed);
+                            }
+                        });
+                        this._svgMutationObserver.observe(svgLayer, { childList: true });
+                    }
                 }, 500);
             } else if (this.isCardsEditMode(this.editorMode) && this.cardsview) {
                 this.cardsview.view = view;
@@ -636,6 +668,8 @@ export class EditorComponent implements OnInit, AfterViewInit, OnDestroy {
      * clear svg-editor and the canvas
      */
     private clearEditor() {
+        this._svgMutationObserver?.disconnect();
+        this._svgMutationObserver = undefined;
         if (this.winRef.nativeWindow.svgEditor) {
             this.winRef.nativeWindow.svgEditor.clickClearAll();
         }


### PR DESCRIPTION
## 📌 Description

### Problem

Pressing **Ctrl+Z (undo)** after adding or pasting a gauge element causes a silent data leak in the project file.

When the user undoes an element addition, the SVG editor removes the element from the canvas internally but **never fires the `eleremoved` callback** that the Angular editor layer listens to. The corresponding entry in `view.items` is therefore left behind permanently — an orphan. These orphans are persisted to the server on every save and reloaded on every subsequent open, accumulating silently across editing sessions and causing unbounded project file growth.

The same issue affects **grouped elements**: when a group containing gauges is deleted or undone, only the group node is visible to the Angular layer — the gauge entries nested inside are never cleaned up.

A real-world instance of this bug produced a project file of **~180 MB**.

### What was changed

A `MutationObserver` is attached to the active SVG layer (`#svgcanvas g`) each time a view is loaded. The observer watches for child element removals and handles two cases:

- **Direct gauge removal** — if the removed node has a `type` attribute starting with `svg-ext` and a non-empty `id`, it is passed directly to `onRemoveElement()`.
- **Container removal** — if the removed node is a group or other container, `querySelectorAll('[type^="svg-ext"]')` is called on it to collect all nested gauge descendants before calling `onRemoveElement()`.

`onRemoveElement()` deletes the corresponding keys from `currentView.items`, keeping the in-memory model in sync with the canvas at all times.

The observer is properly disconnected on view switch (`clearEditor()`) and on component destroy (`ngOnDestroy()`), preventing memory leaks and stale callbacks.

### Why is this needed

The `eleremoved` callback fired by the SVG editor is not triggered by undo operations. Without this fix, every undo of a gauge addition leaves a permanent orphan in `view.items` that silently inflates the project file across sessions. The only existing cleanup path (`cleanView()`) requires the user to either press the Play button or manually select "Clean View" from the view menu — neither of which is a reliable safeguard during normal editing.


---

## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)


---

## 📝 Additional Notes

**File changed:** `client/src/app/editor/editor.component.ts`

**Tests:** A set of unit tests covering the MutationObserver callback logic (filtering rules, grouped-element traversal, and end-to-end `view.items` cleanup) was written to verify this fix. They are not included in this PR to avoid polluting the project with additional files and dependencies. If they are of interest, I am happy to share them directly or open a dedicated PR for the test suite.

**Remaining known limitations:**
- The observer uses `{ childList: true }` without `subtree: true`, so gauges added directly inside a pre-existing group layer and then individually undone are not caught. This covers an uncommon editing workflow; full coverage would require `subtree: true` at a minor performance cost.
- This fix is forward-looking only. Orphans already accumulated in existing project files are not removed automatically on load or save. The existing `cleanView()` call on Play-button press remains the cleanup path for historical backlog.
