### PR TITLE
Fix async script execution in runScript

### DIFF
--- a/client/src/app/_services/script.service.ts
+++ b/client/src/app/_services/script.service.ts
@@ -98,12 +98,24 @@ export class ScriptService {
                     const asyncText = script.sync ? 'function' : 'async function';
                     const callText = `${asyncText} ${script.name}() {\n${this.addSysFunctions(code)} \n }\n${script.name}.call(this);\n`;
                     const result = eval(callText);
-                    observer.next(result);
+
+                    if (result && typeof result.then === 'function') {
+                        result
+                            .then(res => {
+                                observer.next(res);
+                                observer.complete(); // async case
+                            })
+                            .catch(err => {
+                                console.error(err);
+                                observer.error(err);
+                            });
+                    } else {
+                        observer.next(result);
+                        observer.complete(); // sync case
+                    }
                 } catch (err) {
                     console.error(err);
                     observer.error(err);
-                } finally {
-                    observer.complete();
                 }
             }
         });


### PR DESCRIPTION
## 📌 Description
This PR fixes the handling of async scripts executed via eval.

Previously, when a script was defined as async, the returned Promise was passed directly to the Observable without being resolved.