### PR TITLE
Fix view initialization issue caused by premature cleanView call

### DIFF
--- a/client/src/app/_services/project.service.ts
+++ b/client/src/app/_services/project.service.ts
@@ -296,7 +296,6 @@ export class ProjectService {
      * @param view
      */
     setView(view: View, notify = false) {
-        this.cleanView(view);
         const existingView = this.projectData.hmi.views.find(v => v.id === view.id);
         if (existingView) {
             Object.assign(existingView, view);


### PR DESCRIPTION
## 📌 Description

This PR fixes an issue where calling cleanView before saving the view caused the initial configuration to be lost, leading to broken element initialization.