### PR TITLE
fix(odbc): catch error when querying tables with dbo schema for non-M…

### DIFF
--- a/server/runtime/devices/odbc/index.js
+++ b/server/runtime/devices/odbc/index.js
@@ -263,12 +263,12 @@ function ODBCclient(_data, _logger, _events) {
  * Return tables list
  */
 function getTables(endpoint, fncGetProperty, packagerManager) {
-    return new Promise( async function (resolve, reject) {
-        if (loadOdbcLib(packagerManager)) { 
+    return new Promise(async function (resolve, reject) {
+        if (loadOdbcLib(packagerManager)) {
             var connection;
             try {
                 var security
-                await fncGetProperty({query: 'security', name: endpoint.id}).then((result, error) => {
+                await fncGetProperty({ query: 'security', name: endpoint.id }).then((result, error) => {
                     if (result) {
                         security = utils.JsonTryToParse(result.value);
                     }
@@ -286,7 +286,12 @@ function getTables(endpoint, fncGetProperty, packagerManager) {
                     loginTimeout: 10,
                 }
                 connection = await odbc.connect(connectionConfig)
-                var tables = await connection.tables(null, 'dbo', null, null);
+                var tables = [];
+
+                try {
+                    tables = await connection.tables(null, 'dbo', null, null);
+                } catch (err) { }
+
                 if (tables.length <= 0) {
                     tables = await connection.tables(null, null, null, null);
                 }


### PR DESCRIPTION
## 📌 Description

Fix ODBC `getTables` failing on non-MSSQL databases (e.g. MySQL, PostgreSQL, Oracle).

- The original code calls `connection.tables(null, 'dbo', null, null)` directly, but `dbo` is an MSSQL-specific schema. This causes an error on all other databases, preventing table listing.

---

## 🧪 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📝 Additional Notes

Only `server/runtime/devices/odbc/index.js` was modified.