### PR TITLE
Update s7 index.js

### DIFF
--- a/server/runtime/devices/s7/index.js
+++ b/server/runtime/devices/s7/index.js
@@ -348,7 +348,7 @@ function S7client(_data, _logger, _events, _runtime) {
                         type: items[itemidx].type,
                         daq: items[itemidx].daq,
                         changed: changed,
-                        tagref: items[itemidx]
+                        tagref: data.tags[items[itemidx].id] // <--- Passes full tag config including scaling
                     };
                     someval = true;
                 }


### PR DESCRIPTION
fixed S7 Driver: Scaling not applied to peripheral inputs (IW, QW, etc.) due to missing scale object in _updateVarsValue

## 📌 Description

Currently, when reading peripheral inputs (like IW, QW, MB, etc.) from a Siemens S7 PLC, FUXA completely ignores both standard linear scaling and the new "Scale by script" feature. The raw value is passed to the frontend without any transformation applied. However, scaling works perfectly fine for Data Block (DB) addresses.

Expected Behavior:
Scaling configurations (linear or script) defined in the FUXA tag properties should be applied to all S7 data areas, including peripheral inputs.

Actual Behavior:
The scaling engine (deviceUtils.tagValueCompose) skips non-DB tags because the tag.scale property is missing when the temporary tagref object is passed to it.

Root Cause:
In server/runtime/devices/s7/index.js, inside the _updateVarsValue function (around line 309), the driver builds a temporary object to hold the tag data for non-DB addresses. It assigns tagref: items[itemidx].

Because items[itemidx] is just a stripped-down object created during the polling loop, it does not contain the scale properties configured in the UI. When this is passed to the global scaling engine, the engine assumes scaling is disabled.

The Fix:
Changing the tagref assignment to pull from the main data.tags array passes the full configuration (including scaling rules) to the scaling engine.

In server/runtime/devices/s7/index.js:
## 🧪 Type of Change

Please mark the relevant option:

- [x ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [ x] Only source files are included

---

## 🔍 Checklist

- [x ] Code follows project coding standards
- [ x] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

