### PR TITLE
Fixed Modbus tokenized mode when gaps are only 1 address big

### DIFF
--- a/server/runtime/devices/modbus/index.js
+++ b/server/runtime/devices/modbus/index.js
@@ -269,7 +269,7 @@ function MODBUSclient(_data, _logger, _events, _runtime) {
                     mixItemsMap[lastStart].MaxSize = lastAdrSize - lastStart;
                     mixItemsMap[lastStart].Items = getMemoryItems(memory[lastMemAdr].Items, mixItemsMap[lastStart].Start, mixItemsMap[lastStart].MaxSize);
                 }
-                nextAdr = 1 + adr + stepsMap[key].size;
+                nextAdr = adr + stepsMap[key].size;
             } catch (err) {
                 logger.error(`'${data.name}' load error! ${err}`);
             }


### PR DESCRIPTION
When using Modbus TCP devices in the tokenized/fragment mode, it skipped over 1 address wide gaps

## 📌 Description

Please describe the changes introduced by this Pull Request.

- What problem does this solve?
Tokenized/Fragment mode doesn't skip over 1 address wide gaps anymore
- What was changed?
`server\runtime\devices\modbus\index.js:272`
- Why is this needed?
If you have address spaces like [1,2] and [4,5,6] FUXA would throw an error as it tried to read [3] aswell.

---

## 🧪 Type of Change

Please mark the relevant option:

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [X] I did NOT commit `/client/dist`
- [X] I did NOT commit generated Angular build output
- [X] Only source files are included

---

## 🔍 Checklist

- [X] Code follows project coding standards
- [X] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📝 Additional Notes

This bug has been found/identified by using Deepwiki: https://deepwiki.com/search/how-does-fuxa-handle-modbus-tc_8639c0d6-64fe-4474-bbb9-e074d910ae40