### PR TITLE
Device-map: refresh visual layout

### DIFF
--- a/client/src/app/device/device-map/device-map.component.html
+++ b/client/src/app/device/device-map/device-map.component.html
@@ -59,7 +59,7 @@
                         <div class="device-copy">
                             <span class="device-header">{{ flow.name }}</span>
                             <span class="device-pro" *ngIf="flow.property">{{ flow.property.address }}</span>
-                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(flow) || 'Service bridge' }}</span>
+                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(flow) }}</span>
                         </div>
                     </div>
                     <div class="device-status" *ngIf="flow.enabled" [style.background-color]="getDeviceStatusColor(flow)"></div>
@@ -91,7 +91,7 @@
                         <div class="device-copy">
                             <span class="device-header">{{ device.name }}</span>
                             <span class="device-pro" *ngIf="device.property">{{ device.property.address }}</span>
-                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(device) || 'Live connection' }}</span>
+                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(device) || ('device.property-live-connection' | translate) }}</span>
                         </div>
                     </div>
                     <div class="device-status" *ngIf="device.enabled" [style.background-color]="getDeviceStatusColor(device)"></div>

--- a/client/src/app/device/device-map/device-map.component.html
+++ b/client/src/app/device/device-map/device-map.component.html
@@ -17,14 +17,25 @@
                 <div class="connection-line" [style.left.px]="getDeviceConnectionLeftPosition()" [style.top.px]="getDeviceConnectionTopPosition()"
                     [style.width.px]="getDeviceConnectionWidth()" [style.height.px]="lineDeviceSize"></div>
             </div>
-            <div class="map-container">
-                <div class="main-device" *ngIf="server?.property" [style.left.px]="getMainLeftPosition()" [style.top.px]="getMainTopPosition()" [style.width.px]="mainWidth"
+            <div class="map-container map-stage">
+                <div class="main-device device-card device-card--server" *ngIf="server?.property" [ngClass]="getDeviceAccentClass(server)"
+                    [style.left.px]="getMainLeftPosition()" [style.top.px]="getMainTopPosition()" [style.width.px]="mainWidth"
                     [style.height.px]="mainHeight" [style.borderWidth.px]="mainBorder">
-                    <span class="device-header" style="padding-top: 10px;">{{ server.name }}</span>
-                    <span class="device-pro">{{ server.property.address }}</span>
-                    <!-- <mat-icon (click)="onListDevice(server)" class="device-icon device-list">list_alt</mat-icon> -->
-                    <!-- <mat-icon (click)="onEditDevice(server)" class="device-icon device-edit" >edit</mat-icon> -->
-                    <button *ngIf="!readonly" mat-icon-button (click)="onListDevice(server)" class="device-icon device-list mat-button-sm" [style.right.px]="(readonly) ? 2 : 30"
+                    <div class="device-card__glow"></div>
+                    <div class="device-card__topline">
+                        <span class="device-type">{{ server.type }}</span>
+                    </div>
+                    <div class="device-card__main">
+                        <div class="device-avatar">
+                            <mat-icon>{{ getDeviceIcon(server) }}</mat-icon>
+                        </div>
+                        <div class="device-copy">
+                            <span class="device-header">{{ server.name }}</span>
+                            <span class="device-pro">{{ server.property.address }}</span>
+                            <span class="device-pro device-pro--meta">Central node</span>
+                        </div>
+                    </div>
+                    <button *ngIf="!readonly" mat-icon-button (click)="onListDevice(server)" class="device-icon device-list mat-button-sm" [style.right.px]="(readonly) ? 2 : 40"
                         matTooltip="{{'device.property-tags' | translate}}">
                         <mat-icon>link</mat-icon>
                     </button>
@@ -33,15 +44,27 @@
                     </button>
                 </div>
 
-                <div *ngFor="let flow of devicesValue('flow'); index as i" class="node-flow" [style.color]="(flow.enabled) ? '#000000' : '#828282'"
+                <div *ngFor="let flow of devicesValue('flow'); index as i" class="node-flow device-card device-card--flow" [ngClass]="getDeviceAccentClass(flow)"
+                    [style.color]="(flow.enabled) ? '#111827' : '#6b7280'"
                     [style.left.px]="getDeviceLeftPosition(i, 'flow')" [style.top.px]="getDeviceTopPosition('flow')" [style.width.px]="flowWidth" [style.height.px]="flowHeight"
                     [style.borderWidth.px]="flowBorder">
-                    <span class="device-header" style="color: black;">{{ flow.name }}</span>
-                    <span class="device-pro" *ngIf="flow.property">{{ flow.property.address }}</span>
-                    <span class="device-pro" style="padding-bottom: 10px;">{{ getDevicePropertyToShow(flow) }}</span>
+                    <div class="device-card__glow"></div>
+                    <div class="device-card__topline">
+                        <span class="device-type">{{ flow.type }}</span>
+                    </div>
+                    <div class="device-card__main">
+                        <div class="device-avatar">
+                            <mat-icon>{{ getDeviceIcon(flow) }}</mat-icon>
+                        </div>
+                        <div class="device-copy">
+                            <span class="device-header">{{ flow.name }}</span>
+                            <span class="device-pro" *ngIf="flow.property">{{ flow.property.address }}</span>
+                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(flow) || 'Service bridge' }}</span>
+                        </div>
+                    </div>
                     <div class="device-status" *ngIf="flow.enabled" [style.background-color]="getDeviceStatusColor(flow)"></div>
                     <button *ngIf="!readonly && withListConfig(flow)" mat-icon-button (click)="onListDevice(flow)" class="device-list mat-button-sm"
-                        [style.right.px]="(readonly) ? 0 : 30" matTooltip="{{'device.property-tags' | translate}}">
+                        [style.right.px]="(readonly) ? 0 : 40" matTooltip="{{'device.property-tags' | translate}}">
                         <mat-icon>link</mat-icon>
                     </button>
                     <button *ngIf="!readonly" mat-icon-button (click)="onEditDevice(flow)" class="device-edit mat-button-sm" matTooltip="{{'device.property-edit' | translate}}">
@@ -53,15 +76,27 @@
                     </button>
                 </div>
 
-                <div *ngFor="let device of devicesValue(); index as i" [ngClass]="getNodeClass(device)" [style.color]="(device.enabled) ? '#FFFFFF' : '#C5C5C5'"
+                <div *ngFor="let device of devicesValue(); index as i" [ngClass]="[getNodeClass(device), 'device-card', 'device-card--device', getDeviceAccentClass(device)]"
+                    [style.color]="(device.enabled) ? '#f8fafc' : '#cbd5e1'"
                     [style.left.px]="getDeviceLeftPosition(i)" [style.top.px]="getDeviceTopPosition()" [style.width.px]="deviceWidth" [style.height.px]="deviceHeight"
                     [style.borderWidth.px]="deviceBorder">
-                    <span class="device-header">{{ device.name }}</span>
-                    <span class="device-pro" *ngIf="device.property">{{ device.property.address }}</span>
-                    <span class="device-pro" style="padding-bottom: 10px;">{{ getDevicePropertyToShow(device) }}</span>
+                    <div class="device-card__glow"></div>
+                    <div class="device-card__topline">
+                        <span class="device-type">{{ device.type }}</span>
+                    </div>
+                    <div class="device-card__main">
+                        <div class="device-avatar">
+                            <mat-icon>{{ getDeviceIcon(device) }}</mat-icon>
+                        </div>
+                        <div class="device-copy">
+                            <span class="device-header">{{ device.name }}</span>
+                            <span class="device-pro" *ngIf="device.property">{{ device.property.address }}</span>
+                            <span class="device-pro device-pro--meta">{{ getDevicePropertyToShow(device) || 'Live connection' }}</span>
+                        </div>
+                    </div>
                     <div class="device-status" *ngIf="device.enabled" [style.background-color]="getDeviceStatusColor(device)"></div>
                     <button *ngIf="!readonly && withListConfig(device)" mat-icon-button (click)="onListDevice(device)" class="device-list mat-button-sm"
-                        [style.right.px]="(readonly) ? 0 : 30" matTooltip="{{'device.property-tags' | translate}}">
+                        [style.right.px]="(readonly) ? 0 : 40" matTooltip="{{'device.property-tags' | translate}}">
                         <mat-icon>link</mat-icon>
                     </button>
                     <button *ngIf="!readonly" mat-icon-button (click)="onEditDevice(device)" class="device-edit mat-button-sm" matTooltip="{{'device.property-edit' | translate}}">

--- a/client/src/app/device/device-map/device-map.component.scss
+++ b/client/src/app/device/device-map/device-map.component.scss
@@ -1,10 +1,10 @@
 $main-backcolor: #0f4c81;
 $main-bordercolor: #2f79be;
 $device-color: #374151;
-$line-color: #d1d5db;
+$line-color: #9ca3af;
 $flow-backcolor: #f3f4f6;
 $flow-bordercolor: #9ca3af;
-$flowline-color: #e5e7eb;
+$flowline-color: #9ca3af;
 $internal-backcolor: #4b5563;
 
 :host {
@@ -48,8 +48,8 @@ $internal-backcolor: #4b5563;
         position: absolute;
         border-style: solid;
         text-align: left;
-        padding: 12px 14px 34px;
-        border-radius: 8px;
+        padding: 7px 7px 12px;
+        border-radius: 5px;
         overflow: hidden;
         box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
         transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
@@ -212,7 +212,7 @@ $internal-backcolor: #4b5563;
     .flow-line,
     .connection-line {
         position: absolute;
-        border-radius: 2px;
+        // border-radius: 2px;
         box-shadow: none;
         z-index: 1;
     }

--- a/client/src/app/device/device-map/device-map.component.scss
+++ b/client/src/app/device/device-map/device-map.component.scss
@@ -1,11 +1,11 @@
-$main-backcolor: rgb(12, 101, 189);
-$main-bordercolor: var(--mapBorderColor); //rgb(5, 65, 123);
-$device-color: rgb(79, 86, 93);
-$line-color: var(--mapBorderColor);
-$flow-backcolor: rgb(218, 218, 218);
-$flow-bordercolor: var(--mapBorderColor); //rgb(117, 117, 117);
-$flowline-color: var(--mapBorderColor); //rgb(117, 117, 117);
-$internal-backcolor: rgb(114, 120, 125);
+$main-backcolor: #0f4c81;
+$main-bordercolor: #2f79be;
+$device-color: #374151;
+$line-color: #d1d5db;
+$flow-backcolor: #f3f4f6;
+$flow-bordercolor: #9ca3af;
+$flowline-color: #e5e7eb;
+$internal-backcolor: #4b5563;
 
 :host {
     .page-container {
@@ -15,108 +15,168 @@ $internal-backcolor: rgb(114, 120, 125);
         min-height: 0;
         overflow: hidden;
     }
+
     .container {
         flex: 1 1 auto;
         min-height: 0;
-        overflow: auto;  /* scroll solo interno */
+        overflow: auto;
         position: relative;
     }
-    .main-device {
+
+    .map-container {
+        display: flex;
+        flex-direction: column;
+        min-width: 300px;
         position: absolute;
-        text-align: center;
-        background-color: $main-backcolor;
-        color: white;
+        bottom: 0;
+        top: 1px;
+        left: 0;
+        right: 0;
+        overflow: auto;
+        // background: #1f2937;
+    }
+
+    .map-stage {
+        overflow: visible;
+        min-width: 100%;
+    }
+
+    .main-device,
+    .node-device,
+    .node-internal,
+    .node-flow {
+        position: absolute;
         border-style: solid;
+        text-align: left;
+        padding: 12px 14px 34px;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+        transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+
+        &:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 22px rgba(15, 23, 42, 0.12);
+        }
+
+        mat-icon {
+            overflow: visible;
+        }
+    }
+
+    .main-device {
+        background: $main-backcolor;
+        color: white;
         border-color: $main-bordercolor;
     }
 
     .node-device {
-        position: absolute;
-        background-color: $device-color;
-        text-align: center;
-        padding-top: 17px;
-        border-style: solid;
-        border-color: $line-color;
-
-        mat-icon {
-            color: white;
-        }
+        background: $device-color;
+        color: #f8fafc;
+        border-color: #6b7280;
     }
 
     .node-internal {
-        position: absolute;
-        background-color: $internal-backcolor;
-        text-align: center;
-        padding-top: 17px;
-        border-style: solid;
-        border-color: $line-color;
-
-        mat-icon {
-            color: white;
-        }
+        background: $internal-backcolor;
+        color: #f8fafc;
+        border-color: #6b7280;
     }
 
     .node-flow {
-        position: absolute;
-        background-color: $flow-backcolor;
-        text-align: center;
-        padding-top: 17px;
-        border-style: solid;
+        background: $flow-backcolor;
+        color: #0f172a;
         border-color: $flow-bordercolor;
+    }
+
+    .device-card__glow {
+        position: absolute;
+        width: 120px;
+        height: 120px;
+        top: -48px;
+        right: -32px;
+        border-radius: 999px;
+        background: transparent;
+        pointer-events: none;
+    }
+
+    .device-card__topline {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        margin-bottom: 10px;
+    }
+
+    .device-type {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 9px;
+        border-radius: 999px;
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        white-space: nowrap;
+        max-width: calc(100% - 8px);
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .device-type {
+        background: rgba(15, 23, 42, 0.12);
+        color: inherit;
+    }
+
+    .node-flow .device-type {
+        background: #e5e7eb;
+    }
+
+    .device-card__main {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        min-width: 0;
+    }
+
+    .device-avatar {
+        flex: 0 0 40px;
+        width: 40px;
+        height: 40px;
+        border-radius: 14px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 255, 255, 0.08);
 
         mat-icon {
-            color: black;
+            font-size: 20px;
+            width: 20px;
+            height: 20px;
+            color: inherit;
         }
     }
 
-    .main-line {
-        position: absolute;
-        background-color: $line-color;
+    .node-flow .device-avatar {
+        background: #ffffff;
     }
 
-    .main-line-flow {
-        position: absolute;
-        background-color: $flowline-color;
-    }
-
-    .device-line {
-        position: absolute;
-        background-color: $line-color;
-    }
-
-    .flow-line {
-        position: absolute;
-        background-color: $flowline-color;
-    }
-
-    .connection-line {
-        position: absolute;
-        background-color: $line-color;
-    }
-
-    .table-wrapper {
-        position: relative;
-    }
-
-    // mat-header-row {
-    //     position: sticky;
-    //     top: 0;
-    //     z-index: 10;
-    // }
-
-    .paginator-wrapper {
-        position: sticky;
-        bottom: 0;
-        z-index: 11;
-        background: white;
-        padding-top: 4px;
+    .device-copy {
+        min-width: 0;
+        flex: 1 1 auto;
     }
 
     .device-header {
         display: block;
-        font-size: 17px;
-        padding-bottom: 7px;
-        padding-top: 0px;
+        font-size: 16px;
+        font-weight: 700;
+        line-height: 1.25;
+        padding: 0;
+        margin-bottom: 4px;
         min-height: 20px;
         white-space: nowrap;
         overflow: hidden;
@@ -126,11 +186,18 @@ $internal-backcolor: rgb(114, 120, 125);
     .device-pro {
         display: block;
         font-size: 12px;
-        padding-top: 0px;
+        line-height: 1.3;
+        opacity: 0.9;
         min-height: 14px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .device-pro--meta {
+        margin-top: 4px;
+        padding-right: 4px;
+        opacity: 0.72;
     }
 
     .device-pro-line {
@@ -139,24 +206,83 @@ $internal-backcolor: rgb(114, 120, 125);
         padding-top: 5px;
     }
 
+    .main-line,
+    .main-line-flow,
+    .device-line,
+    .flow-line,
+    .connection-line {
+        position: absolute;
+        border-radius: 2px;
+        box-shadow: none;
+        z-index: 1;
+    }
+
+    .main-line,
+    .device-line,
+    .connection-line {
+        background: $line-color;
+        opacity: 1;
+    }
+
+    .main-line-flow,
+    .flow-line {
+        background: $flowline-color;
+        opacity: 1;
+    }
+
+    .main-device,
+    .node-device,
+    .node-internal,
+    .node-flow {
+        z-index: 2;
+    }
+
+    .table-wrapper {
+        position: relative;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    .paginator-wrapper {
+        position: sticky;
+        bottom: 0;
+        z-index: 11;
+        background: white;
+        padding-top: 4px;
+    }
+
     .device-icon {
         position: absolute;
         cursor: pointer;
+        z-index: 2;
+    }
+
+    .device-edit,
+    .device-delete,
+    .device-list {
+        position: absolute;
+        z-index: 2;
+        // border-radius: 10px;
+        background: rgba(15, 23, 42, 0.08);
 
         mat-icon {
             overflow: visible;
         }
     }
 
-    .device-edit {
-        position: absolute;
-        bottom: 0px;
-        right: 0px;
-        font-size: 17px;
+    .node-flow .device-edit,
+    .node-flow .device-delete,
+    .node-flow .device-list {
+        background: rgba(255, 255, 255, 0.9);
+    }
 
-        mat-icon {
-            overflow: visible;
-        }
+    .device-edit {
+        bottom: 6px;
+        right: 6px;
+        font-size: 17px;
     }
 
     .device-edit-disabled {
@@ -165,53 +291,50 @@ $internal-backcolor: rgb(114, 120, 125);
     }
 
     .device-delete {
-        position: absolute;
-        top: 0px;
-        right: 0px;
+        top: 6px;
+        right: 6px;
         font-size: 17px;
-
-        mat-icon {
-            overflow: visible;
-        }
     }
 
     .device-list {
-        position: absolute;
-        right: 30px;
+        right: 40px;
+        bottom: 6px;
         font-size: 24px;
-        bottom: 0px;
-
-        mat-icon {
-            overflow: visible;
-        }
     }
 
     .device-status {
         position: absolute;
-        bottom: 10px;
-        left: 10px;
-        width: 10px;
-        height: 10px;
-        border-radius: 4px;
+        bottom: 16px;
+        left: 16px;
+        width: 11px;
+        height: 11px;
+        border-radius: 999px;
+        box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.75);
+        z-index: 2;
     }
 
-    .map-container {
-        display: flex;
-        flex-direction: column;
-        min-width: 300px;
-        position: absolute;
-        bottom: 0px;
-        top: 1px;
-        left: 0px;
-        right: 0px;
+    .accent-server {
+        .device-avatar {
+            background: rgba(255, 255, 255, 0.1);
+        }
     }
 
-    .table-wrapper {
-        flex: 1 1 auto;
-        min-height: 0;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
+    .accent-flow {
+        .device-card__glow {
+            background: transparent;
+        }
+    }
+
+    .accent-device {
+        .device-card__glow {
+            background: transparent;
+        }
+    }
+
+    .accent-internal {
+        .device-card__glow {
+            background: transparent;
+        }
     }
 
     .table-wrapper mat-table {
@@ -234,7 +357,6 @@ $internal-backcolor: rgb(114, 120, 125);
 
     .mat-table {
         overflow: auto;
-        /* min-width: 1500px; */
         height: 100%;
     }
 
@@ -266,7 +388,6 @@ $internal-backcolor: rgb(114, 120, 125);
     }
 
     .mat-column-select {
-        // overflow: visible;
         flex: 0 0 120px;
     }
 
@@ -321,6 +442,7 @@ $internal-backcolor: rgb(114, 120, 125);
     .hideTable {
         display: none;
     }
+
     .map-container {
         .mat-mdc-icon-button.mat-mdc-button-base {
             height: 30px !important;

--- a/client/src/app/device/device-map/device-map.component.ts
+++ b/client/src/app/device/device-map/device-map.component.ts
@@ -42,12 +42,12 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
     laneSidePadding = 64;
 
     flowBorder = 5;
-    flowWidth = 220;
+    flowWidth = 190;
     flowHeight = 92;
     flowLineHeight = 80;
 
     deviceBorder = 5;
-    deviceWidth = 220;
+    deviceWidth = 190;
     deviceHeight = 110;
     deviceLineHeight = 60;
 
@@ -55,7 +55,7 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
     lineFlowHeight = 70;
     lineDeviceSize = 6;
     mainDeviceLineHeight = 120;
-    mainWidth = 220;
+    mainWidth = 190;
     mainHeight = 110;
     mainBorder = 5;
 
@@ -436,8 +436,6 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
                 return 'api';
             case DeviceType.ODBC:
                 return 'storage';
-            case DeviceType.OPCUA:
-                return 'account_tree';
             case DeviceType.MQTTclient:
                 return 'rss_feed';
             case DeviceType.internal:

--- a/client/src/app/device/device-map/device-map.component.ts
+++ b/client/src/app/device/device-map/device-map.component.ts
@@ -44,7 +44,7 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
     flowBorder = 5;
     flowWidth = 220;
     flowHeight = 92;
-    flowLineHeight = 100;
+    flowLineHeight = 80;
 
     deviceBorder = 5;
     deviceWidth = 220;

--- a/client/src/app/device/device-map/device-map.component.ts
+++ b/client/src/app/device/device-map/device-map.component.ts
@@ -38,22 +38,25 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
     @ViewChild(MatSort, {static: false}) sort: MatSort;
     @ViewChild(MatPaginator, {static: false}) paginator: MatPaginator;
 
+    cardGap = 40;
+    laneSidePadding = 64;
+
     flowBorder = 5;
-    flowWidth = 160;
-    flowHeight = 70;
-    flowLineHeight = 60;
+    flowWidth = 220;
+    flowHeight = 92;
+    flowLineHeight = 100;
 
     deviceBorder = 5;
-    deviceWidth = 160;
-    deviceHeight = 90;
+    deviceWidth = 220;
+    deviceHeight = 110;
     deviceLineHeight = 60;
 
     lineFlowSize = 6;
-    lineFlowHeight = 60;
+    lineFlowHeight = 70;
     lineDeviceSize = 6;
-    mainDeviceLineHeight = 60;
-    mainWidth = 160;
-    mainHeight = 90;
+    mainDeviceLineHeight = 120;
+    mainWidth = 220;
+    mainHeight = 110;
     mainBorder = 5;
 
     server: Device;
@@ -172,14 +175,29 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
             result = this.elementRef.nativeElement.parentElement.clientWidth;
         }
         if (this.devices) {
-            if (result < (this.plcs().length + 2) * this.deviceWidth) {
-                result = (this.plcs().length + 2) * this.deviceWidth;
-            }
-            if (result < (this.flows().length + 2) * this.deviceWidth) {
-                result = (this.flows().length + 2) * this.deviceWidth;
-            }
+            result = Math.max(result, this.getLaneRequiredWidth(this.plcs().length, this.deviceWidth), this.getLaneRequiredWidth(this.flows().length, this.flowWidth));
         }
         return result;
+    }
+
+    private getLaneRequiredWidth(count: number, cardWidth: number) {
+        if (!count) {
+            return cardWidth + this.laneSidePadding * 2;
+        }
+        return count * cardWidth + Math.max(0, count - 1) * this.cardGap + this.laneSidePadding * 2;
+    }
+
+    private getLaneStart(count: number, cardWidth: number) {
+        const laneWidth = this.getLaneRequiredWidth(count, cardWidth);
+        return Math.max(this.laneSidePadding, (this.getWindowWidth() - laneWidth) / 2 + this.laneSidePadding);
+    }
+
+    private getLaneLeftPosition(index: number, count: number, cardWidth: number) {
+        return this.getLaneStart(count, cardWidth) + index * (cardWidth + this.cardGap);
+    }
+
+    private getLaneCenterX(index: number, count: number, cardWidth: number, borderWidth: number, lineSize: number) {
+        return this.getLaneLeftPosition(index, count, cardWidth) + borderWidth + cardWidth / 2 - lineSize / 2;
     }
 
     private getHorizontalCenter() {
@@ -234,17 +252,11 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
         if (this.devices) {
             if (type === 'flow') {
                 if (this.flows().length) {
-                    let pos = index + 1;
-                    let centerd = this.flows().length + 1;
-                    let result = ((this.getWindowWidth() - this.flowWidth) / centerd) * pos;
-                    return result;
+                    return this.getLaneLeftPosition(index, this.flows().length, this.flowWidth);
                 }
             } else {
                 if (this.plcs().length) {
-                    let pos = index + 1;
-                    let centerd = this.plcs().length + 1;
-                    let result = ((this.getWindowWidth() - this.deviceWidth) / centerd) * pos;
-                    return result;
+                    return this.getLaneLeftPosition(index, this.plcs().length, this.deviceWidth);
                 }
             }
         }
@@ -274,19 +286,11 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
         if (this.devices) {
             if (type === 'flow') {
                 if (this.flows().length) {
-                    let pos = index + 1;
-                    let centerd = this.flows().length + 1;
-                    let result = ((this.getWindowWidth() - this.flowWidth) / centerd) * pos;
-                    result += this.flowBorder + this.flowWidth / 2 - this.lineDeviceSize / 2;
-                    return result;
+                    return this.getLaneCenterX(index, this.flows().length, this.flowWidth, this.flowBorder, this.lineDeviceSize);
                 }
             } else {
                 if (this.plcs().length) {
-                    let pos = index + 1;
-                    let centerd = this.plcs().length + 1;
-                    let result = ((this.getWindowWidth() - this.deviceWidth) / centerd) * pos;
-                    result += this.deviceBorder + this.deviceWidth / 2 - this.lineDeviceSize / 2;
-                    return result;
+                    return this.getLaneCenterX(index, this.plcs().length, this.deviceWidth, this.deviceBorder, this.lineDeviceSize);
                 }
             }
         }
@@ -303,15 +307,9 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
 
     getDeviceConnectionLeftPosition(type = null) {
         if (type === 'flow') {
-            let centerd = this.flows().length + 1;
-            let result = ((this.getWindowWidth() - this.flowWidth) / centerd) * 1;
-            result += this.deviceBorder + (this.flowWidth - this.lineFlowSize) / 2;
-            return result;
+            return this.getLaneCenterX(0, this.flows().length, this.flowWidth, this.flowBorder, this.lineFlowSize);
         } else {
-            let centerd = this.plcs().length + 1;
-            let result = ((this.getWindowWidth() - this.deviceWidth) / centerd) * 1;
-            result += this.deviceBorder + (this.deviceWidth - this.lineDeviceSize) / 2;
-            return result;
+            return this.getLaneCenterX(0, this.plcs().length, this.deviceWidth, this.deviceBorder, this.lineDeviceSize);
         }
     }
 
@@ -328,16 +326,20 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
             if (type === 'flow') {
                 let count = this.flows().length;
                 if (count) {
-                    let centerd = this.flows().length + 1;
-                    let result = (((this.getWindowWidth() - this.flowWidth) / centerd) * count) - (((this.getWindowWidth() - this.flowWidth) / centerd) * 1);
-                    return result;
+                    if (count === 1) {
+                        return 0;
+                    }
+                    return this.getLaneCenterX(count - 1, count, this.flowWidth, this.flowBorder, this.lineFlowSize)
+                        - this.getLaneCenterX(0, count, this.flowWidth, this.flowBorder, this.lineFlowSize);
                 }
             } else {
                 let count = this.plcs().length;
                 if (count) {
-                    let centerd = this.plcs().length + 1;
-                    let result = (((this.getWindowWidth() - this.deviceWidth) / centerd) * count) - (((this.getWindowWidth() - this.deviceWidth) / centerd) * 1);
-                    return result;
+                    if (count === 1) {
+                        return 0;
+                    }
+                    return this.getLaneCenterX(count - 1, count, this.deviceWidth, this.deviceBorder, this.lineDeviceSize)
+                        - this.getLaneCenterX(0, count, this.deviceWidth, this.deviceBorder, this.lineDeviceSize);
                 }
             }
         }
@@ -421,6 +423,48 @@ export class DeviceMapComponent implements OnInit, OnDestroy, AfterViewInit {
             }
         }
         return result;
+    }
+
+    getDeviceIcon(device: Device) {
+        if (!device) {
+            return 'devices';
+        }
+        switch (device.type) {
+            case DeviceType.FuxaServer:
+                return 'hub';
+            case DeviceType.WebAPI:
+                return 'api';
+            case DeviceType.ODBC:
+                return 'storage';
+            case DeviceType.OPCUA:
+                return 'account_tree';
+            case DeviceType.MQTTclient:
+                return 'rss_feed';
+            case DeviceType.internal:
+                return 'memory';
+            case DeviceType.WebCam:
+                return 'videocam';
+            case DeviceType.GPIO:
+                return 'settings_input_component';
+            default:
+                return 'developer_board';
+        }
+    }
+
+    getDeviceAccentClass(device: Device) {
+        if (!device) {
+            return 'accent-device';
+        }
+        if (device.type === DeviceType.FuxaServer) {
+            return 'accent-server';
+        }
+        if (device.type === DeviceType.internal) {
+            return 'accent-internal';
+        }
+        if (device.type === DeviceType.WebAPI || device.type === DeviceType.ODBC) {
+            return 'accent-flow';
+        }
+        return 'accent-device';
     }
 
     getDeviceStatusColor(device: Device) {

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1095,6 +1095,7 @@
     "device.property-redis-scan-select": "Select all (filtered)",
     "device.property-redis-scan-scanning": "Scanning…",
     "device.property-redis-scan-found": "Found",
+    "device.property-live-connection": "Live connection",
 
     "device.browsetopics-property-title": "Broker Topics to subscribe and publish",
     "device.browsetopics-property-sub": "Subscribe",


### PR DESCRIPTION
## Summary
This PR refreshes the Device Map UI to make the layout cleaner and more readable.

## What changed
- redesigned device cards with a more modern visual structure
- added device type badges and icons per device category
- improved spacing, sizing, and horizontal alignment across server, flow, and device lanes
- reworked lane positioning logic to keep cards centered with consistent gaps

## Notes
- this PR is mostly visual, but it also updates map positioning calculations to support the new layout
- no functional changes are intended for device configuration/edit flows

<img width="1444" height="837" alt="image" src="https://github.com/user-attachments/assets/1327d076-199b-44ad-8060-9a30b3ff5a60" />