### PR TITLE
Fix TDengine string escaping

### DIFF
--- a/server/runtime/storage/tdengine/index.js
+++ b/server/runtime/storage/tdengine/index.js
@@ -8,7 +8,7 @@ function quoteTdIdentifier(value) {
 }
 
 function escapeTdString(value) {
-    return String(value).replace(/'/g, "''");
+    return String(value).replace(/\\/g, "\\\\").replace(/'/g, "''");
 }
 
 function TDengine(_settings, _log, _currentStorage) {
@@ -119,5 +119,8 @@ function TDengine(_settings, _log, _currentStorage) {
 module.exports = {
     create: function (data, logger, currentStorage) {
         return new TDengine(data, logger, currentStorage);
+    },
+    _private: {
+        escapeTdString
     }
 };

--- a/server/test/storage/tdengine.test.js
+++ b/server/test/storage/tdengine.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const tdengine = require('../../runtime/storage/tdengine');
+
+describe('TDengine storage escaping', () => {
+    let expect;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    it('escapes backslashes before single quotes', () => {
+        const escaped = tdengine._private.escapeTdString("x\\' OR 1=1--");
+
+        expect(escaped).to.equal("x\\\\'' OR 1=1--");
+    });
+
+    it('escapes backslashes in stored values too', () => {
+        const escaped = tdengine._private.escapeTdString("C:\\temp\\tag's value");
+
+        expect(escaped).to.equal("C:\\\\temp\\\\tag''s value");
+    });
+});


### PR DESCRIPTION
## Summary

Fixes GHSA-h9fj-c2qr-76g2: a SQL injection issue in the TDengine DAQ storage connector by escaping backslashes before single quotes.

TDengine treats `\'` as an escaped quote inside string literals, so only doubling single quotes was not sufficient. The escaping order now handles backslashes first, then single quotes.
