### PR TITLE
Fix scheduler action authorization

### DIFF
--- a/server/api/scheduler/index.js
+++ b/server/api/scheduler/index.js
@@ -55,7 +55,9 @@ module.exports = {
                 runtime.logger.error("api post scheduler: Tocken Expired");
                 return;
             }
+            const permission = checkGroupsFnc(req);
             const isGuest = authJwt.isGuestUser(req.userId, req.userGroups);
+            const isAdmin = authJwt.haveAdminPermission(permission);
             if (runtime.settings?.secureEnabled && isGuest) {
                 res.status(401).json({error:"unauthorized_error", message: "Unauthorized!"});
                 runtime.logger.error("api post scheduler: Unauthorized guest");
@@ -70,14 +72,26 @@ module.exports = {
                     runtime.logger.info('[API POST SCHEDULER] Received data for scheduler: ' + schedulerId);
                     runtime.logger.info('[API POST SCHEDULER] Settings: ' + JSON.stringify(schedulerData.settings, null, 2));
                     runtime.logger.info('[API POST SCHEDULER] Device Actions: ' + JSON.stringify(schedulerData.settings?.deviceActions, null, 2));
-                    
-                    const validation = validateSchedulerData(schedulerData);
-                    if (!validation.valid) {
-                        runtime.logger.error("Invalid scheduler data: " + validation.error);
-                        return res.status(400).json({ error: 'Invalid scheduler data: ' + validation.error });
-                    }
-                    
+
                     runtime.schedulerStorage.getSchedulerData(schedulerId).then(oldData => {
+                        if (runtime.settings?.secureEnabled && !isAdmin) {
+                            if (!oldData || !oldData.settings) {
+                                runtime.logger.error("api post scheduler: Unauthorized scheduler settings change");
+                                res.status(401).json({error:"unauthorized_error", message: "Unauthorized!"});
+                                return null;
+                            }
+                            schedulerData = Object.assign({}, oldData, {
+                                schedules: schedulerData.schedules || {}
+                            });
+                        }
+
+                        const validation = validateSchedulerData(schedulerData);
+                        if (!validation.valid) {
+                            runtime.logger.error("Invalid scheduler data: " + validation.error);
+                            res.status(400).json({ error: 'Invalid scheduler data: ' + validation.error });
+                            return null;
+                        }
+
                         return runtime.schedulerStorage.setSchedulerData(schedulerId, schedulerData).then(result => {
                             runtime.logger.info('[API POST SCHEDULER] Data saved successfully to database');
                             res.json({ result: 'ok' });
@@ -104,10 +118,11 @@ module.exports = {
                 runtime.logger.error("api delete scheduler: Tocken Expired");
                 return;
             }
+            const permission = checkGroupsFnc(req);
             const isGuest = authJwt.isGuestUser(req.userId, req.userGroups);
-            if (runtime.settings?.secureEnabled && isGuest) {
+            if (runtime.settings?.secureEnabled && (isGuest || !authJwt.haveAdminPermission(permission))) {
                 res.status(401).json({error:"unauthorized_error", message: "Unauthorized!"});
-                runtime.logger.error("api delete scheduler: Unauthorized guest");
+                runtime.logger.error("api delete scheduler: admin permission required");
                 return;
             }
             try {

--- a/server/test/authorization/schedulerAdminSecurity.test.js
+++ b/server/test/authorization/schedulerAdminSecurity.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const http = require('http');
+const express = require('express');
+
+const schedulerApi = require('../../api/scheduler');
+
+function makeLogger() {
+    return {
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+    };
+}
+
+function makeRuntime(calls, existingData = null) {
+    return {
+        project: {},
+        settings: { secureEnabled: true },
+        logger: makeLogger(),
+        schedulerStorage: {
+            getSchedulerData: () => Promise.resolve(existingData),
+            setSchedulerData: (id, data) => {
+                calls.set.push({ id, data });
+                return Promise.resolve({ changes: 1 });
+            },
+            deleteSchedulerData: (id) => {
+                calls.delete.push(id);
+                return Promise.resolve({ changes: 1 });
+            }
+        },
+        schedulerService: {
+            updateScheduler: () => {},
+            removeScheduler: () => Promise.resolve()
+        }
+    };
+}
+
+function makeApp(runtime, user) {
+    const app = express();
+    app.use(express.json());
+
+    schedulerApi.init(
+        runtime,
+        (req, res, next) => {
+            req.userId = user.id;
+            req.userGroups = user.groups;
+            req.isAuthenticated = user.id !== 'guest';
+            next();
+        },
+        (req) => req.userGroups
+    );
+
+    app.use(schedulerApi.app());
+    return app;
+}
+
+function request(app, method, path, body) {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, () => {
+            const data = body ? JSON.stringify(body) : '';
+            const options = {
+                method,
+                port: server.address().port,
+                path,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(data)
+                }
+            };
+
+            const req = http.request(options, (res) => {
+                let responseBody = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => { responseBody += chunk; });
+                res.on('end', () => {
+                    server.close(() => {
+                        resolve({ statusCode: res.statusCode, body: responseBody });
+                    });
+                });
+            });
+
+            req.on('error', (err) => {
+                server.close(() => reject(err));
+            });
+
+            if (data) {
+                req.write(data);
+            }
+            req.end();
+        });
+    });
+}
+
+function makeSchedulerBody() {
+    return {
+        id: 'sched-1',
+        data: {
+            schedules: {
+                dev1: [{
+                    id: 'evt1',
+                    deviceName: 'dev1',
+                    startTime: '00:00',
+                    days: [true, true, true, true, true, true, true]
+                }]
+            },
+            settings: {
+                devices: [{ name: 'dev1', variableId: 'device.tag' }],
+                deviceActions: [{
+                    deviceName: 'dev1',
+                    action: 'onSetValue',
+                    actoptions: { variable: { variableId: 'device.tag' } },
+                    actparam: '1'
+                }]
+            }
+        }
+    };
+}
+
+describe('Scheduler API authorization', () => {
+    let expect;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    it('preserves scheduler settings when authenticated non-admin users update schedules', async () => {
+        const existingData = makeSchedulerBody().data;
+        const calls = { set: [], delete: [] };
+        const app = makeApp(makeRuntime(calls, existingData), { id: 'alice', groups: 1 });
+
+        const tamperedBody = makeSchedulerBody();
+        tamperedBody.data.schedules.dev1[0].startTime = '12:00';
+        tamperedBody.data.settings.deviceActions = [{
+            deviceName: 'dev1',
+            action: 'onRunScript',
+            actoptions: { script: { id: 'evil' } }
+        }];
+
+        const res = await request(app, 'POST', '/api/scheduler', tamperedBody);
+
+        expect(res.statusCode).to.equal(200);
+        expect(calls.set).to.have.length(1);
+        expect(calls.set[0].data.schedules.dev1[0].startTime).to.equal('12:00');
+        expect(calls.set[0].data.settings.deviceActions).to.deep.equal(existingData.settings.deviceActions);
+    });
+
+    it('rejects scheduler writes from authenticated non-admin users when no admin settings exist', async () => {
+        const calls = { set: [], delete: [] };
+        const app = makeApp(makeRuntime(calls), { id: 'alice', groups: 1 });
+
+        const res = await request(app, 'POST', '/api/scheduler', makeSchedulerBody());
+
+        expect(res.statusCode).to.equal(401);
+        expect(calls.set).to.have.length(0);
+    });
+
+    it('allows scheduler settings writes from admin users', async () => {
+        const calls = { set: [], delete: [] };
+        const app = makeApp(makeRuntime(calls), { id: 'admin', groups: -1 });
+
+        const res = await request(app, 'POST', '/api/scheduler', makeSchedulerBody());
+
+        expect(res.statusCode).to.equal(200);
+        expect(calls.set).to.have.length(1);
+    });
+
+    it('rejects scheduler deletes from authenticated non-admin users', async () => {
+        const calls = { set: [], delete: [] };
+        const app = makeApp(makeRuntime(calls), { id: 'alice', groups: 1 });
+
+        const res = await request(app, 'DELETE', '/api/scheduler?id=sched-1');
+
+        expect(res.statusCode).to.equal(401);
+        expect(calls.delete).to.have.length(0);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes GHSA-8ghr-w65f-j3qr.

Authenticated non-admin users may update scheduler timing, but they must not be able to modify admin-defined scheduler settings or `deviceActions`.

## Changes

- Keep `POST /api/scheduler` available for authenticated operators.
- For non-admin scheduler updates, preserve the stored `settings` and `deviceActions`.
