### PR TITLE
Button control with configurable icon

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -224,6 +224,8 @@ export class GaugeProperty {
     options: any;
     readonly: boolean;
     text: string;               // Text property (used by button)
+    icon?: string;              // Optional Material icon (used by button)
+    image?: string;             // Optional image resource (used by button)
 }
 
 export interface PermissionRoles {

--- a/client/src/app/framework/icon-selector/icon-selector.component.scss
+++ b/client/src/app/framework/icon-selector/icon-selector.component.scss
@@ -1,7 +1,32 @@
 :host {
+    display: inline-block;
+    vertical-align: bottom;
+
     .icons-selector {
         width: 60px;
         height: 30px;
+    }
+
+    ::ng-deep .icons-selector .mat-mdc-select-trigger {
+        align-items: center;
+        height: 30px;
+        min-height: 30px;
+        box-sizing: border-box;
+    }
+
+    ::ng-deep .icons-selector .mat-mdc-select-value,
+    ::ng-deep .icons-selector .mat-mdc-select-value-text,
+    ::ng-deep .icons-selector .mat-mdc-select-min-line {
+        display: inline-flex;
+        align-items: center;
+        height: 100%;
+    }
+
+    ::ng-deep .icons-selector mat-icon {
+        width: 22px;
+        height: 22px;
+        font-size: 22px;
+        line-height: 22px;
     }
 }
 

--- a/client/src/app/gauges/controls/html-button/html-button.component.ts
+++ b/client/src/app/gauges/controls/html-button/html-button.component.ts
@@ -51,11 +51,51 @@ export class HtmlButtonComponent extends GaugeBaseComponent {
         if (ele && gab.property) {
             let htmlButton = Utils.searchTreeStartWith(ele, this.prefixB);
             if (htmlButton) {
-                let text = textTranslation || gab.property.text || gab.name;
-                htmlButton.innerHTML = (text) ? text : '<span>&nbsp;</span>';
+                const icon = gab.property.icon;
+                const image = gab.property.image;
+                let text = textTranslation || gab.property.text;
+                if (!icon && !image) {
+                    text = text || gab.name;
+                }
+                this.setButtonContent(htmlButton, text, icon, image);
             }
         }
         return ele;
+    }
+
+    private static setButtonContent(htmlButton: HTMLElement, text: string, icon?: string, image?: string) {
+        if (!icon && !image) {
+            htmlButton.innerHTML = (text) ? text : '<span>&nbsp;</span>';
+            return;
+        }
+
+        htmlButton.innerHTML = '';
+        htmlButton.style.display = 'inline-flex';
+        htmlButton.style.alignItems = 'center';
+        htmlButton.style.justifyContent = 'center';
+        htmlButton.style.gap = '8px';
+
+        if (image) {
+            const img = document.createElement('img');
+            img.src = image;
+            img.style.width = '1em';
+            img.style.height = '1em';
+            img.style.objectFit = 'contain';
+            htmlButton.appendChild(img);
+        } else if (icon) {
+            const iconElement = document.createElement('span');
+            iconElement.className = 'material-icons';
+            iconElement.style.fontSize = '1em';
+            iconElement.style.lineHeight = '1';
+            iconElement.textContent = icon;
+            htmlButton.appendChild(iconElement);
+        }
+
+        if (text) {
+            const textElement = document.createElement('span');
+            textElement.textContent = text;
+            htmlButton.appendChild(textElement);
+        }
     }
 
     static initElementColor(bkcolor, color, ele) {

--- a/client/src/app/gauges/gauge-property/gauge-property.component.html
+++ b/client/src/app/gauges/gauge-property/gauge-property.component.html
@@ -24,7 +24,15 @@
 						</div>
 						<div class="my-form-field ml10" *ngIf="isTextToShow()">
 							<span>{{'gauges.property-text' | translate}}</span>
-							<input [(ngModel)]="property.text" style="width: 270px" type="text" placeholder="{{'gauges.property-language-text' | translate}}">
+							<input [(ngModel)]="property.text" style="width: 250px" type="text" placeholder="{{'gauges.property-language-text' | translate}}">
+						</div>
+						<div class="my-form-field ml10" *ngIf="isButton()">
+							<span>{{'gauges.property-icon' | translate}}</span>
+							<app-icon-selector
+								[(value)]="property.icon"
+								[filterPlaceholder]="'gauges.property-icons-filter'"
+								(selected)="property.image = ''">
+							</app-icon-selector>
 						</div>
 						<div class="my-form-field" style="padding-left: 100px" *ngIf="isReadonlyToShow()">
 							<span>{{'gauges.property-readonly' | translate}}</span>

--- a/client/src/app/gauges/gauge-property/gauge-property.component.html
+++ b/client/src/app/gauges/gauge-property/gauge-property.component.html
@@ -26,7 +26,7 @@
 							<span>{{'gauges.property-text' | translate}}</span>
 							<input [(ngModel)]="property.text" style="width: 250px" type="text" placeholder="{{'gauges.property-language-text' | translate}}">
 						</div>
-						<div class="my-form-field ml10" *ngIf="isButton()">
+						<div class="my-form-field ml10 icon-property-field" *ngIf="isButton()">
 							<span>{{'gauges.property-icon' | translate}}</span>
 							<app-icon-selector
 								[(value)]="property.icon"

--- a/client/src/app/gauges/gauge-property/gauge-property.component.scss
+++ b/client/src/app/gauges/gauge-property/gauge-property.component.scss
@@ -37,4 +37,8 @@
   .mat-tab-container > div {
     display: block;
   }
+
+  .icon-property-field {
+    vertical-align: bottom;
+  }
 }

--- a/client/src/app/gauges/gauge-property/gauge-property.component.ts
+++ b/client/src/app/gauges/gauge-property/gauge-property.component.ts
@@ -10,6 +10,7 @@ import { PropertyType } from './flex-input/flex-input.component';
 import { PermissionData, PermissionDialogComponent } from './permission-dialog/permission-dialog.component';
 import { SettingsService } from '../../_services/settings.service';
 import { Device } from '../../_models/device';
+import { HtmlButtonComponent } from '../controls/html-button/html-button.component';
 
 @Component({
     selector: 'gauge-property',
@@ -137,6 +138,10 @@ export class GaugePropertyComponent implements AfterViewInit {
 
     isTextToShow() {
         return this.data.languageTextEnabled || (this.dialogType === GaugeDialogType.RangeAndText);
+    }
+
+    isButton() {
+        return this.data.settings?.type === HtmlButtonComponent.TypeTag;
     }
 
     isAlarmToShow() {

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1305,6 +1305,8 @@
     "gauges.property-input-convertion-string": "String",
     "gauges.property-input-maxlength": "Max length",
     "gauges.property-input-readonly": "Readonly",
+    "gauges.property-icon": "Icon",
+    "gauges.property-icons-filter": "Icons Filter",
 
     "gauges.property-update-enabled": "Enable update",
     "gauges.property-update-esc": "ESC update",


### PR DESCRIPTION
## Summary
- Add optional `icon` fields to gauge button properties
- Render HTML buttons with a configured Material icon

<img width="288" height="81" alt="image" src="https://github.com/user-attachments/assets/24c25d81-ba18-4767-9b85-f8ac91f171ac" />

<img width="830" height="194" alt="image" src="https://github.com/user-attachments/assets/5dcd042e-8b06-47f9-8ef1-0f36397ee61a" />
