### PR TITLE
Add support for view parameters in header page events

### DIFF
--- a/client/src/app/fuxa-view/fuxa-view.component.ts
+++ b/client/src/app/fuxa-view/fuxa-view.component.ts
@@ -146,8 +146,9 @@ export class FuxaViewComponent implements OnInit, AfterViewInit, OnDestroy {
         }
     }
 
-    private loadVariableMapping(variablesMapped?: any) {
+    public loadVariableMapping(variablesMapped?: any) {
         try {
+            this.plainVariableMapping = {};
             if (variablesMapped) {
                 this.variablesMapping = variablesMapped;
             }

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -193,11 +193,11 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
         });
     }
 
-    onGoToPage(viewId: string, force: boolean = false) {
+    onGoToPage(viewId: string, force: boolean = false, options: any = {}) {
         if (viewId === this.viewAsAlarms) {
             this.onAlarmsShowMode('expand');
             this.checkToCloseSideNav();
-        } else if (!this.homeView || viewId !== this.homeView?.id || force || this.fuxaview?.view?.id !== viewId) {
+        } else if (!this.homeView || viewId !== this.homeView?.id || force || this.fuxaview?.view?.id !== viewId || this.hasPageOptions(options)) {
             const view = this.hmi.views.find(x => x.id === viewId);
             this.setIframe();
             this.showHomeLink = false;
@@ -209,6 +209,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
                 if (this.homeView.type !== this.cardViewType && this.homeView.type !== this.mapsViewType) {
                     this.checkZoom();
                     this.fuxaview.hmi.layout = this.hmi.layout;
+                    this.applyPageOptions(options);
                     this.fuxaview.loadHmi(this.homeView);
                 } else if (this.cardsview) {
                     this.cardsview.reload();
@@ -217,6 +218,18 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
             this.onAlarmsShowMode('close');
             this.checkToCloseSideNav();
         }
+    }
+
+    private hasPageOptions(options: any): boolean {
+        return !!(options?.variablesMapping || options?.sourceDeviceId);
+    }
+
+    private applyPageOptions(options: any = {}) {
+        if (!this.fuxaview) {
+            return;
+        }
+        this.fuxaview.sourceDeviceId = options?.sourceDeviceId;
+        this.fuxaview.loadVariableMapping(options?.variablesMapping ?? []);
     }
 
     onGoToLink(event: string) {
@@ -496,17 +509,17 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
         ev: Event,
         events: GaugeEvent[]
     ) {
-        let fuxaviewRef = this.fuxaview ?? this.cardsview.getFuxaView(0);
+        const homeEvents = events.filter(event => event.action === 'onpage');
+        homeEvents.forEach(event => {
+            this.onGoToPage(event.actparam, this.hasPageOptions(event.actoptions), event.actoptions);
+        });
+        const fuxaViewEvents = events.filter(event => event.action !== 'onpage');
+        let fuxaviewRef = this.fuxaview ?? this.cardsview?.getFuxaView(0);
         if (!fuxaviewRef) {
             return;
         }
-        const homeEvents = events.filter(event => event.action === 'onpage');
-        homeEvents.forEach(event => {
-            this.onGoToPage(event.actparam);
-        });
-        const fuxaViewEvents = events.filter(event => event.action !== 'onpage');
         if (fuxaViewEvents.length > 0) {
-            fuxaviewRef.runEvents(fuxaviewRef, ga, ev, events);
+            fuxaviewRef.runEvents(fuxaviewRef, ga, ev, fuxaViewEvents);
         }
     }
 


### PR DESCRIPTION
## 📌 Description
Add device and tag parameters to header navigation

Header buttons can now open a view while passing the selected device or
tag mapping to it. This makes it possible to reuse the same view from the
header with different device/tag contexts.

The header event handling was also made more robust when buttons use
authorization settings and no card view is currently available, fix #2335

[open-page-card-placeholder.json](https://github.com/user-attachments/files/27655172/open-page-card-placeholder.json)

