### PR TITLE
fix(docker): add missing ODBC runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ WORKDIR /usr/src/app/FUXA/odbc
 COPY odbc/ ./
 RUN if [ "$INSTALL_ODBC" = "true" ]; then \
     dos2unix install_odbc_drivers.sh && chmod +x install_odbc_drivers.sh && ./install_odbc_drivers.sh; \
-    fi
+    fi \
+    && mkdir -p /usr/lib/odbc /opt/microsoft
 
 # 3. Copy server source, build, then cleanup
 WORKDIR /usr/src/app/FUXA/server
@@ -51,10 +52,19 @@ ARG INSTALL_ODBC=true
 WORKDIR /usr/src/app/FUXA
 
 # Install ONLY runtime libraries
-RUN apt-get update && apt-get install -y \
-    sqlite3 libsqlite3-0 \
-    $( [ "$INSTALL_ODBC" = "true" ] && echo "unixodbc" ) \
+RUN apt-get update \
+    && apt-get install -y \
+        sqlite3 libsqlite3-0 \
+        $( [ "$INSTALL_ODBC" = "true" ] && echo "unixodbc odbc-mariadb odbc-postgresql libsqliteodbc tdsodbc" ) \
+    && if [ "$INSTALL_ODBC" = "true" ]; then \
+        mkdir -p /usr/lib/odbc && \
+        find /usr/lib -path '*/odbc/*.so' -exec cp {} /usr/lib/odbc/ \; ; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy MySQL and MSSQL ODBC drivers from builder (not available in Debian repos)
+COPY --from=server-builder /usr/lib/odbc/ /usr/lib/odbc/
+COPY --from=server-builder /opt/microsoft/ /opt/microsoft/
 
 # 1. Copy Server
 COPY --from=server-builder /usr/src/app/FUXA/server ./server


### PR DESCRIPTION
## 📌 Description

Install odbc-postgresql, libsqliteodbc, tdsodbc and odbc-mariadb in the runner stage and collect their drivers into /usr/lib/odbc/. Copy MySQL Connector/ODBC and MSSQL drivers from the builder stage since they are not available in Debian repos.

Fixes #2282

---

## 🧪 Type of Change

- [x] Bug fix

---

## 🚫 Build Artifacts Check

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [x] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

Tested on x64 via windows11. Verified all 9 drivers registered in odbcinst.ini are present in the final image via `odbcinst -q -d`.

```pwsh
PS C:\Users\soragoto\FUXA> docker run --rm fuxa-test sh -c 'odbcinst -q -d'
[MySQL]
[MySQL ANSI]
[PostgreSQL]
[PostgreSQL ANSI]
[SQLite]
[SQLite3]
[FreeTDS]
[MSSQL]
[MariaDB]
PS C:\Users\soragoto\FUXA> docker run --rm fuxa-test sh -c 'ls -la /usr/lib/odbc'
total 50004
drwxr-xr-x 1 root root     4096 May 25 12:30 .
drwxr-xr-x 1 root root     4096 May 25 12:29 ..
-rw-r--r-- 1 root root   336208 May 25 12:29 libmaodbc.so
-rwxr-xr-x 1 root root 24524112 May 25 12:30 libmyodbc8a.so
-rwxr-xr-x 1 root root 24543144 May 25 12:30 libmyodbc8w.so
-rw-r--r-- 1 root root   198128 May 25 12:29 libsqlite3odbc-0.9998.so
lrwxrwxrwx 1 root root       24 May 25 12:29 libsqlite3odbc.so -> libsqlite3odbc-0.9998.so
-rw-r--r-- 1 root root   470360 May 25 12:29 libtdsodbc.so
drwxr-xr-x 2 root root     4096 May 25 12:30 private
-rw-r--r-- 1 root root   535600 May 25 12:29 psqlodbca.so
-rw-r--r-- 1 root root   572512 May 25 12:29 psqlodbcw.so
```