### PR TITLE
Header bar and items height configurable

### DIFF
--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -127,6 +127,8 @@ export class HeaderSettings {
     infos: NotificationModeType;
     bkcolor = '#ffffff';
     fgcolor = '#000000';
+    height = 46;
+    buttonHeight = 36;
     fontFamily: string;
     fontSize = 13;
     items: HeaderItem[];
@@ -145,6 +147,7 @@ export interface HeaderItem {
     fgcolor: string;
     marginLeft: number;
     marginRight: number;
+    height?: number;
     property: GaugeProperty;
     status: GaugeStatus;
     element: HTMLElement;

--- a/client/src/app/_models/hmi.ts
+++ b/client/src/app/_models/hmi.ts
@@ -122,13 +122,16 @@ export class NaviItem {
 }
 
 export class HeaderSettings {
+    static readonly DefaultHeight = 46;
+    static readonly DefaultButtonHeight = 36;
+
     title: string;
     alarms: NotificationModeType;
     infos: NotificationModeType;
     bkcolor = '#ffffff';
     fgcolor = '#000000';
-    height = 46;
-    buttonHeight = 36;
+    height = HeaderSettings.DefaultHeight;
+    buttonHeight = HeaderSettings.DefaultButtonHeight;
     fontFamily: string;
     fontSize = 13;
     items: HeaderItem[];

--- a/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.html
+++ b/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.html
@@ -6,41 +6,51 @@
             <span>{{'dlg.headeritem-icon' | translate}}</span>
             <app-icon-selector
                 [(value)]="item.icon"
+                [image]="item.image"
+                [allowImage]="true"
+                [imageLabel]="'dlg.menuitem-image'"
                 [filterPlaceholder]="'dlg.headeritem-icons-filter'"
-                (selected)="item.image = ''">
+                (selected)="item.image = ''"
+                (imageSelected)="onSetImage($event)">
             </app-icon-selector>
         </div>
-        <div class="block mt10">
-            <div class="my-form-field ftl">
+        <div class="header-item-row mt10">
+            <div class="my-form-field type-field">
                 <span>{{'dlg.layout-lbl-type' | translate}}</span>
-                <mat-select [(ngModel)]="item.type" style="width: 120px">
+                <mat-select [(ngModel)]="item.type">
                     <mat-option *ngFor="let type of headerType" [value]="type">
                         {{ 'item.headertype-' + type | translate }}
                     </mat-option>
                 </mat-select>
             </div>
-            <div class="ftr ml10">
-                <div class="my-form-field lbk field-input-60">
-                    <span>{{'dlg.layout-lbl-margin-left' | translate}}</span>
-                    <input numberOnly [(ngModel)]="item.marginLeft" min="0" step="1" type="number">
-                </div>
-                <div class="my-form-field lbk field-input-60 ml5">
-                    <span>{{'dlg.layout-lbl-margin-right' | translate}}</span>
-                    <input numberOnly [(ngModel)]="item.marginRight" min="0" step="1" type="number">
-                </div>
+            <div class="my-form-field field-input-70">
+                <span>{{'dlg.layout-lbl-height' | translate}}</span>
+                <input numberOnly [(ngModel)]="item.height" min="20" max="100" step="1" type="number">
             </div>
         </div>
-        <div class="my-form-field ftl mt10">
-            <span>{{'dlg.layout-nav-bkcolor' | translate}}</span>
-            <input [(colorPicker)]="item.bkcolor" [style.background]="item.bkcolor" [cpAlphaChannel]="'always'" class="input-color" [cpPresetColors]="defaultColor"
-                [cpOKButton]="true" [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButtonText]="'OK'"
-                [cpOKButtonClass]="'cpOKButtonClass'" style="width:120px;" [cpPosition]="'bottom'" />
+        <div class="header-item-row mt10">
+            <div class="my-form-field field-input-70">
+                <span>{{'dlg.layout-lbl-margin-left' | translate}}</span>
+                <input numberOnly [(ngModel)]="item.marginLeft" min="0" step="1" type="number">
+            </div>
+            <div class="my-form-field field-input-70">
+                <span>{{'dlg.layout-lbl-margin-right' | translate}}</span>
+                <input numberOnly [(ngModel)]="item.marginRight" min="0" step="1" type="number">
+            </div>
         </div>
-        <div class="my-form-field ftr mt10">
-            <span>{{'dlg.layout-nav-fgcolor' | translate}}</span>
-            <input [(colorPicker)]="item.fgcolor" [style.background]="item.fgcolor" [cpAlphaChannel]="'always'" class="input-color" [cpPresetColors]="defaultColor"
-                [cpOKButton]="true" [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButtonText]="'OK'"
-                [cpOKButtonClass]="'cpOKButtonClass'" style="width:120px;" [cpPosition]="'bottom'" />
+        <div class="header-item-row mt10">
+            <div class="my-form-field color-field">
+                <span>{{'dlg.layout-nav-bkcolor' | translate}}</span>
+                <input [(colorPicker)]="item.bkcolor" [style.background]="item.bkcolor" [cpAlphaChannel]="'always'" class="input-color" [cpPresetColors]="defaultColor"
+                    [cpOKButton]="true" [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButtonText]="'OK'"
+                    [cpOKButtonClass]="'cpOKButtonClass'" [cpPosition]="'bottom'" />
+            </div>
+            <div class="my-form-field color-field">
+                <span>{{'dlg.layout-nav-fgcolor' | translate}}</span>
+                <input [(colorPicker)]="item.fgcolor" [style.background]="item.fgcolor" [cpAlphaChannel]="'always'" class="input-color" [cpPresetColors]="defaultColor"
+                    [cpOKButton]="true" [cpCancelButton]="true" [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButtonText]="'OK'"
+                    [cpOKButtonClass]="'cpOKButtonClass'" [cpPosition]="'bottom'" />
+            </div>
         </div>
     </div>
     <div mat-dialog-actions class="dialog-action">

--- a/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.scss
+++ b/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.scss
@@ -1,7 +1,34 @@
 :host {
+    .header-item-row {
+        display: grid;
+        grid-template-columns: 120px 120px;
+        column-gap: 10px;
+        align-items: end;
+    }
+
+    .type-field {
+        mat-select {
+            width: 120px;
+        }
+    }
+
     .field-input-60 {
         input {
             width: 60px;
+        }
+    }
+
+    .field-input-70 {
+        input {
+            box-sizing: border-box;
+            width: 120px;
+        }
+    }
+
+    .color-field {
+        input {
+            box-sizing: border-box;
+            width: 120px;
         }
     }
 }

--- a/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.ts
+++ b/client/src/app/editor/layout-property/layout-header-item-property/layout-header-item-property.component.ts
@@ -1,8 +1,9 @@
-import { Component, Inject } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject } from '@angular/core';
 import { MatDialogRef as MatDialogRef, MAT_DIALOG_DATA as MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { HeaderItem, HeaderItemType } from '../../../_models/hmi';
 import { ProjectService } from '../../../_services/project.service';
 import { Utils } from '../../../_helpers/utils';
+import { UploadFile } from '../../../_models/project';
 
 @Component({
     selector: 'app-layout-header-item-property',
@@ -16,6 +17,7 @@ export class LayoutHeaderItemPropertyComponent {
 
     constructor(
         public projectService: ProjectService,
+        private cdr: ChangeDetectorRef,
         public dialogRef: MatDialogRef<LayoutHeaderItemPropertyComponent>,
         @Inject(MAT_DIALOG_DATA) public data: HeaderItem) {
 
@@ -27,6 +29,38 @@ export class LayoutHeaderItemPropertyComponent {
     }
 
     onOkClick(): void {
+        if (this.item.height === null || this.item.height === undefined || `${this.item.height}` === '') {
+            delete this.item.height;
+        }
         this.dialogRef.close(this.item);
+    }
+
+    /**
+     * add image to view
+     * @param event selected file
+     */
+    onSetImage(event) {
+        if (event.target.files) {
+            let filename = event.target.files[0].name;
+            let fileToUpload = { type: filename.split('.').pop().toLowerCase(), name: filename.split('/').pop(), data: null };
+            let reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    fileToUpload.data = reader.result;
+                    this.projectService.uploadFile(fileToUpload).subscribe((result: UploadFile) => {
+                        this.item.image = result.location;
+                        this.item.icon = 'image';
+                        this.cdr.detectChanges();
+                    });
+                } catch (err) {
+                    console.error(err);
+                }
+            };
+            if (fileToUpload.type === 'svg') {
+                reader.readAsText(event.target.files[0]);
+            } else {
+                reader.readAsDataURL(event.target.files[0]);
+            }
+        }
     }
 }

--- a/client/src/app/editor/layout-property/layout-property.component.html
+++ b/client/src/app/editor/layout-property/layout-property.component.html
@@ -223,8 +223,8 @@
             <mat-tab label="{{'dlg.layout-header' | translate}}">
                 <div class="tab-container">
                     <div class="header-layout"
-                         [style.--header-height]="data.layout.header.height + 'px'"
-                         [style.--header-button-height]="data.layout.header.buttonHeight + 'px'"
+                         [style.--header-height]="data.layout.header.height ? data.layout.header.height + 'px' : null"
+                         [style.--header-button-height]="data.layout.header.buttonHeight ? data.layout.header.buttonHeight + 'px' : null"
                          [style.background-color]="data.layout.header.bkcolor"
                          [style.color]="data.layout.header.fgcolor">
                         <div class="header-menu">
@@ -479,6 +479,6 @@
     </div>
     <div mat-dialog-actions class="dialog-action">
         <button mat-raised-button [mat-dialog-close]="">{{'dlg.cancel' | translate}}</button>
-        <button mat-raised-button color="primary" [mat-dialog-close]="data" cdkFocusInitial>{{'dlg.ok' | translate}}</button>
+        <button mat-raised-button color="primary" (click)="onOkClick()" cdkFocusInitial>{{'dlg.ok' | translate}}</button>
     </div>
 </div>

--- a/client/src/app/editor/layout-property/layout-property.component.html
+++ b/client/src/app/editor/layout-property/layout-property.component.html
@@ -222,7 +222,11 @@
             </mat-tab>
             <mat-tab label="{{'dlg.layout-header' | translate}}">
                 <div class="tab-container">
-                    <div class="header-layout" [style.background-color]="data.layout.header.bkcolor" [style.color]="data.layout.header.fgcolor">
+                    <div class="header-layout"
+                         [style.--header-height]="data.layout.header.height + 'px'"
+                         [style.--header-button-height]="data.layout.header.buttonHeight + 'px'"
+                         [style.background-color]="data.layout.header.bkcolor"
+                         [style.color]="data.layout.header.fgcolor">
                         <div class="header-menu">
                             <button mat-icon-button
                                     [style.background-color]="data.layout.header.bkcolor"
@@ -230,41 +234,56 @@
                                 <mat-icon aria-label="Menu">menu</mat-icon>
                             </button>
                         </div>
-                        <div class="header-items-button" [style.textAlign]="data.layout.header.itemsAnchor">
+                        <div class="header-items-button"
+                             [style.textAlign]="data.layout.header.itemsAnchor"
+                             [style.justifyContent]="data.layout.header.itemsAnchor === 'right' ? 'flex-end' : data.layout.header.itemsAnchor">
                             <ng-container *ngFor="let item of headerItems; let i = index" [ngSwitch]="item.type">
                                 <ng-container *ngSwitchCase="'button'">
                                     <button mat-raised-button
+                                            [style.--header-item-button-height]="item.height ? item.height + 'px' : null"
                                             [style.background-color]="item.bkcolor ?? data.layout.header.bkcolor"
                                             [style.color]="item.fgcolor ?? data.layout.header.fgcolor"
                                             [style.fontFamily]="data.layout.header.fontFamily"
                                             [style.fontSize]="data.layout.header.fontSize + 'px !important'"
                                             [style.marginLeft.px]="item.marginLeft"
                                             [style.marginRight.px]="item.marginRight">
-                                        <mat-icon *ngIf="item.icon"
-                                                  style="font-size: 1.5rem; height: 1.5rem; width: 1.5rem;">
-                                            {{item.icon}}
-                                        </mat-icon>
+                                        <img *ngIf="item.image; else headerButtonIcon" class="header-item-button-image" [src]="item.image" alt="">
+                                        <ng-template #headerButtonIcon>
+                                            <mat-icon *ngIf="item.icon"
+                                                      class="header-item-icon">
+                                                {{item.icon}}
+                                            </mat-icon>
+                                        </ng-template>
                                         {{ item.property?.text ?? item.type }}
                                     </button>
                                 </ng-container>
                                 <ng-container *ngSwitchCase="'label'">
                                     <button mat-button
+                                            [style.--header-item-button-height]="item.height ? item.height + 'px' : null"
                                             [style.background-color]="item.bkcolor ?? data.layout.header.bkcolor"
                                             [style.color]="item.fgcolor ?? data.layout.header.fgcolor"
                                             [style.fontFamily]="data.layout.header.fontFamily"
                                             [style.fontSize]="data.layout.header.fontSize + 'px !important'"
                                             [style.marginLeft.px]="item.marginLeft"
                                             [style.marginRight.px]="item.marginRight">
+                                        <img *ngIf="item.image; else headerLabelIcon" class="header-item-label-image" [src]="item.image" alt="">
+                                        <ng-template #headerLabelIcon>
+                                            <mat-icon *ngIf="item.icon" class="header-item-icon">{{item.icon}}</mat-icon>
+                                        </ng-template>
                                         {{ item.property?.text ?? item.type }}
                                     </button>
                                 </ng-container>
                                 <ng-container *ngSwitchCase="'image'">
                                     <button mat-icon-button
+                                            [style.--header-item-button-height]="item.height ? item.height + 'px' : null"
                                             [style.background-color]="item.bkcolor ?? data.layout.header.bkcolor"
                                             [style.color]="item.fgcolor ?? data.layout.header.fgcolor"
                                             [style.marginLeft.px]="item.marginLeft"
                                             [style.marginRight.px]="item.marginRight">
-                                        <mat-icon>{{ item.icon }}</mat-icon>
+                                        <img *ngIf="item.image; else headerImageIcon" class="header-item-image" [src]="item.image" alt="">
+                                        <ng-template #headerImageIcon>
+                                            <mat-icon class="header-item-icon">{{ item.icon }}</mat-icon>
+                                        </ng-template>
                                     </button>
                                 </ng-container>
                             </ng-container>
@@ -410,16 +429,22 @@
                                 </div>
                                 <div class="my-form-field lbk ml15">
                                     <span>{{'dlg.layout-lbl-font-size' | translate}}</span>
-                                    <input numberOnly [(ngModel)]="data.layout.header.fontSize" max="20" min="10" step="1" type="number">
+                                    <input numberOnly class="header-size-input" [(ngModel)]="data.layout.header.fontSize" max="20" min="10" step="1" type="number">
                                 </div>
                             </div>
                             <div class="my-form-field block mt10">
-                                <span>{{'dlg.layout-lbl-anchor' | translate}}</span>
-                                <mat-select [(ngModel)]="data.layout.header.itemsAnchor" style="width: 260px">
-                                    <mat-option *ngFor="let type of anchorType" [value]="type">
-                                        {{ 'item.headeranchor-' + type | translate }}
-                                    </mat-option>
-                                </mat-select>
+                                <div class="my-form-field lbk">
+                                    <span>{{'dlg.layout-lbl-anchor' | translate}}</span>
+                                    <mat-select [(ngModel)]="data.layout.header.itemsAnchor" style="width: 180px">
+                                        <mat-option *ngFor="let type of anchorType" [value]="type">
+                                            {{ 'item.headeranchor-' + type | translate }}
+                                        </mat-option>
+                                    </mat-select>
+                                </div>
+                                <div class="my-form-field lbk ml15">
+                                    <span>{{'dlg.layout-lbl-button-height' | translate}}</span>
+                                    <input numberOnly class="header-size-input" [(ngModel)]="data.layout.header.buttonHeight" max="100" min="20" step="1" type="number">
+                                </div>
                             </div>
                             <div class="colors block">
                                 <div class="my-form-field inbk">
@@ -435,6 +460,10 @@
                                         class="input-color" [cpPresetColors]="defaultColor" [cpOKButton]="true" [cpCancelButton]="true"
                                         [cpCancelButtonClass]="'cpCancelButtonClass'" [cpCancelButtonText]="'Cancel'" [cpOKButtonText]="'OK'" [cpOKButtonClass]="'cpOKButtonClass'"
                                         style="width:100px;" [cpPosition]="'bottom'" />
+                                </div>
+                                <div class="my-form-field inbk ml10">
+                                    <span>{{'dlg.layout-lbl-height' | translate}}</span>
+                                    <input numberOnly class="header-size-input" [(ngModel)]="data.layout.header.height" max="120" min="32" step="1" type="number">
                                 </div>
                             </div>
                         </div>

--- a/client/src/app/editor/layout-property/layout-property.component.scss
+++ b/client/src/app/editor/layout-property/layout-property.component.scss
@@ -2,6 +2,7 @@
     .content {
         min-width: 950px;
         min-height: 700px;
+        box-sizing: border-box;
     }
 
     .tab-container {
@@ -94,19 +95,53 @@
     .header-layout {
         display: flex;
         box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2) !important;
-        height: 46px !important;
-        line-height: 46px;
+        height: var(--header-height, 46px);
+        line-height: var(--header-height, 46px);
         padding-left: 4px;
         padding-right: 10px;
         background-color: rgba(255, 255, 255, 1);
 
+        button[mat-button],
+        button[mat-raised-button],
+        button[mat-icon-button] {
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            min-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            line-height: normal;
+        }
+
+        button[mat-icon-button] {
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            padding: 0;
+        }
+
+        ::ng-deep .mat-mdc-icon-button {
+            --mdc-icon-button-state-layer-size: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            padding: 0;
+            line-height: var(--header-item-button-height, var(--header-button-height, 36px));
+        }
+
+        ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target {
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+        }
+
+        ::ng-deep .mat-mdc-icon-button mat-icon {
+            width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+        }
+
         .header-menu {
             display: flex;
             align-items: center;
-            height: 46px;
+            height: var(--header-height, 46px);
+            margin-right: 8px;
 
             mat-icon {
-                line-height: 24px;
+                line-height: calc(var(--header-button-height, 36px) - 8px);
             }
         }
 
@@ -115,12 +150,12 @@
             margin-left: 20px;
             min-width: 200px;
             text-align: right;
-            line-height: 46px
+            line-height: var(--header-height, 46px);
         }
 
         .header-login {
             display: flex;
-            line-height: 46px;
+            line-height: var(--header-height, 46px);
             align-items: center;
             border-left-width: 1px;
             border-left-style: solid;
@@ -130,7 +165,7 @@
                 display: flex;
                 flex-direction: column;
                 justify-content: center;
-                height: 46px;
+                height: var(--header-height, 46px);
             }
 
             .primary {
@@ -170,7 +205,7 @@
             padding-left: 10px;
             padding-right: 10px;
             display: flex;
-            line-height: 46px;
+            line-height: var(--header-height, 46px);
             align-items: center;
             gap: 4px;
 
@@ -184,7 +219,7 @@
 
         .header-notify-button {
             display: flex;
-            line-height: 46px;
+            line-height: var(--header-height, 46px);
             text-align: right;
             margin-left: 10px;
             margin-right: 10px;
@@ -192,9 +227,9 @@
             align-items: center;
 
             mat-icon {
-                font-size: 28px;
-                width: 28px;
-                height: 28px;
+                font-size: calc(var(--header-button-height, 36px) - 8px);
+                width: calc(var(--header-button-height, 36px) - 8px);
+                height: calc(var(--header-button-height, 36px) - 8px);
             }
 
             .alarm-button, .info-button {
@@ -206,7 +241,54 @@
             flex: 1;
             align-items: center;
             display: flex;
-            line-height: 46px;
+            line-height: var(--header-height, 46px);
+
+            .header-item-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                vertical-align: middle;
+            }
+
+            .header-item-button-image,
+            .header-item-label-image,
+            .header-item-icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                vertical-align: middle;
+            }
+
+            .header-item-button-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                object-fit: contain;
+            }
+
+            .header-item-label-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 14px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 10px);
+                object-fit: contain;
+            }
+
+            .header-item-icon {
+                width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+            }
+
+            ::ng-deep .mat-mdc-button,
+            ::ng-deep .mat-mdc-raised-button {
+                line-height: normal;
+            }
+
+            ::ng-deep .mat-mdc-button .mdc-button__label,
+            ::ng-deep .mat-mdc-raised-button .mdc-button__label {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                line-height: normal;
+            }
         }
     }
 
@@ -288,7 +370,12 @@
             .colors {
                 display: block;
                 margin-top: 10px;
-                width: 268px
+                width: 330px;
+            }
+
+            .header-size-input {
+                box-sizing: border-box;
+                width: 65px;
             }
         }
     }

--- a/client/src/app/editor/layout-property/layout-property.component.scss
+++ b/client/src/app/editor/layout-property/layout-property.component.scss
@@ -95,53 +95,65 @@
     .header-layout {
         display: flex;
         box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2) !important;
-        height: var(--header-height, 46px);
-        line-height: var(--header-height, 46px);
+        --default-header-height: 46px;
+        --default-header-button-height: 36px;
+        height: var(--header-height, var(--default-header-height));
+        line-height: var(--header-height, var(--default-header-height));
         padding-left: 4px;
         padding-right: 10px;
         background-color: rgba(255, 255, 255, 1);
+        --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+        --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+        --header-item-icon-size: calc(var(--effective-header-button-height) - 12px);
+        --header-label-icon-size: calc(var(--effective-header-button-height) - 14px);
 
         button[mat-button],
         button[mat-raised-button],
         button[mat-icon-button] {
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
-            min-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+            --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+            --header-item-icon-size: calc(var(--effective-header-button-height) - 12px);
+            --header-label-icon-size: calc(var(--effective-header-button-height) - 14px);
+            height: var(--effective-header-button-height);
+            min-height: var(--effective-header-button-height);
             line-height: normal;
         }
 
         button[mat-icon-button] {
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--effective-header-button-height);
             padding: 0;
         }
 
         ::ng-deep .mat-mdc-icon-button {
-            --mdc-icon-button-state-layer-size: var(--header-item-button-height, var(--header-button-height, 36px));
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+            --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+            --mdc-icon-button-state-layer-size: var(--effective-header-button-height);
+            width: var(--effective-header-button-height);
+            height: var(--effective-header-button-height);
             padding: 0;
-            line-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            line-height: var(--effective-header-button-height);
         }
 
         ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target {
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--effective-header-button-height);
+            height: var(--effective-header-button-height);
         }
 
         ::ng-deep .mat-mdc-icon-button mat-icon {
-            width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            width: var(--header-button-icon-size);
+            height: var(--header-button-icon-size);
+            font-size: var(--header-button-icon-size);
+            line-height: var(--header-button-icon-size);
         }
 
         .header-menu {
             display: flex;
             align-items: center;
-            height: var(--header-height, 46px);
+            height: var(--header-height, var(--default-header-height));
             margin-right: 8px;
 
             mat-icon {
-                line-height: calc(var(--header-button-height, 36px) - 8px);
+                line-height: var(--header-button-icon-size);
             }
         }
 
@@ -150,12 +162,12 @@
             margin-left: 20px;
             min-width: 200px;
             text-align: right;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
         }
 
         .header-login {
             display: flex;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
             align-items: center;
             border-left-width: 1px;
             border-left-style: solid;
@@ -165,7 +177,7 @@
                 display: flex;
                 flex-direction: column;
                 justify-content: center;
-                height: var(--header-height, 46px);
+                height: var(--header-height, var(--default-header-height));
             }
 
             .primary {
@@ -205,7 +217,7 @@
             padding-left: 10px;
             padding-right: 10px;
             display: flex;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
             align-items: center;
             gap: 4px;
 
@@ -219,7 +231,7 @@
 
         .header-notify-button {
             display: flex;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
             text-align: right;
             margin-left: 10px;
             margin-right: 10px;
@@ -227,9 +239,9 @@
             align-items: center;
 
             mat-icon {
-                font-size: calc(var(--header-button-height, 36px) - 8px);
-                width: calc(var(--header-button-height, 36px) - 8px);
-                height: calc(var(--header-button-height, 36px) - 8px);
+                font-size: var(--header-button-icon-size);
+                width: var(--header-button-icon-size);
+                height: var(--header-button-icon-size);
             }
 
             .alarm-button, .info-button {
@@ -241,11 +253,11 @@
             flex: 1;
             align-items: center;
             display: flex;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
 
             .header-item-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-height: var(--header-button-icon-size);
+                max-width: var(--header-button-icon-size);
                 vertical-align: middle;
             }
 
@@ -259,22 +271,22 @@
             }
 
             .header-item-button-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-height: var(--header-item-icon-size);
+                max-width: var(--header-button-icon-size);
                 object-fit: contain;
             }
 
             .header-item-label-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 14px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 10px);
+                max-height: var(--header-label-icon-size);
+                max-width: calc(var(--effective-header-button-height) - 10px);
                 object-fit: contain;
             }
 
             .header-item-icon {
-                width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                width: var(--header-item-icon-size);
+                height: var(--header-item-icon-size);
+                font-size: var(--header-item-icon-size);
+                line-height: var(--header-item-icon-size);
             }
 
             ::ng-deep .mat-mdc-button,

--- a/client/src/app/editor/layout-property/layout-property.component.ts
+++ b/client/src/app/editor/layout-property/layout-property.component.ts
@@ -275,6 +275,19 @@ export class LayoutPropertyComponent implements OnInit, OnDestroy {
         this.dialogRef.close();
     }
 
+    onOkClick(): void {
+        this.normalizeHeaderSize('height');
+        this.normalizeHeaderSize('buttonHeight');
+        this.dialogRef.close(this.data);
+    }
+
+    private normalizeHeaderSize(property: 'height' | 'buttonHeight'): void {
+        const value = this.data.layout.header?.[property];
+        if (value === null || value === undefined || `${value}` === '') {
+            delete (this.data.layout.header as any)[property];
+        }
+    }
+
     toggleSubMenu(item: NaviItem) {
         if (item.id && item.children?.length) {
             if (this.expandedItems.has(item.id)) {

--- a/client/src/app/editor/setup/setup.component.ts
+++ b/client/src/app/editor/setup/setup.component.ts
@@ -92,6 +92,9 @@ export class SetupComponent {
         }
         let dialogRef = this.dialog.open(LayoutPropertyComponent, {
             position: { top: '60px' },
+            width: '80vw',
+            minWidth: '950px',
+            maxWidth: 'none',
             data: <ILayoutPropertyData>{ layout: templayout, views: hmi.views, securityEnabled: this.projectService.isSecurityEnabled() }
         });
         dialogRef.afterClosed().subscribe(result => {

--- a/client/src/app/framework/icon-selector/icon-selector.component.html
+++ b/client/src/app/framework/icon-selector/icon-selector.component.html
@@ -6,8 +6,15 @@
     [ngStyle]="{ width: width, height: height }"
     #iconsel>
     <mat-select-trigger>
-        <mat-icon>{{iconsel.value}}</mat-icon>
+        <img *ngIf="image; else iconTrigger" class="icon-selector-image" [src]="image" alt="">
+        <ng-template #iconTrigger>
+            <mat-icon>{{iconsel.value}}</mat-icon>
+        </ng-template>
     </mat-select-trigger>
+    <mat-option *ngIf="allowImage" [value]="'image'" (click)="imagefile.value = '';imagefile.click();">
+        {{ imageLabel | translate }}
+        <input #imagefile type="file" style="display: none;" (change)="onImageSelected($event)" accept="image/png|jpg|svg" />
+    </mat-option>
     <mat-option>
         <div class="my-form-field">
             <input

--- a/client/src/app/framework/icon-selector/icon-selector.component.scss
+++ b/client/src/app/framework/icon-selector/icon-selector.component.scss
@@ -28,6 +28,12 @@
         font-size: 22px;
         line-height: 22px;
     }
+
+    .icon-selector-image {
+        max-height: 24px;
+        max-width: 24px;
+        vertical-align: middle;
+    }
 }
 
 ::ng-deep .icon-selector-panel .mat-pseudo-checkbox,

--- a/client/src/app/framework/icon-selector/icon-selector.component.ts
+++ b/client/src/app/framework/icon-selector/icon-selector.component.ts
@@ -17,6 +17,10 @@ export class IconSelectorComponent implements OnInit {
     @Input() filterPlaceholder = 'dlg.headeritem-icons-filter';
     @Input() width = '60px';
     @Input() height = '30px';
+    @Input() image: string;
+    @Input() allowImage = false;
+    @Input() imageLabel = 'dlg.menuitem-image';
+    @Output() imageSelected = new EventEmitter<Event>();
 
     icons$: Observable<string[]>;
     filteredIcons$: Observable<string[]>;
@@ -48,5 +52,11 @@ export class IconSelectorComponent implements OnInit {
         this.value = icon;
         this.valueChange.emit(icon);
         this.selected.emit(icon);
+    }
+
+    onImageSelected(event: Event) {
+        this.value = 'image';
+        this.valueChange.emit(this.value);
+        this.imageSelected.emit(event);
     }
 }

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -6,52 +6,77 @@
 	<mat-sidenav #matsidenav *ngIf="showNavigation && showSidenav" class="sidenav" [mode]="showSidenav">
 		<app-sidenav #sidenav [sidenav]="matsidenav" (goToPage)="onGoToPage($event)" (goToLink)="onGoToLink($event)"></app-sidenav>
 	</mat-sidenav>
-	<mat-sidenav-content [style.background-color]="backgroudColor" (click)="checkToCloseSideNav()">
-		<div *ngIf="showNavigation" class="header" [style.background-color]="layoutHeader.bkcolor" [style.color]="layoutHeader.fgcolor">
+	<mat-sidenav-content
+		[style.--header-height]="layoutHeader.height + 'px'"
+		[style.--header-button-height]="layoutHeader.buttonHeight + 'px'"
+		[style.background-color]="backgroudColor"
+		(click)="checkToCloseSideNav()">
+		<div *ngIf="showNavigation"
+			 class="header"
+			 [style.--header-height]="layoutHeader.height + 'px'"
+			 [style.--header-button-height]="layoutHeader.buttonHeight + 'px'"
+			 [style.background-color]="layoutHeader.bkcolor"
+			 [style.color]="layoutHeader.fgcolor">
 			<div *ngIf="showSidenav && showSidenav !== 'side'" class="header-menu">
 				<button mat-icon-button
 					(click)="$event.stopPropagation(); (matsidenav.opened) ? matsidenav.close() : matsidenav.open()">
 					<mat-icon aria-label="Menu">menu</mat-icon>
 				</button>
 			</div>
-			<div #header class="header-items-button" [style.textAlign]="layoutHeader.itemsAnchor">
+			<div #header
+				 class="header-items-button"
+				 [style.textAlign]="layoutHeader.itemsAnchor"
+				 [style.justifyContent]="layoutHeader.itemsAnchor === 'right' ? 'flex-end' : layoutHeader.itemsAnchor">
 				<ng-container *ngFor="let item of layoutHeader.items; let i = index" [ngSwitch]="item.type">
 					<ng-container *ngSwitchCase="'button'">
 						<button mat-raised-button
 								[id]="item.id"
+								[style.--header-item-button-height]="item.height ? item.height + 'px' : null"
 								[style.background-color]="item.bkcolor ?? layoutHeader.bkcolor"
 								[style.color]="item.fgcolor ?? layoutHeader.fgcolor"
 								[style.fontFamily]="layoutHeader.fontFamily"
 								[style.fontSize]="layoutHeader.fontSize + 'px !important'"
 								[style.marginLeft.px]="item.marginLeft"
 								[style.marginRight.px]="item.marginRight">
-							<mat-icon *ngIf="item.icon"
-									  style="font-size: 1.5rem; height: 1.5rem; width: 1.5rem;">
-								{{item.icon}}
-							</mat-icon>
+							<img *ngIf="item.image; else headerButtonIcon" class="header-item-button-image" [src]="item.image" alt="">
+							<ng-template #headerButtonIcon>
+								<mat-icon *ngIf="item.icon"
+										  class="header-item-icon">
+									{{item.icon}}
+								</mat-icon>
+							</ng-template>
 							{{ item.text ?? item.type }}
 						</button>
 					</ng-container>
 					<ng-container *ngSwitchCase="'label'">
 						<button mat-button
 								[id]="item.id"
+								[style.--header-item-button-height]="item.height ? item.height + 'px' : null"
 								[style.background-color]="item.bkcolor ?? layoutHeader.bkcolor"
 								[style.color]="item.fgcolor ?? layoutHeader.fgcolor"
 								[style.fontFamily]="layoutHeader.fontFamily"
 								[style.fontSize]="layoutHeader.fontSize + 'px !important'"
 								[style.marginLeft.px]="item.marginLeft"
 								[style.marginRight.px]="item.marginRight">
+							<img *ngIf="item.image; else headerLabelIcon" class="header-item-label-image" [src]="item.image" alt="">
+							<ng-template #headerLabelIcon>
+								<mat-icon *ngIf="item.icon" class="header-item-icon">{{item.icon}}</mat-icon>
+							</ng-template>
 							{{ item.text ?? item.type }}
 						</button>
 					</ng-container>
 					<ng-container *ngSwitchCase="'image'">
 						<button mat-icon-button
 								[id]="item.id"
+								[style.--header-item-button-height]="item.height ? item.height + 'px' : null"
 								[style.background-color]="item.bkcolor ?? layoutHeader.bkcolor"
 								[style.color]="item.fgcolor ?? layoutHeader.fgcolor"
 								[style.marginLeft.px]="item.marginLeft"
 								[style.marginRight.px]="item.marginRight">
-							<mat-icon>{{ item.icon }}</mat-icon>
+							<img *ngIf="item.image; else headerImageIcon" class="header-item-image" [src]="item.image" alt="">
+							<ng-template #headerImageIcon>
+								<mat-icon class="header-item-icon">{{ item.icon }}</mat-icon>
+							</ng-template>
 						</button>
 					</ng-container>
 				</ng-container>
@@ -113,7 +138,11 @@
 				</div>
 			</div>
 		</div>
-		<div id="container"  [ngClass]="showNavigation?'home-container-nav':'home-container'" #container (click)="checkToCloseSideNav()">
+		<div id="container"
+			 [ngClass]="showNavigation?'home-container-nav':'home-container'"
+			 [style.top.px]="showNavigation ? layoutHeader.height : 0"
+			 #container
+			 (click)="checkToCloseSideNav()">
 			<ng-container *ngIf="!showHomeLink && homeView">
 				<ng-container [ngSwitch]="homeView.type">
 					<ng-container *ngSwitchCase="cardViewType">

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -7,14 +7,14 @@
 		<app-sidenav #sidenav [sidenav]="matsidenav" (goToPage)="onGoToPage($event)" (goToLink)="onGoToLink($event)"></app-sidenav>
 	</mat-sidenav>
 	<mat-sidenav-content
-		[style.--header-height]="layoutHeader.height + 'px'"
-		[style.--header-button-height]="layoutHeader.buttonHeight + 'px'"
+		[style.--header-height]="layoutHeader.height ? layoutHeader.height + 'px' : null"
+		[style.--header-button-height]="layoutHeader.buttonHeight ? layoutHeader.buttonHeight + 'px' : null"
 		[style.background-color]="backgroudColor"
 		(click)="checkToCloseSideNav()">
 		<div *ngIf="showNavigation"
 			 class="header"
-			 [style.--header-height]="layoutHeader.height + 'px'"
-			 [style.--header-button-height]="layoutHeader.buttonHeight + 'px'"
+			 [style.--header-height]="layoutHeader.height ? layoutHeader.height + 'px' : null"
+			 [style.--header-button-height]="layoutHeader.buttonHeight ? layoutHeader.buttonHeight + 'px' : null"
 			 [style.background-color]="layoutHeader.bkcolor"
 			 [style.color]="layoutHeader.fgcolor">
 			<div *ngIf="showSidenav && showSidenav !== 'side'" class="header-menu">
@@ -140,7 +140,7 @@
 		</div>
 		<div id="container"
 			 [ngClass]="showNavigation?'home-container-nav':'home-container'"
-			 [style.top.px]="showNavigation ? layoutHeader.height : 0"
+			 [style.top.px]="showNavigation ? (layoutHeader.height || defaultHeaderHeight) : 0"
 			 #container
 			 (click)="checkToCloseSideNav()">
 			<ng-container *ngIf="!showHomeLink && homeView">

--- a/client/src/app/home/home.component.scss
+++ b/client/src/app/home/home.component.scss
@@ -38,54 +38,66 @@
         display: flex;
         z-index: 9999 !important;
         box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 3px 1px -2px rgba(0,0,0,0.12), 0 1px 5px 0 rgba(0,0,0,0.2) !important;
-        height: var(--header-height, 46px);
+        --default-header-height: 46px;
+        --default-header-button-height: 36px;
+        height: var(--header-height, var(--default-header-height));
         padding-left: 4px;
         padding-right: 10px;
         background-color: rgba(255, 255, 255, 1);
-        line-height: var(--header-height, 46px);
+        line-height: var(--header-height, var(--default-header-height));
+        --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+        --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+        --header-item-icon-size: calc(var(--effective-header-button-height) - 12px);
+        --header-label-icon-size: calc(var(--effective-header-button-height) - 14px);
 
         button[mat-button],
         button[mat-raised-button],
         button[mat-icon-button] {
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
-            min-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+            --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+            --header-item-icon-size: calc(var(--effective-header-button-height) - 12px);
+            --header-label-icon-size: calc(var(--effective-header-button-height) - 14px);
+            height: var(--effective-header-button-height);
+            min-height: var(--effective-header-button-height);
             line-height: normal;
         }
 
         button[mat-icon-button] {
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--effective-header-button-height);
             padding: 0;
         }
 
         ::ng-deep .mat-mdc-icon-button {
-            --mdc-icon-button-state-layer-size: var(--header-item-button-height, var(--header-button-height, 36px));
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            --effective-header-button-height: var(--header-item-button-height, var(--header-button-height, var(--default-header-button-height)));
+            --header-button-icon-size: calc(var(--effective-header-button-height) - 8px);
+            --mdc-icon-button-state-layer-size: var(--effective-header-button-height);
+            width: var(--effective-header-button-height);
+            height: var(--effective-header-button-height);
             padding: 0;
-            line-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            line-height: var(--effective-header-button-height);
         }
 
         ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target {
-            width: var(--header-item-button-height, var(--header-button-height, 36px));
-            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--effective-header-button-height);
+            height: var(--effective-header-button-height);
         }
 
         ::ng-deep .mat-mdc-icon-button mat-icon {
-            width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-            line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            width: var(--header-button-icon-size);
+            height: var(--header-button-icon-size);
+            font-size: var(--header-button-icon-size);
+            line-height: var(--header-button-icon-size);
         }
 
         .header-items-button {
             flex: 1;
             align-items: center;
             display: flex;
-            line-height: var(--header-height, 46px);
+            line-height: var(--header-height, var(--default-header-height));
 
             .header-item-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-height: var(--header-button-icon-size);
+                max-width: var(--header-button-icon-size);
                 vertical-align: middle;
             }
 
@@ -99,22 +111,22 @@
             }
 
             .header-item-button-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-height: var(--header-item-icon-size);
+                max-width: var(--header-button-icon-size);
                 object-fit: contain;
             }
 
             .header-item-label-image {
-                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 14px);
-                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 10px);
+                max-height: var(--header-label-icon-size);
+                max-width: calc(var(--effective-header-button-height) - 10px);
                 object-fit: contain;
             }
 
             .header-item-icon {
-                width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
-                line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                width: var(--header-item-icon-size);
+                height: var(--header-item-icon-size);
+                font-size: var(--header-item-icon-size);
+                line-height: var(--header-item-icon-size);
             }
 
             ::ng-deep .mat-mdc-button,
@@ -134,12 +146,12 @@
         .header-menu {
             display: flex;
             align-items: center;
-            height: var(--header-height, 46px);
+            height: var(--header-height, var(--default-header-height));
             margin-right: 8px;
             margin-left: 8px;
 
             mat-icon {
-                line-height: calc(var(--header-button-height, 36px) - 8px);
+                line-height: var(--header-button-icon-size);
             }
         }
     }
@@ -147,8 +159,8 @@
     .header-login {
         display: flex;
         align-items: center;
-        height: var(--header-height, 46px);
-        line-height: var(--header-height, 46px);
+        height: var(--header-height, var(--default-header-height));
+        line-height: var(--header-height, var(--default-header-height));
         border-left-width: 1px;
         border-left-style: solid;
         padding-left: 10px;
@@ -157,7 +169,7 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
-            height: var(--header-height, 46px);
+            height: var(--header-height, var(--default-header-height));
             max-width: 140px;
         }
         .primary {
@@ -196,20 +208,20 @@
         padding-right: 10px;
         display: flex;
         align-items: center;
-        height: var(--header-height, 46px);
+        height: var(--header-height, var(--default-header-height));
         gap: 4px;
     }
 
     .header-button {
         float: right;
-        line-height: var(--header-height, 46px);
+        line-height: var(--header-height, var(--default-header-height));
         text-align: right;
         margin-right: 10px;
     }
 
     .header-notify-button {
         display: flex;
-        line-height: var(--header-height, 46px);
+        line-height: var(--header-height, var(--default-header-height));
         text-align: right;
         margin-left: 10px;
         margin-right: 10px;
@@ -217,16 +229,16 @@
         align-items: center;
 
         mat-icon {
-            font-size: calc(var(--header-button-height, 36px) - 8px);
-            width: calc(var(--header-button-height, 36px) - 8px);
-            height: calc(var(--header-button-height, 36px) - 8px);
-            line-height: calc(var(--header-button-height, 36px) - 8px);
+            font-size: var(--header-button-icon-size);
+            width: var(--header-button-icon-size);
+            height: var(--header-button-icon-size);
+            line-height: var(--header-button-icon-size);
         }
 
         .alarm-button, .info-button {
             display: flex;
             align-items: center;
-            height: var(--header-height, 46px);
+            height: var(--header-height, var(--default-header-height));
             margin-right: 20px;
         }
 
@@ -305,7 +317,7 @@
     }
 
     #alarms-panel.is-full-active {
-        top: var(--header-height, 46px);
+        top: var(--header-height, var(--default-header-height));
         height: 100%;
         transition:  top 300ms;
         z-index: 999;

--- a/client/src/app/home/home.component.scss
+++ b/client/src/app/home/home.component.scss
@@ -38,28 +38,108 @@
         display: flex;
         z-index: 9999 !important;
         box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 3px 1px -2px rgba(0,0,0,0.12), 0 1px 5px 0 rgba(0,0,0,0.2) !important;
-        /* min-height: 46px !important; */
-        /* max-height: 46px !important; */
-        height: 46px !important;
+        height: var(--header-height, 46px);
         padding-left: 4px;
         padding-right: 10px;
         background-color: rgba(255, 255, 255, 1);
-        line-height: 46px;
+        line-height: var(--header-height, 46px);
+
+        button[mat-button],
+        button[mat-raised-button],
+        button[mat-icon-button] {
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            min-height: var(--header-item-button-height, var(--header-button-height, 36px));
+            line-height: normal;
+        }
+
+        button[mat-icon-button] {
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            padding: 0;
+        }
+
+        ::ng-deep .mat-mdc-icon-button {
+            --mdc-icon-button-state-layer-size: var(--header-item-button-height, var(--header-button-height, 36px));
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+            padding: 0;
+            line-height: var(--header-item-button-height, var(--header-button-height, 36px));
+        }
+
+        ::ng-deep .mat-mdc-icon-button .mat-mdc-button-touch-target {
+            width: var(--header-item-button-height, var(--header-button-height, 36px));
+            height: var(--header-item-button-height, var(--header-button-height, 36px));
+        }
+
+        ::ng-deep .mat-mdc-icon-button mat-icon {
+            width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+            line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+        }
 
         .header-items-button {
             flex: 1;
             align-items: center;
             display: flex;
-            line-height: 46px;
+            line-height: var(--header-height, 46px);
+
+            .header-item-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                vertical-align: middle;
+            }
+
+            .header-item-button-image,
+            .header-item-label-image,
+            .header-item-icon {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                vertical-align: middle;
+            }
+
+            .header-item-button-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 8px);
+                object-fit: contain;
+            }
+
+            .header-item-label-image {
+                max-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 14px);
+                max-width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 10px);
+                object-fit: contain;
+            }
+
+            .header-item-icon {
+                width: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                font-size: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+                line-height: calc(var(--header-item-button-height, var(--header-button-height, 36px)) - 12px);
+            }
+
+            ::ng-deep .mat-mdc-button,
+            ::ng-deep .mat-mdc-raised-button {
+                line-height: normal;
+            }
+
+            ::ng-deep .mat-mdc-button .mdc-button__label,
+            ::ng-deep .mat-mdc-raised-button .mdc-button__label {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                line-height: normal;
+            }
         }
 
         .header-menu {
             display: flex;
             align-items: center;
-            height: 46px;
+            height: var(--header-height, 46px);
+            margin-right: 8px;
+            margin-left: 8px;
 
             mat-icon {
-                line-height: 24px;
+                line-height: calc(var(--header-button-height, 36px) - 8px);
             }
         }
     }
@@ -67,8 +147,8 @@
     .header-login {
         display: flex;
         align-items: center;
-        height: 46px;
-        line-height: 46px;
+        height: var(--header-height, 46px);
+        line-height: var(--header-height, 46px);
         border-left-width: 1px;
         border-left-style: solid;
         padding-left: 10px;
@@ -77,7 +157,7 @@
             display: flex;
             flex-direction: column;
             justify-content: center;
-            height: 46px;
+            height: var(--header-height, 46px);
             max-width: 140px;
         }
         .primary {
@@ -116,20 +196,20 @@
         padding-right: 10px;
         display: flex;
         align-items: center;
-        height: 46px;
+        height: var(--header-height, 46px);
         gap: 4px;
     }
 
     .header-button {
         float: right;
-        line-height: 46px;
+        line-height: var(--header-height, 46px);
         text-align: right;
         margin-right: 10px;
     }
 
     .header-notify-button {
         display: flex;
-        line-height: 46px;
+        line-height: var(--header-height, 46px);
         text-align: right;
         margin-left: 10px;
         margin-right: 10px;
@@ -137,16 +217,16 @@
         align-items: center;
 
         mat-icon {
-            font-size: 28px;
-            width: 28px;
-            height: 28px;
-            line-height: 24px;
+            font-size: calc(var(--header-button-height, 36px) - 8px);
+            width: calc(var(--header-button-height, 36px) - 8px);
+            height: calc(var(--header-button-height, 36px) - 8px);
+            line-height: calc(var(--header-button-height, 36px) - 8px);
         }
 
         .alarm-button, .info-button {
             display: flex;
             align-items: center;
-            height: 46px;
+            height: var(--header-height, 46px);
             margin-right: 20px;
         }
 
@@ -225,7 +305,7 @@
     }
 
     #alarms-panel.is-full-active {
-        top: 46px;
+        top: var(--header-height, 46px);
         height: 100%;
         transition:  top 300ms;
         z-index: 999;

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -82,6 +82,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     private destroy$ = new Subject<void>();
     loggedUser$: Observable<User>;
     language$: Observable<LanguageConfiguration>;
+    readonly defaultHeaderHeight = HeaderSettings.DefaultHeight;
 
     constructor(private projectService: ProjectService,
         private changeDetector: ChangeDetectorRef,

--- a/client/src/assets/i18n/de.json
+++ b/client/src/assets/i18n/de.json
@@ -58,6 +58,8 @@
     "dlg.layout-lbl-infos": "Info-Benachrichtigungsmodus",
     "dlg.layout-lbl-font": "Schriftart",
     "dlg.layout-lbl-font-size": "Schriftgröße",
+    "dlg.layout-lbl-height": "Höhe",
+    "dlg.layout-lbl-button-height": "Button-Höhe",
     "dlg.layout-lbl-anchor": "Richtung",
     "dlg.layout-lbl-margin-left": "Linker Rand",
     "dlg.layout-lbl-margin-right": "Rechter Rand",

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -61,6 +61,8 @@
     "dlg.layout-lbl-infos": "Info notification mode",
     "dlg.layout-lbl-font": "Font family",
     "dlg.layout-lbl-font-size": "Font size",
+    "dlg.layout-lbl-height": "Height",
+    "dlg.layout-lbl-button-height": "Button height",
     "dlg.layout-lbl-anchor": "Direction",
     "dlg.layout-lbl-margin-left": "Margin left",
     "dlg.layout-lbl-margin-right": "Margin right",

--- a/client/src/assets/i18n/fr.json
+++ b/client/src/assets/i18n/fr.json
@@ -61,6 +61,8 @@
   "dlg.layout-lbl-infos": "Mode de notification d'informations",
   "dlg.layout-lbl-font": "Famille de police",
   "dlg.layout-lbl-font-size": "Taille de police",
+  "dlg.layout-lbl-height": "Hauteur",
+  "dlg.layout-lbl-button-height": "Hauteur bouton",
   "dlg.layout-lbl-anchor": "Direction",
   "dlg.layout-lbl-margin-left": "Marge gauche",
   "dlg.layout-lbl-margin-right": "Marge droite",

--- a/client/src/assets/i18n/ja.json
+++ b/client/src/assets/i18n/ja.json
@@ -61,6 +61,8 @@
     "dlg.layout-lbl-infos": "情報通知モード",
     "dlg.layout-lbl-font": "フォントファミリー",
     "dlg.layout-lbl-font-size": "フォントサイズ",
+    "dlg.layout-lbl-height": "高さ",
+    "dlg.layout-lbl-button-height": "ボタンの高さ",
     "dlg.layout-lbl-anchor": "方向",
     "dlg.layout-lbl-margin-left": "左マージン",
     "dlg.layout-lbl-margin-right": "右マージン",

--- a/client/src/assets/i18n/sv.json
+++ b/client/src/assets/i18n/sv.json
@@ -61,6 +61,8 @@
     "dlg.layout-lbl-infos": "Läge för info-notis",
     "dlg.layout-lbl-font": "Typsnitt",
     "dlg.layout-lbl-font-size": "Teckenstorlek",
+    "dlg.layout-lbl-height": "Höjd",
+    "dlg.layout-lbl-button-height": "Knapphöjd",
     "dlg.layout-lbl-anchor": "Riktning",
     "dlg.layout-lbl-margin-left": "Vänstermarginal",
     "dlg.layout-lbl-margin-right": "Högermarginal",

--- a/client/src/assets/i18n/zh-cn.json
+++ b/client/src/assets/i18n/zh-cn.json
@@ -61,6 +61,8 @@
     "dlg.layout-lbl-infos": "信息通知模式",
     "dlg.layout-lbl-font": "字体族",
     "dlg.layout-lbl-font-size": "字体大小",
+    "dlg.layout-lbl-height": "高度",
+    "dlg.layout-lbl-button-height": "按钮高度",
     "dlg.layout-lbl-anchor": "方向",
     "dlg.layout-lbl-margin-left": "左边距",
     "dlg.layout-lbl-margin-right": "右边距",

--- a/client/src/assets/i18n/zh-tw.json
+++ b/client/src/assets/i18n/zh-tw.json
@@ -61,6 +61,8 @@
     "dlg.layout-lbl-infos": "資訊通知模式",
     "dlg.layout-lbl-font": "字型族",
     "dlg.layout-lbl-font-size": "字型大小",
+    "dlg.layout-lbl-height": "高度",
+    "dlg.layout-lbl-button-height": "按鈕高度",
     "dlg.layout-lbl-anchor": "方向",
     "dlg.layout-lbl-margin-left": "左邊距",
     "dlg.layout-lbl-margin-right": "右邊距",


### PR DESCRIPTION
## Summary

- Added configurable header bar height in layout settings.
- Added global header button height setting.
- Added optional per-header-item height override, falling back to the global button height when empty.
- Added image selection support for header items via the icon selector.
- Render header item images for button, label, and image item types.
- Improved header item sizing/alignment for icons, images, labels, and Material icon buttons.
- Improved layout header item dialog field alignment.
- Expanded layout property dialog width to 90vw with a 950px minimum.

## Compatibility

Existing projects remain compatible:
- Missing `layout.header.height` defaults to `46`.
- Missing `layout.header.buttonHeight` defaults to `36`.
- Missing per-item `height` falls back to the global header button height.
