### PR TITLE
Marker image configuration for maps

### DIFF
--- a/client/src/app/_models/maps.ts
+++ b/client/src/app/_models/maps.ts
@@ -13,6 +13,7 @@ export class MapsLocation {
     showMarkerIcon?: boolean;
     showMarkerValue?: boolean;
     markerIcon?: string;
+    markerImage?: string;
     markerBackground?: string;
     markerColor?: string;
     markerTagValueId?: string;

--- a/client/src/app/maps/maps-location-property/maps-location-property.component.html
+++ b/client/src/app/maps/maps-location-property/maps-location-property.component.html
@@ -57,21 +57,16 @@
                             </div>
                             <div *ngIf="formGroup.controls?.showMarkerIcon?.value" class="my-form-field block">
                                 <span>{{'dlg.menuitem-icon' | translate}}</span>
-                                <mat-select formControlName="markerIcon" style="width: 60px; height: 30px" #iconsel>
-                                    <mat-select-trigger>
-                                        <mat-icon>{{iconsel.value}}</mat-icon>
-                                    </mat-select-trigger>
-                                    <mat-option>
-                                        <div class="my-form-field">
-                                            <input matInput [(ngModel)]="filterText" [ngModelOptions]="{standalone: true}" (input)="onFilterChange()"
-                                                (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()" placeholder="{{'dlg.menuitem-icons-filter' | translate}}"
-                                                type="text" autocomplete="off" />
-                                        </div>
-                                    </mat-option>
-                                    <mat-option *ngFor="let icon of filteredIcons$ | async" [value]="icon" style="display: inline-block !important;">
-                                        <mat-icon class="">{{ icon }}</mat-icon>
-                                    </mat-option>
-                                </mat-select>
+                                <app-icon-selector
+                                    [value]="formGroup.get('markerIcon')?.value"
+                                    (valueChange)="formGroup.get('markerIcon')?.setValue($event)"
+                                    [image]="formGroup.get('markerImage')?.value"
+                                    [allowImage]="true"
+                                    [imageLabel]="'dlg.menuitem-image'"
+                                    [filterPlaceholder]="'dlg.menuitem-icons-filter'"
+                                    (selected)="onMarkerIconSelected()"
+                                    (imageSelected)="onSetMarkerImage($event)">
+                                </app-icon-selector>
                             </div>
                         </div>
                         <div class="col-4">

--- a/client/src/app/maps/maps-location-property/maps-location-property.component.ts
+++ b/client/src/app/maps/maps-location-property/maps-location-property.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA as MAT_DIALOG_DATA, MatDialogRef as MatDialogRef } from '@angular/material/dialog';
 import { TranslateService } from '@ngx-translate/core';
@@ -6,10 +6,9 @@ import { ProjectService } from '../../_services/project.service';
 import { MapsLocation, MAPSLOCATION_PREFIX } from '../../_models/maps';
 import { Utils } from '../../_helpers/utils';
 import { GaugeAction, GaugeRangeProperty, View, ViewType } from '../../_models/hmi';
-import { BehaviorSubject, combineLatest, map, Observable, of } from 'rxjs';
-import { Define } from '../../_helpers/define';
 import { FlexDeviceTagValueType } from '../../gauges/gauge-property/flex-device-tag/flex-device-tag.component';
 import { FlexActionsStandaloneComponent } from '../../gauges/gauge-property/flex-actions-standalone/flex-actions-standalone.component';
+import { UploadFile } from '../../_models/project';
 
 @Component({
     selector: 'app-maps-location-property',
@@ -22,10 +21,6 @@ export class MapsLocationPropertyComponent implements OnInit {
     formGroup: UntypedFormGroup;
     views: View[] = [];
     actions: GaugeAction[] = [];
-    filteredIcons$: Observable<string[]>;
-    filterText = '';
-    private filterTextSubject = new BehaviorSubject<string>('');
-    icons$: Observable<string[]>;
     defaultColor = Utils.defaultColor;
     @ViewChild('flexActionsStandalone', { static: false }) flexActionsStandalone: FlexActionsStandaloneComponent;
 
@@ -34,23 +29,9 @@ export class MapsLocationPropertyComponent implements OnInit {
         private fb: UntypedFormBuilder,
         private translateService: TranslateService,
         private projectService: ProjectService,
+        private cdr: ChangeDetectorRef,
         @Inject(MAT_DIALOG_DATA) public data: MapsLocation) {
             this.location = this.data ?? new MapsLocation(Utils.getGUID(MAPSLOCATION_PREFIX));
-
-        this.icons$ = of(Define.MaterialIconsRegular).pipe(
-            map((data: string) => data.split('\n')),
-            map(lines => lines.map(line => line.split(' ')[0])),
-            map(names => names.filter(name => !!name))
-        );
-
-        this.filteredIcons$ = combineLatest([
-            this.icons$,
-            this.filterTextSubject.asObservable()
-        ]).pipe(
-            map(([icons, filterText]) =>
-                icons.filter(icon => icon.toLowerCase().includes(filterText.toLowerCase()))
-            )
-        );
     }
 
     ngOnInit() {
@@ -68,6 +49,7 @@ export class MapsLocationPropertyComponent implements OnInit {
             showMarkerIcon: [this.location.showMarkerIcon],
             showMarkerValue: [this.location.showMarkerValue],
             markerIcon: [this.location.markerIcon],
+            markerImage: [this.location.markerImage],
             markerBackground: [this.location.markerBackground ?? '#ffffff'],
             markerColor: [this.location.markerColor ?? '#000000'],
             markerTagValueId: [this.location.markerTagValueId]
@@ -98,8 +80,33 @@ export class MapsLocationPropertyComponent implements OnInit {
         };
     }
 
-    onFilterChange() {
-        this.filterTextSubject.next(this.filterText);
+    onMarkerIconSelected() {
+        this.formGroup.get('markerImage')?.setValue('');
+    }
+
+    onSetMarkerImage(event) {
+        if (event.target.files) {
+            let filename = event.target.files[0].name;
+            let fileToUpload = { type: filename.split('.').pop().toLowerCase(), name: filename.split('/').pop(), data: null };
+            let reader = new FileReader();
+            reader.onload = () => {
+                try {
+                    fileToUpload.data = reader.result;
+                    this.projectService.uploadFile(fileToUpload).subscribe((result: UploadFile) => {
+                        this.formGroup.get('markerImage')?.setValue(result.location);
+                        this.formGroup.get('markerIcon')?.setValue('image');
+                        this.cdr.detectChanges();
+                    });
+                } catch (err) {
+                    console.error(err);
+                }
+            };
+            if (fileToUpload.type === 'svg') {
+                reader.readAsText(event.target.files[0]);
+            } else {
+                reader.readAsDataURL(event.target.files[0]);
+            }
+        }
     }
 
     onTagChanged(tag: FlexDeviceTagValueType) {

--- a/client/src/app/maps/maps-view/maps-view.component.scss
+++ b/client/src/app/maps/maps-view/maps-view.component.scss
@@ -73,6 +73,12 @@
     color: var(--bubble-fg);           /* ✔ colore dinamico */
 }
 
+:host ::ng-deep .bubble-image {
+    max-width: 24px;
+    max-height: 24px;
+    display: block;
+}
+
 /* Testo */
 :host ::ng-deep .bubble-text {
     font-size: 12px;

--- a/client/src/app/maps/maps-view/maps-view.component.ts
+++ b/client/src/app/maps/maps-view/maps-view.component.ts
@@ -136,13 +136,16 @@ export class MapsViewComponent implements AfterViewInit, OnDestroy {
             const color = loc.markerColor ?? '#000000';
             const background = loc.markerBackground ?? '#ffffff';
             const icon = loc.markerIcon ? loc.markerIcon : '';
+            const image = loc.markerImage ? loc.markerImage : '';
             const nameHtml = loc.showMarkerName
                                 ? `<div class="bubble-text"
                                         style="color: var(--bubble-fg);">${loc.name}</div>`
                                 : '';
             const iconHtml = loc.showMarkerIcon
-                                ? `<span class="material-icons bubble-icon"
-                                        style="color: var(--bubble-fg);">${icon}</span>`
+                                ? image
+                                    ? `<img class="bubble-image" src="${image}" alt="">`
+                                    : `<span class="material-icons bubble-icon"
+                                            style="color: var(--bubble-fg);">${icon}</span>`
                                 : '';
             const valueHtml = loc.markerTagValueId && loc.showMarkerValue
                                 ? `<div class="bubble-value" id="${valueHtmlId}">##.##</div>`


### PR DESCRIPTION
## Summary

This PR updates the Maps Location Marker configuration to use the shared `app-icon-selector`, matching the selector already used by header items.

## Changes

- Replaced the custom Material icon selector in the Marker tab with `app-icon-selector`.
- Added support for selecting either a Material icon or an uploaded image.
- Added `markerImage` to the `MapsLocation` model.
- Uploads marker images through the existing `ProjectService.uploadFile` flow.
- Updated map marker rendering to display the configured image when present.
