### PR TITLE
Add Omron NJ/NX EtherNet/IP device driver

### DIFF
--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -246,6 +246,7 @@ export enum DeviceType {
     MQTTclient = 'MQTTclient',
     internal = 'internal',
     EthernetIP = 'EthernetIP',
+    OmronEthernetIP = 'OmronEthernetIP',
     ODBC = 'ODBC',
     ADSclient = 'ADSclient',
     GPIO = 'GPIO',

--- a/client/src/app/_models/plugin.ts
+++ b/client/src/app/_models/plugin.ts
@@ -17,6 +17,7 @@ export enum PluginType {
     Raspberry = 'Raspberry',
     SiemensS7 = 'SiemensS7',
     EthernetIP = 'EthernetIP',
+    OmronEthernetIP = 'OmronEthernetIP',
     MELSEC = 'MELSEC',
     REDIS = 'REDIS'
 }

--- a/client/src/app/device/device-list/device-list.component.ts
+++ b/client/src/app/device/device-list/device-list.component.ts
@@ -274,7 +274,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
 
     isToEdit(type, tag: Tag) {
         if (type === DeviceType.SiemensS7 || type === DeviceType.ModbusTCP || type === DeviceType.ModbusRTU ||
-            type === DeviceType.internal || type === DeviceType.EthernetIP || type === DeviceType.FuxaServer ||
+            type === DeviceType.internal || type === DeviceType.EthernetIP || type === DeviceType.OmronEthernetIP || type === DeviceType.FuxaServer ||
             type === DeviceType.OPCUA || type === DeviceType.GPIO || type === DeviceType.ADSclient ||
             type === DeviceType.WebCam || type === DeviceType.MELSEC || type === DeviceType.REDIS) {
             return true;
@@ -315,7 +315,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
             });
             return;
         }
-        if (this.deviceSelected.type === DeviceType.EthernetIP) {
+        if (this.deviceSelected.type === DeviceType.EthernetIP || this.deviceSelected.type === DeviceType.OmronEthernetIP) {
             this.tagPropertyService.editTagPropertyEthernetIp(this.deviceSelected, tag, checkToAdd).subscribe(result => {
                 this.tagsMap[tag.id] = tag;
                 this.bindToTable(this.deviceSelected.tags);

--- a/client/src/app/device/device-property/device-property.component.html
+++ b/client/src/app/device/device-property/device-property.component.html
@@ -415,6 +415,13 @@
                         </div>
                     </div>
                 </div>
+                <div *ngSwitchCase="deviceType.OmronEthernetIP">
+                    <div class="my-form-field" style="display: inline-block; margin-bottom: 10px;">
+                        <span>{{'device.property-address-port' | translate}}</span>
+                        <input [(ngModel)]="data.device.property.address" style="width: 350px" type="ip"
+                            (click)="onAddressChanged()">
+                    </div>
+                </div>
                 <div *ngSwitchCase="deviceType.ODBC">
                     <div class="my-form-field block">
                         <span>{{'device.property-dsn' | translate}}</span>

--- a/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
+++ b/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
@@ -156,7 +156,7 @@ export class DeviceTagSelectionComponent implements OnInit, AfterViewInit, OnDes
             this.tagPropertyService.editTagPropertyInternal(device, newTag, true).subscribe(result => {
                 this.loadDevicesTags(newTag, device.name);
             });
-        } else if (device.type === DeviceType.EthernetIP) {
+        } else if (device.type === DeviceType.EthernetIP || device.type === DeviceType.OmronEthernetIP) {
             this.tagPropertyService.editTagPropertyEthernetIp(device, newTag, true).subscribe(result => {
                 this.loadDevicesTags(newTag, device.name);
             });

--- a/client/src/app/plugins/plugins-list/plugins-list.component.ts
+++ b/client/src/app/plugins/plugins-list/plugins-list.component.ts
@@ -105,6 +105,7 @@ export class PluginsListComponent implements OnInit, OnDestroy {
         case PluginType.Raspberry:
         case PluginType.SiemensS7:
         case PluginType.EthernetIP:
+        case PluginType.OmronEthernetIP:
         case PluginType.MELSEC:
             return 'settings_input_component';
         case PluginType.REDIS:

--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -10,6 +10,7 @@ var BACNETclient = require('./bacnet');
 var HTTPclient = require('./httprequest');
 var MQTTclient = require('./mqtt');
 var EthernetIPclient = require('./ethernetip');
+var OmronEthernetIPclient = require('./omron-ethernetip');
 var FuxaServer = require('./fuxaserver');
 var ODBCclient = require('./odbc');
 var ADSclient = require('./adsclient');
@@ -84,6 +85,11 @@ function Device(data, runtime) {
             return null;
         }
         comm = EthernetIPclient.create(data, logger, events, manager, runtime);
+    } else if (data.type === DeviceEnum.OmronEthernetIP) {
+        if (!OmronEthernetIPclient) {
+            return null;
+        }
+        comm = OmronEthernetIPclient.create(data, logger, events, manager, runtime);
     } else if (data.type === DeviceEnum.FuxaServer) {
         if (!FuxaServer) {
             return null;
@@ -532,6 +538,8 @@ function loadPlugin(type, module) {
         MQTTclient = require(module);
     } else if (type === DeviceEnum.EthernetIP) {
         EthernetIPclient = require(module);
+    } else if (type === DeviceEnum.OmronEthernetIP) {
+        OmronEthernetIPclient = require(module);
     } else if (type === DeviceEnum.FuxaServer) {
         FuxaServer = require(module);
     } else if (type === DeviceEnum.ODBC) {
@@ -578,6 +586,7 @@ var DeviceEnum = {
     WebAPI: 'WebAPI',
     MQTTclient: 'MQTTclient',
     EthernetIP: 'EthernetIP',
+    OmronEthernetIP: 'OmronEthernetIP',
     FuxaServer: 'FuxaServer',
     ODBC: 'ODBC',
     ADSclient: 'ADSclient',

--- a/server/runtime/devices/omron-ethernetip/index.js
+++ b/server/runtime/devices/omron-ethernetip/index.js
@@ -12,7 +12,6 @@ const utils = require('../../utils');
 const deviceUtils = require('../device-utils');
 
 const DEFAULT_PORT = 44818;
-const DEFAULT_READ_TIMEOUT = 5000;
 
 function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
   var runtime = _runtime;
@@ -26,6 +25,7 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
   var overloading = 0;
   var varsValue = {}; // tag id -> { id, value, type, daq, changed, timestamp }
   var lastTimestampValue;
+  var connectionVersion = 0;
 
   this.init = function (_type) {
     console.error('Not supported!');
@@ -47,6 +47,7 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
         client.connect().then(
           function () {
             connected = true;
+            connectionVersion++;
             logger.info(`'${data.name}' connected!`, true);
             _emitStatus('connect-ok');
             resolve();
@@ -80,6 +81,7 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
       client = null;
       connected = false;
       working = false;
+      connectionVersion++;
       _emitStatus('connect-off');
       _clearVarsValue();
       resolve(true);
@@ -98,13 +100,15 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
     try {
       var timestamp = Date.now();
       var changed = {};
-      var updated = {};
       var hasSuccessfulRead = false;
-      var connectionLost = false;
+      var pollingConnectionVersion = connectionVersion;
       for (var id in data.tags) {
         var tag = data.tags[id];
         try {
-          var result = await _readTag(tag.address);
+          var result = await client.readTag(tag.address);
+          if (!connected || pollingConnectionVersion !== connectionVersion) {
+            return;
+          }
           var value = await deviceUtils.tagValueCompose(
             result.value,
             varsValue[id] ? varsValue[id].value : null,
@@ -121,28 +125,19 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
             timestamp: timestamp,
           };
           hasSuccessfulRead = true;
-          updated[id] = varsValue[id];
           if (this.addDaq && deviceUtils.tagDaqToSave(varsValue[id], timestamp)) {
             changed[id] = varsValue[id];
           }
           varsValue[id].changed = false;
         } catch (err) {
           logger.error(`'${data.name}' read '${tag.address}' error! ${err && err.message}`);
-          if (err && err.code === 'ETIMEDOUT') {
-            connectionLost = true;
-            break;
-          }
         }
-      }
-      if (connectionLost) {
-        _handleConnectionLost();
-        return;
       }
       if (!hasSuccessfulRead) {
         return;
       }
       lastTimestampValue = timestamp;
-      _emitValues(updated);
+      _emitValues(varsValue);
       if (this.addDaq && !utils.isEmptyObject(changed)) {
         this.addDaq(changed, data.name, data.id);
       }
@@ -241,28 +236,9 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
     events.emit('device-value:changed', { id: data.id, values: values });
   };
 
-  var _readTag = function (address) {
-    var timeout = _getReadTimeout();
-    var timer;
-    var timeoutPromise = new Promise(function (_, reject) {
-      timer = setTimeout(function () {
-        var err = new Error(`read timeout after ${timeout}ms`);
-        err.code = 'ETIMEDOUT';
-        reject(err);
-      }, timeout);
-    });
-    return Promise.race([client.readTag(address), timeoutPromise]).finally(function () {
-      clearTimeout(timer);
-    });
-  };
-
-  var _getReadTimeout = function () {
-    var timeout = data.property && parseInt(data.property.readTimeout, 10);
-    return timeout > 0 ? timeout : DEFAULT_READ_TIMEOUT;
-  };
-
   var _handleConnectionLost = function () {
     connected = false;
+    connectionVersion++;
     try {
       if (client) client.close();
     } catch (err) {
@@ -278,9 +254,13 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
     if (check && working) {
       overloading++;
       logger.warn(`'${data.name}' working overload! ${overloading}`);
-      if (overloading < 3) {
-        return false;
+      if (overloading >= 3) {
+        logger.error(`'${data.name}' polling blocked, reconnecting`);
+        working = false;
+        overloading = 0;
+        _handleConnectionLost();
       }
+      return false;
     }
     working = check;
     overloading = 0;

--- a/server/runtime/devices/omron-ethernetip/index.js
+++ b/server/runtime/devices/omron-ethernetip/index.js
@@ -35,10 +35,11 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
   this.connect = function () {
     return new Promise(function (resolve, reject) {
       if (!data.property || !data.property.address) {
-        logger.error(`'${data.name}' missing connection address!`);
+        var missingAddressError = new Error('missing connection address');
+        logger.error(`'${data.name}' ${missingAddressError.message}!`);
         _emitStatus('connect-failed');
         _clearVarsValue();
-        return reject();
+        return reject(missingAddressError);
       }
       try {
         var target = _parseAddress(data.property.address);
@@ -57,7 +58,7 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
             logger.error(`'${data.name}' connect failed! ${err && err.message}`);
             _emitStatus('connect-error');
             _clearVarsValue();
-            reject();
+            reject(err);
           }
         );
       } catch (err) {
@@ -65,7 +66,7 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
         logger.error(`'${data.name}' try to connect error! ${err}`);
         _emitStatus('connect-error');
         _clearVarsValue();
-        reject();
+        reject(err);
       }
     });
   };
@@ -105,6 +106,9 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
       for (var id in data.tags) {
         var tag = data.tags[id];
         try {
+          if (!client || !connected || pollingConnectionVersion !== connectionVersion) {
+            return;
+          }
           var result = await client.readTag(tag.address);
           if (!connected || pollingConnectionVersion !== connectionVersion) {
             return;
@@ -132,6 +136,9 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
         } catch (err) {
           logger.error(`'${data.name}' read '${tag.address}' error! ${err && err.message}`);
         }
+      }
+      if (!connected || pollingConnectionVersion !== connectionVersion) {
+        return;
       }
       if (!hasSuccessfulRead) {
         return;

--- a/server/runtime/devices/omron-ethernetip/index.js
+++ b/server/runtime/devices/omron-ethernetip/index.js
@@ -1,0 +1,273 @@
+'use strict';
+
+// FUXA device driver for Omron NJ/NX PLCs over EtherNet/IP (CIP).
+//
+// This file implements the FUXA device-driver contract by wrapping the
+// 'omron-ethernet-ip' npm package. To install it, copy this folder to:
+//   <FUXA>/server/runtime/devices/omron-ethernetip/index.js
+// and apply the changes described in fuxa/INTEGRATION.md.
+
+var OmronEip;
+const utils = require('../../utils');
+const deviceUtils = require('../device-utils');
+
+const DEFAULT_PORT = 44818;
+
+function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
+  var runtime = _runtime;
+  var data = JSON.parse(JSON.stringify(_data)); // { id, name, tags, property, ... }
+  var logger = _logger;
+  var events = _events;
+  var client = null; // omron-ethernet-ip OmronEipClient
+  var connected = false;
+  var lastStatus = '';
+  var working = false;
+  var overloading = 0;
+  var varsValue = {}; // tag id -> { id, value, type, daq, changed, timestamp }
+  var lastTimestampValue;
+
+  this.init = function (_type) {
+    console.error('Not supported!');
+  };
+
+  // Connect to the PLC and register an EtherNet/IP session.
+  this.connect = function () {
+    return new Promise(function (resolve, reject) {
+      if (!data.property || !data.property.address) {
+        logger.error(`'${data.name}' missing connection address!`);
+        _emitStatus('connect-failed');
+        _clearVarsValue();
+        return reject();
+      }
+      try {
+        var target = _parseAddress(data.property.address);
+        logger.info(`'${data.name}' try to connect ${data.property.address}`, true);
+        client = new OmronEip.OmronEipClient({ host: target.host, port: target.port });
+        client.connect().then(
+          function () {
+            connected = true;
+            logger.info(`'${data.name}' connected!`, true);
+            _emitStatus('connect-ok');
+            resolve();
+          },
+          function (err) {
+            connected = false;
+            logger.error(`'${data.name}' connect failed! ${err && err.message}`);
+            _emitStatus('connect-error');
+            _clearVarsValue();
+            reject();
+          }
+        );
+      } catch (err) {
+        connected = false;
+        logger.error(`'${data.name}' try to connect error! ${err}`);
+        _emitStatus('connect-error');
+        _clearVarsValue();
+        reject();
+      }
+    });
+  };
+
+  // Disconnect from the PLC.
+  this.disconnect = function () {
+    return new Promise(function (resolve) {
+      try {
+        if (client) client.close();
+      } catch (err) {
+        logger.error(`'${data.name}' disconnect failure! ${err}`);
+      }
+      client = null;
+      connected = false;
+      working = false;
+      _emitStatus('connect-off');
+      _clearVarsValue();
+      resolve(true);
+    });
+  };
+
+  // Poll every configured tag and emit the values to the FUXA runtime.
+  this.polling = async function () {
+    if (!_checkWorking(true)) {
+      return;
+    }
+    if (!client || !connected) {
+      _checkWorking(false);
+      return;
+    }
+    try {
+      var timestamp = Date.now();
+      var changed = {};
+      for (var id in data.tags) {
+        var tag = data.tags[id];
+        try {
+          var result = await client.readTag(tag.address);
+          var value = await deviceUtils.tagValueCompose(
+            result.value,
+            varsValue[id] ? varsValue[id].value : null,
+            tag,
+            runtime
+          );
+          var valueChanged = !varsValue[id] || varsValue[id].value !== value;
+          varsValue[id] = {
+            id: id,
+            value: value,
+            type: tag.type,
+            daq: tag.daq,
+            changed: valueChanged,
+            timestamp: timestamp,
+          };
+          if (this.addDaq && deviceUtils.tagDaqToSave(varsValue[id], timestamp)) {
+            changed[id] = varsValue[id];
+          }
+          varsValue[id].changed = false;
+        } catch (err) {
+          logger.error(`'${data.name}' read '${tag.address}' error! ${err && err.message}`);
+        }
+      }
+      lastTimestampValue = timestamp;
+      _emitValues(varsValue);
+      if (this.addDaq && !utils.isEmptyObject(changed)) {
+        this.addDaq(changed, data.name, data.id);
+      }
+    } catch (err) {
+      logger.error(`'${data.name}' polling error: ${err}`);
+    }
+    _checkWorking(false);
+  };
+
+  // Load/refresh the tag configuration.
+  this.load = function (_data) {
+    varsValue = {};
+    data = JSON.parse(JSON.stringify(_data));
+    var count = data.tags ? Object.keys(data.tags).length : 0;
+    logger.info(`'${data.name}' data loaded (${count})`, true);
+  };
+
+  this.getValues = function () {
+    return varsValue;
+  };
+
+  this.getValue = function (id) {
+    if (varsValue[id]) {
+      return { id: id, value: varsValue[id].value, ts: lastTimestampValue };
+    }
+    return null;
+  };
+
+  this.getStatus = function () {
+    return lastStatus;
+  };
+
+  this.getTagProperty = function (id) {
+    if (data.tags[id]) {
+      return {
+        id: id,
+        name: data.tags[id].name,
+        type: data.tags[id].type,
+        format: data.tags[id].format,
+      };
+    }
+    return null;
+  };
+
+  // Write a value to a tag. The CIP data type is discovered automatically.
+  this.setValue = async function (id, value) {
+    if (!data.tags[id] || !client || !connected) {
+      return false;
+    }
+    try {
+      var valueToSend = await deviceUtils.tagRawCalculator(value, data.tags[id], runtime);
+      await client.writeTag(data.tags[id].address, valueToSend);
+      logger.info(`'${data.tags[id].name}' setValue(${valueToSend})`, true, true);
+      return true;
+    } catch (err) {
+      logger.error(`'${data.tags[id].name}' setValue error! ${err && err.message}`);
+      return false;
+    }
+  };
+
+  this.isConnected = function () {
+    return connected;
+  };
+
+  this.bindAddDaq = function (fnc) {
+    this.addDaq = fnc;
+  };
+  this.addDaq = null;
+
+  this.lastReadTimestamp = () => lastTimestampValue;
+
+  this.getTagDaqSettings = (id) => (data.tags[id] ? data.tags[id].daq : null);
+
+  this.setTagDaqSettings = (id, settings) => {
+    if (data.tags[id]) {
+      utils.mergeObjectsValues(data.tags[id].daq, settings);
+    }
+  };
+
+  var _clearVarsValue = function () {
+    for (var id in varsValue) {
+      varsValue[id].value = null;
+    }
+    if (Object.keys(varsValue).length) {
+      _emitValues(varsValue);
+    }
+  };
+
+  var _emitStatus = function (status) {
+    lastStatus = status;
+    events.emit('device-status:changed', { id: data.id, status: status });
+  };
+
+  var _emitValues = function (values) {
+    events.emit('device-value:changed', { id: data.id, values: values });
+  };
+
+  // Guard against overlapping connect/polling cycles.
+  var _checkWorking = function (check) {
+    if (check && working) {
+      overloading++;
+      logger.warn(`'${data.name}' working overload! ${overloading}`);
+      if (overloading < 3) {
+        return false;
+      }
+    }
+    working = check;
+    overloading = 0;
+    return true;
+  };
+
+  // Parse "host" or "host:port" into { host, port }.
+  function _parseAddress(address) {
+    var idx = address.indexOf(':');
+    if (idx === -1) {
+      return { host: address, port: DEFAULT_PORT };
+    }
+    return {
+      host: address.substring(0, idx),
+      port: parseInt(address.substring(idx + 1), 10) || DEFAULT_PORT,
+    };
+  }
+}
+
+module.exports = {
+  init: function (settings) {},
+  create: function (data, logger, events, manager, runtime) {
+    try {
+      OmronEip = require('omron-ethernet-ip');
+    } catch (e) {
+      // not installed in node_modules
+    }
+    if (!OmronEip && manager) {
+      try {
+        OmronEip = manager.require('omron-ethernet-ip');
+      } catch (e) {
+        // not available via the plugin manager
+      }
+    }
+    if (!OmronEip) {
+      return null;
+    }
+    return new OmronEthernetIPClient(data, logger, events, runtime);
+  },
+};

--- a/server/runtime/devices/omron-ethernetip/index.js
+++ b/server/runtime/devices/omron-ethernetip/index.js
@@ -12,6 +12,7 @@ const utils = require('../../utils');
 const deviceUtils = require('../device-utils');
 
 const DEFAULT_PORT = 44818;
+const DEFAULT_READ_TIMEOUT = 5000;
 
 function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
   var runtime = _runtime;
@@ -97,10 +98,13 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
     try {
       var timestamp = Date.now();
       var changed = {};
+      var updated = {};
+      var hasSuccessfulRead = false;
+      var connectionLost = false;
       for (var id in data.tags) {
         var tag = data.tags[id];
         try {
-          var result = await client.readTag(tag.address);
+          var result = await _readTag(tag.address);
           var value = await deviceUtils.tagValueCompose(
             result.value,
             varsValue[id] ? varsValue[id].value : null,
@@ -111,28 +115,42 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
           varsValue[id] = {
             id: id,
             value: value,
-            type: tag.type,
+            type: result.typeName || tag.type,
             daq: tag.daq,
             changed: valueChanged,
             timestamp: timestamp,
           };
+          hasSuccessfulRead = true;
+          updated[id] = varsValue[id];
           if (this.addDaq && deviceUtils.tagDaqToSave(varsValue[id], timestamp)) {
             changed[id] = varsValue[id];
           }
           varsValue[id].changed = false;
         } catch (err) {
           logger.error(`'${data.name}' read '${tag.address}' error! ${err && err.message}`);
+          if (err && err.code === 'ETIMEDOUT') {
+            connectionLost = true;
+            break;
+          }
         }
       }
+      if (connectionLost) {
+        _handleConnectionLost();
+        return;
+      }
+      if (!hasSuccessfulRead) {
+        return;
+      }
       lastTimestampValue = timestamp;
-      _emitValues(varsValue);
+      _emitValues(updated);
       if (this.addDaq && !utils.isEmptyObject(changed)) {
         this.addDaq(changed, data.name, data.id);
       }
     } catch (err) {
       logger.error(`'${data.name}' polling error: ${err}`);
+    } finally {
+      _checkWorking(false);
     }
-    _checkWorking(false);
   };
 
   // Load/refresh the tag configuration.
@@ -221,6 +239,38 @@ function OmronEthernetIPClient(_data, _logger, _events, _runtime) {
 
   var _emitValues = function (values) {
     events.emit('device-value:changed', { id: data.id, values: values });
+  };
+
+  var _readTag = function (address) {
+    var timeout = _getReadTimeout();
+    var timer;
+    var timeoutPromise = new Promise(function (_, reject) {
+      timer = setTimeout(function () {
+        var err = new Error(`read timeout after ${timeout}ms`);
+        err.code = 'ETIMEDOUT';
+        reject(err);
+      }, timeout);
+    });
+    return Promise.race([client.readTag(address), timeoutPromise]).finally(function () {
+      clearTimeout(timer);
+    });
+  };
+
+  var _getReadTimeout = function () {
+    var timeout = data.property && parseInt(data.property.readTimeout, 10);
+    return timeout > 0 ? timeout : DEFAULT_READ_TIMEOUT;
+  };
+
+  var _handleConnectionLost = function () {
+    connected = false;
+    try {
+      if (client) client.close();
+    } catch (err) {
+      logger.error(`'${data.name}' close after polling failure error! ${err}`);
+    }
+    client = null;
+    _emitStatus('connect-error');
+    _clearVarsValue();
   };
 
   // Guard against overlapping connect/polling cycles.

--- a/server/runtime/plugins/index.js
+++ b/server/runtime/plugins/index.js
@@ -296,6 +296,7 @@ function createDefaultPlugins() {
     registry['node-snap7'] = new Plugin('node-snap7', './s7', 'SiemensS7', '1.0.9', PluginGroupType.connectionDevice, true);
     registry['ads-client'] = new Plugin('ads-client', './adsclient', 'ADSclient', '2.1.0', PluginGroupType.connectionDevice, true);
     registry['nodepccc'] = new Plugin('nodepccc', './ethernetip', 'EthernetIP', '0.1.17', PluginGroupType.connectionDevice, true);
+    registry['omron-ethernet-ip'] = new Plugin('omron-ethernet-ip', './omron-ethernetip', 'OmronEthernetIP', '0.0.1', PluginGroupType.connectionDevice, true);
     registry['odbc'] = new Plugin('odbc', './odbc', 'ODBC', '2.4.9', PluginGroupType.connectionDatabase, true);
     registry['chart.js'] = new Plugin('chart.js', './chartjs', 'Chart', '2.9.4', PluginGroupType.chartReport, true);
     registry['chartjs-node-canvas'] = new Plugin('chartjs-node-canvas', 'chartjs-canvas', 'Chart', '3.2.0', PluginGroupType.chartReport, true);

--- a/server/runtime/plugins/index.js
+++ b/server/runtime/plugins/index.js
@@ -296,7 +296,7 @@ function createDefaultPlugins() {
     registry['node-snap7'] = new Plugin('node-snap7', './s7', 'SiemensS7', '1.0.9', PluginGroupType.connectionDevice, true);
     registry['ads-client'] = new Plugin('ads-client', './adsclient', 'ADSclient', '2.1.0', PluginGroupType.connectionDevice, true);
     registry['nodepccc'] = new Plugin('nodepccc', './ethernetip', 'EthernetIP', '0.1.17', PluginGroupType.connectionDevice, true);
-    registry['omron-ethernet-ip'] = new Plugin('omron-ethernet-ip', './omron-ethernetip', 'OmronEthernetIP', '0.0.1', PluginGroupType.connectionDevice, true);
+    registry['omron-ethernet-ip'] = new Plugin('omron-ethernet-ip', './omron-ethernetip', 'OmronEthernetIP', '0.0.2', PluginGroupType.connectionDevice, true);
     registry['odbc'] = new Plugin('odbc', './odbc', 'ODBC', '2.4.9', PluginGroupType.connectionDatabase, true);
     registry['chart.js'] = new Plugin('chart.js', './chartjs', 'Chart', '2.9.4', PluginGroupType.chartReport, true);
     registry['chartjs-node-canvas'] = new Plugin('chartjs-node-canvas', 'chartjs-canvas', 'Chart', '3.2.0', PluginGroupType.chartReport, true);

--- a/server/test/devices/omronEthernetip.test.js
+++ b/server/test/devices/omronEthernetip.test.js
@@ -1,0 +1,146 @@
+const EventEmitter = require('events');
+const Module = require('module');
+
+describe('Omron EtherNet/IP device driver', () => {
+    let driver;
+    let MockClient;
+    let lastOptions;
+    let instances;
+    let originalLoad;
+
+    before(async () => {
+        const chai = await import('chai');
+        global.expect = chai.expect;
+    });
+
+    beforeEach(() => {
+        delete require.cache[require.resolve('../../runtime/devices/omron-ethernetip')];
+        try {
+            delete require.cache[require.resolve('../../runtime/utils')];
+        } catch (err) {
+            // The module may not have been loaded yet.
+        }
+        originalLoad = Module._load;
+        Module._load = function (request, parent, isMain) {
+            if (request === 'ip') {
+                return {};
+            }
+            return originalLoad.apply(this, arguments);
+        };
+        lastOptions = null;
+        instances = [];
+        MockClient = class {
+            constructor(options) {
+                lastOptions = options;
+                this.closed = false;
+                instances.push(this);
+            }
+
+            connect() {
+                return Promise.resolve();
+            }
+
+            readTag(address) {
+                return MockClient.readTag(address);
+            }
+
+            writeTag(address, value) {
+                return MockClient.writeTag(address, value);
+            }
+
+            close() {
+                this.closed = true;
+            }
+        };
+        MockClient.readTag = () => Promise.resolve({ value: 1, typeName: 'DINT' });
+        MockClient.writeTag = () => Promise.resolve();
+        driver = require('../../runtime/devices/omron-ethernetip');
+    });
+
+    afterEach(() => {
+        Module._load = originalLoad;
+    });
+
+    function createDevice(overrides = {}) {
+        const data = Object.assign({
+            id: 'device-1',
+            name: 'Omron',
+            property: { address: '192.168.1.10' },
+            tags: {
+                tag1: {
+                    id: 'tag1',
+                    name: 'Tag 1',
+                    address: 'GlobalTag',
+                    type: 'number',
+                    daq: { enabled: false },
+                },
+            },
+        }, overrides);
+        const logger = { info() {}, warn() {}, error() {} };
+        const events = new EventEmitter();
+        const manager = {
+            require(name) {
+                if (name === 'omron-ethernet-ip') {
+                    return { OmronEipClient: MockClient };
+                }
+                throw new Error(`unexpected package ${name}`);
+            },
+        };
+        const device = driver.create(data, logger, events, manager, {});
+        device.load(data);
+        return { device, events };
+    }
+
+    it('connects with default EtherNet/IP port when only host is configured', async () => {
+        const { device } = createDevice();
+
+        await device.connect();
+
+        expect(lastOptions).to.deep.equal({ host: '192.168.1.10', port: 44818 });
+        expect(device.isConnected()).to.equal(true);
+    });
+
+    it('updates timestamp and emitted values only after successful reads', async () => {
+        const { device, events } = createDevice();
+        const emitted = [];
+        events.on('device-value:changed', event => emitted.push(event));
+        MockClient.readTag = () => Promise.resolve({ value: '42', typeName: 'DINT' });
+
+        await device.connect();
+        await device.polling();
+
+        expect(device.lastReadTimestamp()).to.be.a('number');
+        expect(emitted).to.have.length(1);
+        expect(emitted[0].values.tag1.value).to.equal(42);
+        expect(emitted[0].values.tag1.type).to.equal('DINT');
+    });
+
+    it('does not refresh lastReadTimestamp or emit stale values when reads fail', async () => {
+        const { device, events } = createDevice();
+        let valueEvents = 0;
+        events.on('device-value:changed', () => valueEvents++);
+        MockClient.readTag = () => Promise.reject(new Error('bad tag'));
+
+        await device.connect();
+        await device.polling();
+
+        expect(device.lastReadTimestamp()).to.equal(undefined);
+        expect(valueEvents).to.equal(0);
+        expect(device.isConnected()).to.equal(true);
+    });
+
+    it('closes the client and marks the device disconnected when reads time out', async () => {
+        const { device } = createDevice({
+            property: { address: '192.168.1.10:44819', readTimeout: 5 },
+        });
+        MockClient.readTag = () => new Promise(() => {});
+
+        await device.connect();
+        await device.polling();
+
+        expect(lastOptions).to.deep.equal({ host: '192.168.1.10', port: 44819 });
+        expect(device.getStatus()).to.equal('connect-error');
+        expect(device.isConnected()).to.equal(false);
+        expect(instances[0].closed).to.equal(true);
+    });
+});

--- a/server/test/devices/omronEthernetip.test.js
+++ b/server/test/devices/omronEthernetip.test.js
@@ -115,6 +115,18 @@ describe('Omron EtherNet/IP device driver', () => {
         expect(emitted[0].values.tag1.type).to.equal('DINT');
     });
 
+    it('propagates connect errors with details', async () => {
+        const { device } = createDevice();
+        MockClient.prototype.connect = () => Promise.reject(new Error('connect detail'));
+
+        try {
+            await device.connect();
+            throw new Error('connect should have failed');
+        } catch (err) {
+            expect(err.message).to.equal('connect detail');
+        }
+    });
+
     it('does not refresh lastReadTimestamp or emit stale values when reads fail', async () => {
         const { device, events } = createDevice();
         let valueEvents = 0;
@@ -127,6 +139,45 @@ describe('Omron EtherNet/IP device driver', () => {
         expect(device.lastReadTimestamp()).to.equal(undefined);
         expect(valueEvents).to.equal(0);
         expect(device.isConnected()).to.equal(true);
+    });
+
+    it('stops the active polling loop when overload recovery closes the client mid-cycle', async () => {
+        const { device } = createDevice({
+            tags: {
+                tag1: {
+                    id: 'tag1',
+                    name: 'Tag 1',
+                    address: 'GlobalTag1',
+                    type: 'number',
+                    daq: { enabled: false },
+                },
+                tag2: {
+                    id: 'tag2',
+                    name: 'Tag 2',
+                    address: 'GlobalTag2',
+                    type: 'number',
+                    daq: { enabled: false },
+                },
+            },
+        });
+        let readCount = 0;
+        MockClient.readTag = async () => {
+            readCount++;
+            if (readCount === 1) {
+                await device.polling();
+                await device.polling();
+                await device.polling();
+                return { value: '42', typeName: 'DINT' };
+            }
+            throw new Error('second tag should not be read after recovery closes the client');
+        };
+
+        await device.connect();
+        await device.polling();
+
+        expect(readCount).to.equal(1);
+        expect(device.getStatus()).to.equal('connect-error');
+        expect(device.isConnected()).to.equal(false);
     });
 
     it('closes the client and marks the device disconnected when polling remains blocked', async () => {

--- a/server/test/devices/omronEthernetip.test.js
+++ b/server/test/devices/omronEthernetip.test.js
@@ -129,13 +129,16 @@ describe('Omron EtherNet/IP device driver', () => {
         expect(device.isConnected()).to.equal(true);
     });
 
-    it('closes the client and marks the device disconnected when reads time out', async () => {
+    it('closes the client and marks the device disconnected when polling remains blocked', async () => {
         const { device } = createDevice({
-            property: { address: '192.168.1.10:44819', readTimeout: 5 },
+            property: { address: '192.168.1.10:44819' },
         });
         MockClient.readTag = () => new Promise(() => {});
 
         await device.connect();
+        device.polling();
+        await device.polling();
+        await device.polling();
         await device.polling();
 
         expect(lastOptions).to.deep.equal({ host: '192.168.1.10', port: 44819 });


### PR DESCRIPTION
Adds a new OmronEthernetIP device type for Omron NJ/NX series PLCs. These controllers use CIP symbolic tag messaging, a protocol the existing EthernetIP (PCCC/Allen-Bradley) driver cannot speak.

The driver wraps the optional 'omron-ethernet-ip' npm package and is registered as an optional plugin (like nodepccc/EthernetIP), so it is not a bundled dependency: if the package is not installed the device type is simply unavailable and FUXA still starts normally.

Server:
- runtime/devices/omron-ethernetip/index.js - driver wrapper
- runtime/devices/device.js - register the OmronEthernetIP device type
- runtime/plugins/index.js - register omron-ethernet-ip as a plugin

Client:
- DeviceType and PluginType enums
- device property editor: host:port address field
- tag editing and plugin icon reuse the EthernetIP handlers

## 📌 Description

Please describe the changes introduced by this Pull Request.

- What problem does this solve?
- What was changed?
- Why is this needed?

For documentation-only PRs, focus on the Documentation checklist.

---

## 🧪 Type of Change

Please mark the relevant option:

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [ ] I did NOT commit `/client/dist`
- [ ] I did NOT commit generated Angular build output
- [ ] Only source files are included

---

## 🔍 Checklist

- [ ] Code follows project coding standards
- [ ] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

Add any other context or screenshots here.