### PR TITLE
Security hardening for JWT lifecycle and Socket.IO admin operations

### DIFF
--- a/client/src/app/_services/auth.service.ts
+++ b/client/src/app/_services/auth.service.ts
@@ -113,12 +113,24 @@ export class AuthService {
         return false;
     }
 
-	setNewToken(token: string) {
+	setNewToken(token: string, userData?: Partial<UserProfile>) {
 		if (!this.currentUser) {
 			return;
 		}
+		if (userData) {
+			this.currentUser.username = userData.username ?? this.currentUser.username;
+			this.currentUser.fullname = userData.fullname ?? this.currentUser.fullname;
+			this.currentUser.groups = userData.groups ?? this.currentUser.groups;
+			this.currentUser.info = userData.info ?? this.currentUser.info;
+			if (this.currentUser.info) {
+				this.currentUser.infoRoles = JSON.parse(this.currentUser.info)?.roles;
+			} else {
+				this.currentUser.infoRoles = null;
+			}
+		}
 		this.currentUser.token = token;
 		this.saveUserToken(this.currentUser);
+		this.currentUser$.next(this.currentUser);
 	}
 
 	// to check by page refresh
@@ -180,8 +192,8 @@ export class AuthService {
 						...(this.currentUser || {}),
 						username: result.data.username || this.currentUser?.username,
 						fullname: result.data.fullname || this.currentUser?.fullname,
-						groups: result.data.groups || this.currentUser?.groups,
-						info: result.data.info || this.currentUser?.info,
+						groups: result.data.groups ?? this.currentUser?.groups,
+						info: result.data.info ?? this.currentUser?.info,
 						token: result.data.token
 					};
 					if (refreshed.info) {

--- a/client/src/app/_services/heartbeat.service.ts
+++ b/client/src/app/_services/heartbeat.service.ts
@@ -29,7 +29,7 @@ export class HeartbeatService {
 			this.heartbeatSubscription = interval(this.heartbeatInterval).subscribe(() => {
 				this.server.heartbeat(this.activity).subscribe(res => {
 					if (res?.message === 'tokenRefresh' && res?.token) {
-						this.authService.setNewToken(res.token);
+						this.authService.setNewToken(res.token, res.data);
 					} else if (res?.message === 'guest' && res?.token) {
 						this.authService.signOut();
 					}

--- a/server/api/auth/index.js
+++ b/server/api/auth/index.js
@@ -52,7 +52,7 @@ function buildAccessToken(user) {
 }
 
 function buildRefreshToken(user) {
-    return jwt.sign({ id: user.username, groups: user.groups, type: 'refresh' }, secretCode, { expiresIn: refreshTokenExpiresIn });
+    return jwt.sign({ id: user.username, type: 'refresh' }, secretCode, { expiresIn: refreshTokenExpiresIn });
 }
 
 function setRefreshCookie(res, token) {
@@ -155,20 +155,18 @@ module.exports = {
                     return res.status(401).json({ status: 'error', message: 'Invalid refresh token' });
                 }
 
-                let userData = null;
-                try {
-                    const users = await runtime.users.getUsers({ username: decoded.id });
-                    if (users && users.length) {
-                        userData = users[0];
-                    }
-                } catch (err) {
-                    runtime.logger.error(`api refresh: user lookup failed ${err}`);
+                const users = await runtime.users.getUsers({ username: decoded.id });
+                if (!users || !users.length) {
+                    clearRefreshCookie(res);
+                    return res.status(401).json({ status: 'error', message: 'Invalid refresh token' });
                 }
+
+                const userData = users[0];
 
                 const user = {
                     username: decoded.id,
                     fullname: userData?.fullname,
-                    groups: userData?.groups || decoded.groups,
+                    groups: userData?.groups,
                     info: userData?.info
                 };
 

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -185,7 +185,7 @@ function init(_server, _runtime) {
             /**
              * GET Heartbeat to check token
              */
-            apiApp.post('/api/heartbeat', authMiddleware, function (req, res) {
+            apiApp.post('/api/heartbeat', authMiddleware, async function (req, res) {
 
                 if (!runtime.settings.secureEnabled) {
                     return res.end();
@@ -200,10 +200,17 @@ function init(_server, _runtime) {
                         });
                     }
 
+                    const currentUser = await getCurrentTokenUser(req);
+                    if (!currentUser) {
+                        return res.status(401).json({ error: 'unauthorized_error', message: 'Unauthorized!' });
+                    }
+
+                    req.userGroups = currentUser.groups;
                     const token = authJwt.getNewTokenFromRequest(req);
                     return res.status(200).json({
                         message: 'tokenRefresh',
-                        token
+                        token,
+                        data: currentUser
                     });
                 }
 
@@ -279,6 +286,28 @@ function mergeUserSettings(settings) {
     }
 }
 
+async function getCurrentTokenUser(req) {
+    if (!req.isAuthenticated || authJwt.isGuestUser(req.userId, req.userGroups)) {
+        return null;
+    }
+
+    try {
+        const users = await runtime.users.getUsers({ username: req.userId });
+        if (users && users.length && !utils.isNullOrUndefined(users[0].groups)) {
+            return {
+                username: users[0].username,
+                fullname: users[0].fullname,
+                groups: users[0].groups,
+                info: users[0].info
+            };
+        }
+    } catch (err) {
+        runtime.logger.error(`api heartbeat: user lookup failed ${err}`);
+    }
+
+    return null;
+}
+
 function verifyGroups(req) {
     if (runtime.settings && runtime.settings.secureEnabled) {
         if (req.apiKey) {
@@ -288,6 +317,9 @@ function verifyGroups(req) {
             return (runtime.settings.userRole) ? null : 0;
         }
         const userInfo = runtime.users.getUserCache(req.userId);
+        if (req.isAuthenticated && !authJwt.isGuestUser(req.userId, req.userGroups) && !userInfo) {
+            return null;
+        }
         return (runtime.settings.userRole && req.userId !== 'admin') ? userInfo : userInfo ? userInfo.groups : req.userGroups;
     } else {
         return authJwt.adminGroups[0];

--- a/server/api/jwt-helper.js
+++ b/server/api/jwt-helper.js
@@ -72,27 +72,6 @@ function verifyToken (req, res, next) {
 }
 
 function requireAuth (req, res, next) {
-    // Allow requests from FUXA interface (iframe embedding)
-    // Check for common FUXA referer patterns
-    const referer = req.headers.referer;
-    if (referer) {
-        // Allow if referer is from the same host (to support IP access without specific paths)
-        const requestHost = req.headers.host;
-        if (referer.startsWith(`http://${requestHost}`) || referer.startsWith(`https://${requestHost}`)) {
-            return next();
-        }
-        // Allow if referer contains common FUXA paths or is from the same server
-        const fuxaPatterns = [
-            '/fuxa', '/editor', '/viewer', '/lab', '/home',
-            'localhost:', '127.0.0.1:', '0.0.0.0:'
-        ];
-        const hasFuxaReferer = fuxaPatterns.some(pattern => referer.includes(pattern));
-        if (hasFuxaReferer) {
-            return next();
-        }
-    }
-
-    // For direct access, require authentication
     let token = req.headers['x-access-token'];
 
     if (!token) {

--- a/server/api/users/index.js
+++ b/server/api/users/index.js
@@ -8,6 +8,22 @@ var runtime;
 var secureFnc;
 var checkGroupsFnc;
 
+function sanitizeUser(user) {
+    if (!user || typeof user !== 'object') {
+        return user;
+    }
+    const sanitized = Object.assign({}, user);
+    delete sanitized.password;
+    return sanitized;
+}
+
+function sanitizeUsers(users) {
+    if (Array.isArray(users)) {
+        return users.map(sanitizeUser);
+    }
+    return sanitizeUser(users);
+}
+
 module.exports = {
     init: function (_runtime, _secureFnc, _checkGroupsFnc) {
         runtime = _runtime;
@@ -40,7 +56,7 @@ module.exports = {
                     // res.header("Access-Control-Allow-Origin", "*");
                     // res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
                     if (result) {
-                        res.json(result);
+                        res.json(sanitizeUsers(result));
                     } else {
                         res.end();
                     }

--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -40,6 +40,13 @@ function isSocketWriteAuthorized(socket) {
     return !!(socket && socket.isAuthenticated);
 }
 
+function isSocketAdminAuthorized(socket) {
+    if (!settings || !settings.secureEnabled) {
+        return true;
+    }
+    return !!(socket && socket.isAuthenticated && api?.authJwt?.haveAdminPermission(socket.userGroups));
+}
+
 function init(_io, _api, _settings, _log, eventsMain) {
     io = _io;
     settings = _settings;
@@ -300,7 +307,7 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask device webapi request and return result
         socket.on(Events.IoEventTypes.DEVICE_WEBAPI_REQUEST, (message) => {
             try {
-                if (!isSocketWriteAuthorized(socket)) {
+                if (!isSocketAdminAuthorized(socket)) {
                     logger.warn(`${Events.IoEventTypes.DEVICE_WEBAPI_REQUEST}: unauthorized request from ${socket.userId || 'guest'}`);
                     return;
                 }

--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -204,6 +204,10 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask device browse
         socket.on(Events.IoEventTypes.DEVICE_BROWSE, (message) => {
             try {
+                if (!isSocketAdminAuthorized(socket)) {
+                    logger.warn(`${Events.IoEventTypes.DEVICE_BROWSE}: unauthorized request from ${socket.userId || 'guest'}`);
+                    return;
+                }
                 if (message) {
                     if (message.device) {
                         devices.browseDevice(message.device, message.node, function (nodes) {
@@ -225,6 +229,10 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask device node attribute
         socket.on(Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE, (message) => {
             try {
+                if (!isSocketAdminAuthorized(socket)) {
+                    logger.warn(`${Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE}: unauthorized request from ${socket.userId || 'guest'}`);
+                    return;
+                }
                 if (message) {
                     if (message.device) {
                         devices.readNodeAttribute(message.device, message.node).then(result => {
@@ -285,6 +293,10 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask host interfaces
         socket.on(Events.IoEventTypes.HOST_INTERFACES, (message) => {
             try {
+                if (!isSocketAdminAuthorized(socket)) {
+                    logger.warn(`${Events.IoEventTypes.HOST_INTERFACES}: unauthorized request from ${socket.userId || 'guest'}`);
+                    return;
+                }
                 if (message === 'get') {
                     message = {};
                     utils.getHostInterfaces().then(result => {
@@ -333,6 +345,10 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask device tags configurtions, used for connections that load tags dinamically (webapi)
         socket.on(Events.IoEventTypes.DEVICE_TAGS_REQUEST, (message) => {
             try {
+                if (!isSocketAdminAuthorized(socket)) {
+                    logger.warn(`${Events.IoEventTypes.DEVICE_TAGS_REQUEST}: unauthorized request from ${socket.userId || 'guest'}`);
+                    return;
+                }
                 if (message && message.deviceId) {
                     devices.getDeviceTagsResult(message.deviceId).then(result => {
                         message.result = result;

--- a/server/runtime/users/index.js
+++ b/server/runtime/users/index.js
@@ -90,6 +90,7 @@ function removeUsers(username) {
     return new Promise(function (resolve, reject) {
         if (username) {
             usrstorage.removeUser(username).then(() => {
+                usersMap.delete(username);
                 resolve();
             }).catch(function (err) {
                 logger.error(`users.usrstorage-remove-users failed! ${err}`);

--- a/server/test/authorization/jwtLifecycleSecurity.test.js
+++ b/server/test/authorization/jwtLifecycleSecurity.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+const apiIndex = require('../../api');
+const authApi = require('../../api/auth');
+const usersApi = require('../../api/users');
+
+const SECRET = 'jwt-lifecycle-secret';
+
+let expect;
+
+function request(server, options) {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            host: '127.0.0.1',
+            port: server.address().port,
+            method: options.method || 'GET',
+            path: options.path,
+            headers: options.headers || {}
+        }, (res) => {
+            let body = '';
+            res.setEncoding('utf8');
+            res.on('data', (chunk) => {
+                body += chunk;
+            });
+            res.on('end', () => {
+                let json = null;
+                try {
+                    json = body ? JSON.parse(body) : null;
+                } catch (err) {
+                    json = null;
+                }
+                resolve({
+                    statusCode: res.statusCode,
+                    headers: res.headers,
+                    body,
+                    json
+                });
+            });
+        });
+        req.on('error', reject);
+        req.end(options.body || undefined);
+    });
+}
+
+function listen(app) {
+    return new Promise((resolve) => {
+        const server = app.listen(0, '127.0.0.1', () => {
+            resolve(server);
+        });
+    });
+}
+
+describe('Security - JWT lifecycle', () => {
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    it('rejects refresh cookies for deleted users instead of reusing token groups', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                secureEnabled: true,
+                enableRefreshCookieAuth: true
+            },
+            users: {
+                getUsers() {
+                    return Promise.resolve();
+                }
+            },
+            logger: {
+                error() {},
+                info() {}
+            }
+        };
+
+        authApi.init(runtime, SECRET, '1h', true, '7d');
+        const app = express();
+        app.use(authApi.app());
+        const server = await listen(app);
+
+        try {
+            const refreshToken = jwt.sign({ id: 'admin', groups: -1, type: 'refresh' }, SECRET, { expiresIn: '7d' });
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/refresh',
+                headers: {
+                    Cookie: `fuxa_refresh=${refreshToken}`
+                }
+            });
+
+            expect(response.statusCode).to.equal(401);
+            expect(response.json.message).to.equal('Invalid refresh token');
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('refreshes access tokens with current stored groups after demotion', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                secureEnabled: true,
+                enableRefreshCookieAuth: true
+            },
+            users: {
+                getUsers() {
+                    return Promise.resolve([
+                        {
+                            username: 'admin',
+                            fullname: 'Administrator',
+                            groups: 1,
+                            info: '{}'
+                        }
+                    ]);
+                }
+            },
+            logger: {
+                error() {},
+                info() {}
+            }
+        };
+
+        authApi.init(runtime, SECRET, '1h', true, '7d');
+        const app = express();
+        app.use(authApi.app());
+        const server = await listen(app);
+
+        try {
+            const refreshToken = jwt.sign({ id: 'admin', groups: -1, type: 'refresh' }, SECRET, { expiresIn: '7d' });
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/refresh',
+                headers: {
+                    Cookie: `fuxa_refresh=${refreshToken}`
+                }
+            });
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.json.data.groups).to.equal(1);
+
+            const decodedAccess = jwt.verify(response.json.data.token, SECRET);
+            expect(decodedAccess.groups).to.equal(1);
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('refreshes access tokens with groups zero after role clear', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                secureEnabled: true,
+                enableRefreshCookieAuth: true
+            },
+            users: {
+                getUsers() {
+                    return Promise.resolve([
+                        {
+                            username: 'admin',
+                            fullname: 'Administrator',
+                            groups: 0,
+                            info: '{"roles":[]}'
+                        }
+                    ]);
+                }
+            },
+            logger: {
+                error() {},
+                info() {}
+            }
+        };
+
+        authApi.init(runtime, SECRET, '1h', true, '7d');
+        const app = express();
+        app.use(authApi.app());
+        const server = await listen(app);
+
+        try {
+            const refreshToken = jwt.sign({ id: 'admin', groups: -1, type: 'refresh' }, SECRET, { expiresIn: '7d' });
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/refresh',
+                headers: {
+                    Cookie: `fuxa_refresh=${refreshToken}`
+                }
+            });
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.json.data.groups).to.equal(0);
+            expect(response.json.data.info).to.equal('{"roles":[]}');
+
+            const decodedAccess = jwt.verify(response.json.data.token, SECRET);
+            expect(decodedAccess.groups).to.equal(0);
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('does not expose password hashes from the users endpoint', async () => {
+        const runtime = {
+            project: {},
+            users: {
+                getUsers() {
+                    return Promise.resolve([
+                        {
+                            username: 'admin',
+                            fullname: 'Administrator',
+                            password: '$2a$10$hash',
+                            groups: -1,
+                            info: '{}'
+                        }
+                    ]);
+                }
+            },
+            logger: {
+                error() {}
+            }
+        };
+
+        function secureFnc(req, res, next) {
+            req.userId = 'admin';
+            req.userGroups = -1;
+            next();
+        }
+
+        function checkGroupsFnc() {
+            return -1;
+        }
+
+        usersApi.init(runtime, secureFnc, checkGroupsFnc);
+        const app = express();
+        app.use(usersApi.app());
+        const server = await listen(app);
+
+        try {
+            const response = await request(server, {
+                path: '/api/users'
+            });
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.json[0]).to.not.have.property('password');
+            expect(response.body).to.not.contain('$2a$10$hash');
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('heartbeat reissues tokens with current stored groups after demotion', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                secureEnabled: true,
+                secretCode: SECRET,
+                tokenExpiresIn: '1h',
+                logApiLevel: 'none'
+            },
+            users: {
+                getUserCache(username) {
+                    if (username === 'alice') {
+                        return { groups: 2, info: {} };
+                    }
+                    return null;
+                },
+                getUsers() {
+                    return Promise.resolve([
+                        {
+                            username: 'alice',
+                            groups: 2,
+                            info: '{"roles":["operator"]}'
+                        }
+                    ]);
+                }
+            },
+            logger: {
+                error() {},
+                info() {},
+                warn() {}
+            }
+        };
+
+        await apiIndex.init(null, runtime);
+        const server = await listen(apiIndex.apiApp);
+
+        try {
+            const staleAdminToken = jwt.sign({ id: 'alice', groups: -1 }, SECRET, { expiresIn: '1h' });
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/heartbeat',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-access-token': staleAdminToken
+                },
+                body: JSON.stringify({ params: true })
+            });
+
+            expect(response.statusCode).to.equal(200);
+            expect(response.json.message).to.equal('tokenRefresh');
+            expect(response.json.data.groups).to.equal(2);
+            expect(response.json.data.info).to.equal('{"roles":["operator"]}');
+
+            const decodedAccess = jwt.verify(response.json.token, SECRET);
+            expect(decodedAccess.groups).to.equal(2);
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('heartbeat refuses to reissue tokens for deleted users', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                secureEnabled: true,
+                secretCode: SECRET,
+                tokenExpiresIn: '1h',
+                logApiLevel: 'none'
+            },
+            users: {
+                getUserCache() {
+                    return null;
+                },
+                getUsers() {
+                    return Promise.resolve();
+                }
+            },
+            logger: {
+                error() {},
+                info() {},
+                warn() {}
+            }
+        };
+
+        await apiIndex.init(null, runtime);
+        const server = await listen(apiIndex.apiApp);
+
+        try {
+            const staleAdminToken = jwt.sign({ id: 'alice', groups: -1 }, SECRET, { expiresIn: '1h' });
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/heartbeat',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-access-token': staleAdminToken
+                },
+                body: JSON.stringify({ params: true })
+            });
+
+            expect(response.statusCode).to.equal(401);
+            expect(response.json.message).to.equal('Unauthorized!');
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+});


### PR DESCRIPTION
## Summary

This PR includes targeted security hardening for authenticated deployments (GHSA-rg7m-xwqc-mjw6, GHSA-wrg6-49wh-46pw, GHSA-rh5p-m38p-2w75):

- Fixes JWT lifecycle handling for refresh tokens and heartbeat token renewal.
- Prevents deleted, demoted, or role-cleared users from minting fresh access tokens from stale credentials.
- Removes password hashes from `/api/users` responses.
- Restricts sensitive Socket.IO runtime/editor operations to admin users when `secureEnabled=true`.
- Removes Referer/Host based authentication bypass logic from `requireAuth`.

## Changes

### JWT lifecycle

- Refresh tokens no longer carry authorization data such as `groups`.
- `/api/refresh` now reloads the current user from storage before issuing a new access token.
- Deleted users are rejected and the refresh cookie is cleared.
- `groups=0` is preserved correctly by using nullish handling instead of falsy fallback behavior.
- `/api/heartbeat` now reloads the current user before renewing the access token.
- Client-side token refresh now updates current user data, including `groups`, `info`, and role metadata.
- Deleted users are removed from the runtime user cache.

### User API hardening

- `/api/users` responses no longer expose stored password hashes.

### Socket.IO hardening

The following Socket.IO events now require admin permission when security is enabled:

- `device-webapi-request`
- `device-browse`
- `device-node-attribute`
- `host-interfaces`
- `device-tags-request`

Public/runtime viewer events remain unchanged, including device values, status, alarms, DAQ data, and tag subscriptions.

### Auth helper cleanup

- Removed Referer/Host based bypass behavior from `requireAuth`.
- `requireAuth` now requires a valid `x-access-token`.

## Compatibility notes

- When `secureEnabled=false`, FUXA keeps the existing open-by-default behavior.
- Authenticated viewer/operator runtime data access is preserved.
- Non-admin users can no longer call admin/editor metadata operations over Socket.IO.

## Tests

Added regression coverage for JWT lifecycle security cases:

- deleted user refresh token rejection
- demoted user heartbeat renewal rejection/update
- `groups=0` handling
- password hash sanitization from `/api/users`

Also validated syntax for the changed server files.