### PR TITLE
Update fuxa-ack-alarm.html

### DIFF
--- a/node-red/node-red-contrib-fuxa/nodes/fuxa-ack-alarm.html
+++ b/node-red/node-red-contrib-fuxa/nodes/fuxa-ack-alarm.html
@@ -4,7 +4,7 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            alarmName: {value:"", required:true},
+            alarmName: {value:"", required:false},
             types: {value:""}
         },
         inputs:1,


### PR DESCRIPTION
## 📌 Description

Please describe the changes introduced by this Pull Request.

- **What problem does this solve?**
  The `ack-alarm` Node-RED node requires users to select an alarm from a static dropdown menu because the `alarmName` field is marked as `required: true`. This strictly blocks the Node-RED editor from deploying flows unless a static alarm is chosen, which directly contradicts the node's built-in help documentation stating that users can pass dynamic overrides via `msg.alarmName` or `msg.payload`.

- **What was changed?**
  In `fuxa-ack-alarm.html`: Changed the `alarmName` property validation from `required: true` to `required: false`.

- **Why is this needed?**
  This change is needed to allow a fully dynamic, message-driven workflow without being forced by the Node-RED editor UI to select a placeholder static alarm just to be able to deploy the flow.

---

## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [ ] Issue opened (for major changes)

---

## 📚 Documentation Checklist (if applicable)

- [ ] The documentation builds locally with `mkdocs serve`
- [ ] All links were tested
- [ ] Images use relative paths (e.g. `images/example.png`)
- [ ] No references to the old GitHub Wiki
- [ ] Navigation updated in `mkdocs.yml` (if required)

---

## 📝 Additional Notes

By changing `required` to `false`, the editor validation passes even if the field is empty, allowing the node to gracefully rely on runtime incoming messages (`msg.alarmName`).