### PR TITLE
Security: strengthen Node-RED authorization

### DIFF
--- a/server/api/jwt-helper.js
+++ b/server/api/jwt-helper.js
@@ -26,12 +26,25 @@ function init(_secureEnabled, _secretCode, _tokenExpires) {
  */
 function verify (token) {
     return new Promise ((resolve, reject) => {
-        jwt.verify(token, secretCode, (err, decoded) => {
+        jwt.verify(token, secretCode, (err) => {
             if (err) {
                 console.error(`verify token error: ${err}`);
                 reject(false);
             } else {
                 resolve(true);
+            }
+        });
+    });
+}
+
+function verifyAndDecode(token) {
+    return new Promise((resolve, reject) => {
+        jwt.verify(token, secretCode, (err, decoded) => {
+            if (err) {
+                console.error(`verify token error: ${err}`);
+                reject(false);
+            } else {
+                resolve(decoded);
             }
         });
     });
@@ -140,6 +153,7 @@ function getTokenExpiresIn() {
 module.exports = {
     init: init,
     verify: verify,
+    verifyAndDecode: verifyAndDecode,
     verifyToken: verifyToken,
     requireAuth: requireAuth,
     getNewTokenFromRequest: getNewTokenFromRequest,

--- a/server/integrations/node-red/index.js
+++ b/server/integrations/node-red/index.js
@@ -21,6 +21,98 @@ function tryRequireNodeRed(runtime) {
     }
 }
 
+const getCookieValue = (req, name) => {
+    const cookieHeader = req.headers.cookie;
+    if (!cookieHeader) return null;
+    const cookies = cookieHeader.split(';');
+    for (const cookie of cookies) {
+        const [key, ...rest] = cookie.trim().split('=');
+        if (key === name) {
+            return rest.join('=');
+        }
+    }
+    return null;
+};
+
+const verifyApiKey = (runtime, apiKey) => {
+    return runtime.apiKeys.getApiKeys().then(stored => {
+        const now = Date.now();
+        return stored.find(k => {
+            if (!k || k.key !== apiKey || k.enabled === false) {
+                return false;
+            }
+            if (!k.expires) {
+                return true;
+            }
+            const expiresAt = new Date(k.expires).getTime();
+            return !isNaN(expiresAt) && expiresAt > now;
+        });
+    });
+};
+
+function createNodeRedAuthMiddleware({ settings, runtime, logger, authJwt }) {
+    // Allow only dashboard routes as public; require an authenticated user or API key for the editor.
+    return (req, res, next) => {
+        // Public dashboard UI and its HTTP APIs (served from httpNodeRoot/ui.path).
+        // baseUrl comes from Express mount point and is not affected by query/path tricks.
+        if (req.baseUrl === '/dashboard') return next();
+
+        if (!settings.secureEnabled || settings.nodeRedAuthMode === 'legacy-open') {
+            return next();
+        }
+
+        const apiKey = req.headers['x-api-key'];
+        if (apiKey) {
+            return verifyApiKey(runtime, apiKey)
+                .then(validKey => {
+                    if (!validKey) {
+                        return res.status(401).json({ error: "unauthorized_error", message: "Invalid API Key" });
+                    }
+                    return next();
+                })
+                .catch(err => {
+                    logger.error(`api-key validation failed: ${err}`);
+                    return res.status(500).json({ error: "unexpected_error", message: "ApiKey validation failed" });
+                });
+        }
+
+        const headerToken = req.headers['x-access-token'];
+        const queryToken = req.query?.token;
+        const cookieToken = getCookieValue(req, 'nodered_auth');
+        // Prefer explicit tokens over cookie to avoid stale cookie blocking valid logins
+        const token = headerToken || queryToken || cookieToken;
+        if (!token) {
+            return res.status(401).json({ error: "unauthorized_error", message: "Authentication required!" });
+        }
+
+        return authJwt.verifyAndDecode(token)
+            .then(decoded => {
+                if (!decoded?.id || decoded.type === 'refresh' || authJwt.isGuestUser(decoded.id, decoded.groups)) {
+                    return res.status(403).json({ error: "forbidden_error", message: "Authenticated user required!" });
+                }
+                if (queryToken) {
+                    res.cookie('nodered_auth', token, {
+                        httpOnly: true,
+                        sameSite: 'lax',
+                        secure: !!settings.https,
+                    });
+                    if (req.method === 'GET') {
+                        const cleanUrl = new URL(req.originalUrl, `http://${req.headers.host}`);
+                        cleanUrl.searchParams.delete('token');
+                        return res.redirect(cleanUrl.pathname + cleanUrl.search);
+                    }
+                }
+                return next();
+            })
+            .catch(() => {
+                if (cookieToken) {
+                    res.clearCookie('nodered_auth');
+                }
+                return res.status(401).json({ error: "unauthorized_error", message: "Invalid token!" });
+            });
+    };
+}
+
 async function mountNodeRedIfInstalled({ app, server, settings, runtime, logger, authJwt, events }) {
     const RED = tryRequireNodeRed(runtime);
     if (!RED) {
@@ -127,92 +219,7 @@ async function mountNodeRedIfInstalled({ app, server, settings, runtime, logger,
     // Initialize Node-RED on the existing HTTP server (must be done before server.listen)
     RED.init(server, redSettings);
 
-    const getCookieValue = (req, name) => {
-        const cookieHeader = req.headers.cookie;
-        if (!cookieHeader) return null;
-        const cookies = cookieHeader.split(';');
-        for (const cookie of cookies) {
-            const [key, ...rest] = cookie.trim().split('=');
-            if (key === name) {
-                return rest.join('=');
-            }
-        }
-        return null;
-    };
-
-    const verifyApiKey = (runtimeRef, apiKey) => {
-        return runtimeRef.apiKeys.getApiKeys().then(stored => {
-            const now = Date.now();
-            return stored.find(k => {
-                if (!k || k.key !== apiKey || k.enabled === false) {
-                    return false;
-                }
-                if (!k.expires) {
-                    return true;
-                }
-                const expiresAt = new Date(k.expires).getTime();
-                return !isNaN(expiresAt) && expiresAt > now;
-            });
-        });
-    };
-
-    // Allow only dashboard routes as public; require JWT or API key for admin/editor/flows when security is enabled
-    const allowDashboard = (req, res, next) => {
-        // Public dashboard UI and its HTTP APIs (served from httpNodeRoot/ui.path).
-        // baseUrl comes from Express mount point and is not affected by query/path tricks.
-        if (req.baseUrl === '/dashboard') return next();
-
-        if (!settings.secureEnabled || settings.nodeRedAuthMode === 'legacy-open') {
-            return next();
-        }
-
-        const apiKey = req.headers['x-api-key'];
-        if (apiKey) {
-            return verifyApiKey(runtime, apiKey)
-                .then(validKey => {
-                    if (!validKey) {
-                        return res.status(401).json({ error: "unauthorized_error", message: "Invalid API Key" });
-                    }
-                    return next();
-                })
-                .catch(err => {
-                    logger.error(`api-key validation failed: ${err}`);
-                    return res.status(500).json({ error: "unexpected_error", message: "ApiKey validation failed" });
-                });
-        }
-
-        const headerToken = req.headers['x-access-token'];
-        const queryToken = req.query?.token;
-        const cookieToken = getCookieValue(req, 'nodered_auth');
-        // Prefer explicit tokens over cookie to avoid stale cookie blocking valid logins
-        const token = headerToken || queryToken || cookieToken;
-        if (!token) {
-            return res.status(401).json({ error: "unauthorized_error", message: "Authentication required!" });
-        }
-
-        return authJwt.verify(token)
-            .then(() => {
-                if (queryToken) {
-                    res.cookie('nodered_auth', token, {
-                        httpOnly: true,
-                        sameSite: 'lax',
-                        secure: !!settings.https,
-                    });
-                    if (req.method === 'GET') {
-                        const cleanUrl = new URL(req.originalUrl, `http://${req.headers.host}`);
-                        cleanUrl.searchParams.delete('token');
-                        return res.redirect(cleanUrl.pathname + cleanUrl.search);
-                    }
-                }
-                return next();
-            })
-            .catch(() => {
-                if (cookieToken) {
-                    res.clearCookie('nodered_auth');
-                }
-                return res.status(401).json({ error: "unauthorized_error", message: "Invalid token!" });
-            });
-    };
+    const allowDashboard = createNodeRedAuthMiddleware({ settings, runtime, logger, authJwt });
 
     // Mount Node-RED admin/editor under /nodered; HTTP nodes (including dashboard)
     // are served from httpNodeRoot ('/dashboard') so they appear at /dashboard/... etc.
@@ -286,4 +293,4 @@ async function mountNodeRedIfInstalled({ app, server, settings, runtime, logger,
     logger.info('[Node-RED] Started at /nodered');
 }
 
-module.exports = { mountNodeRedIfInstalled };
+module.exports = { mountNodeRedIfInstalled, createNodeRedAuthMiddleware };

--- a/server/test/authorization/nodeRedSecurity.test.js
+++ b/server/test/authorization/nodeRedSecurity.test.js
@@ -1,0 +1,238 @@
+'use strict';
+
+const http = require('http');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+const authJwt = require('../../api/jwt-helper');
+const { createNodeRedAuthMiddleware } = require('../../integrations/node-red');
+
+const SECRET = 'node-red-security-test-secret';
+
+function makeResponse() {
+    return {
+        statusCode: 200,
+        body: null,
+        cookies: [],
+        clearedCookies: [],
+        redirectUrl: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(body) {
+            this.body = body;
+            return this;
+        },
+        cookie(name, value, options) {
+            this.cookies.push({ name, value, options });
+        },
+        clearCookie(name) {
+            this.clearedCookies.push(name);
+        },
+        redirect(url) {
+            this.redirectUrl = url;
+        }
+    };
+}
+
+function makeRequest(headers = {}, overrides = {}) {
+    return {
+        baseUrl: '/nodered',
+        headers,
+        query: {},
+        method: 'POST',
+        originalUrl: '/nodered/flows',
+        ...overrides
+    };
+}
+
+function request(app, path, headers = {}) {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, '127.0.0.1', () => {
+            const req = http.request({
+                host: '127.0.0.1',
+                port: server.address().port,
+                method: 'GET',
+                path,
+                headers
+            }, (res) => {
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => { body += chunk; });
+                res.on('end', () => {
+                    server.close(() => resolve({
+                        statusCode: res.statusCode,
+                        headers: res.headers,
+                        body
+                    }));
+                });
+            });
+            req.on('error', err => server.close(() => reject(err)));
+            req.end();
+        });
+    });
+}
+
+describe('Node-RED secure mode authorization', () => {
+    let expect;
+    let middleware;
+
+    function makeMiddleware(settings = {}) {
+        return createNodeRedAuthMiddleware({
+            settings: {
+                secureEnabled: true,
+                nodeRedAuthMode: 'secure',
+                ...settings
+            },
+            runtime: {
+                apiKeys: {
+                    getApiKeys: () => Promise.resolve([{ id: 'key-1', key: 'valid-api-key' }])
+                }
+            },
+            logger: {
+                error() {}
+            },
+            authJwt
+        });
+    }
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+        authJwt.init(true, SECRET, 60 * 60);
+        middleware = makeMiddleware();
+    });
+
+    async function authorize(headers, overrides, authMiddleware = middleware) {
+        const req = makeRequest(headers, overrides);
+        const res = makeResponse();
+        let allowed = false;
+
+        await authMiddleware(req, res, () => {
+            allowed = true;
+        });
+
+        return { allowed, res };
+    }
+
+    it('rejects a valid guest JWT', async () => {
+        const result = await authorize({ 'x-access-token': authJwt.getGuestToken() });
+
+        expect(result.allowed).to.equal(false);
+        expect(result.res.statusCode).to.equal(403);
+    });
+
+    it('allows an authenticated user with numeric groups', async () => {
+        const token = jwt.sign({ id: 'operator', groups: 2 }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({ 'x-access-token': token });
+
+        expect(result.allowed).to.equal(true);
+        expect(result.res.statusCode).to.equal(200);
+    });
+
+    it('allows an authenticated role-based user without groups in the JWT', async () => {
+        const token = jwt.sign({ id: 'role-user' }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({ 'x-access-token': token });
+
+        expect(result.allowed).to.equal(true);
+        expect(result.res.statusCode).to.equal(200);
+    });
+
+    it('allows an authenticated user with no assigned groups', async () => {
+        const token = jwt.sign({ id: 'no-group-user', groups: 0 }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({ 'x-access-token': token });
+
+        expect(result.allowed).to.equal(true);
+        expect(result.res.statusCode).to.equal(200);
+    });
+
+    it('rejects a signed refresh token', async () => {
+        const token = jwt.sign({ id: 'operator', type: 'refresh' }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({ 'x-access-token': token });
+
+        expect(result.allowed).to.equal(false);
+        expect(result.res.statusCode).to.equal(403);
+    });
+
+    it('allows a valid API key', async () => {
+        const result = await authorize({ 'x-api-key': 'valid-api-key' });
+
+        expect(result.allowed).to.equal(true);
+        expect(result.res.statusCode).to.equal(200);
+    });
+
+    it('rejects missing and invalid credentials', async () => {
+        const missing = await authorize();
+        const invalid = await authorize({ 'x-access-token': 'invalid-token' });
+
+        expect(missing.allowed).to.equal(false);
+        expect(missing.res.statusCode).to.equal(401);
+        expect(invalid.allowed).to.equal(false);
+        expect(invalid.res.statusCode).to.equal(401);
+    });
+
+    it('preserves query-token login, cookie creation and clean redirect', async () => {
+        const token = jwt.sign({ id: 'operator', groups: 2 }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({}, {
+            method: 'GET',
+            query: { token, tab: 'flows' },
+            originalUrl: `/nodered/?token=${token}&tab=flows`,
+            headers: { host: 'localhost' }
+        });
+
+        expect(result.allowed).to.equal(false);
+        expect(result.res.cookies).to.have.length(1);
+        expect(result.res.cookies[0].name).to.equal('nodered_auth');
+        expect(result.res.redirectUrl).to.equal('/nodered/?tab=flows');
+    });
+
+    it('preserves authenticated cookie access', async () => {
+        const token = jwt.sign({ id: 'operator', groups: 2 }, SECRET, { expiresIn: '1h' });
+        const result = await authorize({ cookie: `other=value; nodered_auth=${token}` });
+
+        expect(result.allowed).to.equal(true);
+    });
+
+    it('clears an invalid authentication cookie', async () => {
+        const result = await authorize({ cookie: 'nodered_auth=invalid-token' });
+
+        expect(result.allowed).to.equal(false);
+        expect(result.res.statusCode).to.equal(401);
+        expect(result.res.clearedCookies).to.deep.equal(['nodered_auth']);
+    });
+
+    it('keeps dashboard routes public', async () => {
+        const result = await authorize({}, { baseUrl: '/dashboard' });
+
+        expect(result.allowed).to.equal(true);
+    });
+
+    it('preserves legacy-open access without credentials', async () => {
+        const result = await authorize({}, {}, makeMiddleware({ nodeRedAuthMode: 'legacy-open' }));
+
+        expect(result.allowed).to.equal(true);
+    });
+
+    it('preserves access without credentials when FUXA security is disabled', async () => {
+        const result = await authorize({}, {}, makeMiddleware({ secureEnabled: false }));
+
+        expect(result.allowed).to.equal(true);
+    });
+
+    it('enforces the same policy when mounted by Express', async () => {
+        const app = express();
+        app.use('/nodered', middleware, (req, res) => res.status(200).send('allowed'));
+
+        const guest = await request(app, '/nodered/flows', {
+            'x-access-token': authJwt.getGuestToken()
+        });
+        const userToken = jwt.sign({ id: 'operator', groups: 2 }, SECRET, { expiresIn: '1h' });
+        const user = await request(app, `/nodered/?token=${userToken}`);
+
+        expect(guest.statusCode).to.equal(403);
+        expect(user.statusCode).to.equal(302);
+        expect(user.headers.location).to.equal('/nodered/');
+        expect(user.headers['set-cookie'][0]).to.contain('nodered_auth=');
+    });
+});


### PR DESCRIPTION
## 📌 Description

Improves Node-RED authorization when FUXA security is enabled (GHSA-5h5x-9h7x-23f4).

The Node-RED editor now requires an authenticated user or a valid API key. Guest and refresh tokens are no longer accepted.

Existing behavior is preserved for public dashboard routes, legacy-open mode, query-token login, and authentication cookies.

Includes regression tests for the updated authorization behavior.
