### PR TITLE
Security: improve settings sanitization and role cleanup

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -106,16 +106,12 @@ function init(_server, _runtime) {
             /**
              * GET Server setting data
              */
-            apiApp.get('/api/settings', function (req, res) {
+            apiApp.get('/api/settings', authMiddleware, function (req, res) {
                 if (runtime.settings) {
-                    let tosend = JSON.parse(JSON.stringify(runtime.settings));
-                    delete tosend.secretCode;
-                    if (tosend.smtp) {
-                        delete tosend.smtp.password;
-                    }
-                    if (tosend.daqstore?.credentials) {
-                        delete tosend.daqstore.credentials;
-                    }
+                    const permission = verifyGroups(req);
+                    const tosend = authJwt.haveAdminPermission(permission)
+                        ? getSanitizedSettings(runtime.settings)
+                        : getPublicSettings(runtime.settings);
                     // res.header("Access-Control-Allow-Origin", "*");
                     // res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
                     res.json(tosend);
@@ -232,6 +228,32 @@ function init(_server, _runtime) {
     });
 }
 
+function getPublicSettings(settings) {
+    const tosend = getSanitizedSettings(settings);
+    if (tosend.smtp) {
+        delete tosend.smtp.host;
+        delete tosend.smtp.port;
+        delete tosend.smtp.username;
+    }
+    if (tosend.daqstore) {
+        delete tosend.daqstore.url;
+        delete tosend.daqstore.host;
+    }
+    return tosend;
+}
+
+function getSanitizedSettings(settings) {
+    const tosend = JSON.parse(JSON.stringify(settings));
+    delete tosend.secretCode;
+    if (tosend.smtp) {
+        delete tosend.smtp.password;
+    }
+    if (tosend.daqstore?.credentials) {
+        delete tosend.daqstore.credentials;
+    }
+    return tosend;
+}
+
 function mergeUserSettings(settings) {
     if (settings.language) {
         runtime.settings.language = settings.language;
@@ -339,5 +361,7 @@ module.exports = {
 
     get apiApp() { return apiApp; },
     get server() { return server; },
-    get authJwt() { return authJwt; }
+    get authJwt() { return authJwt; },
+    _getPublicSettings: getPublicSettings,
+    _getSanitizedSettings: getSanitizedSettings
 };

--- a/server/runtime/users/index.js
+++ b/server/runtime/users/index.js
@@ -145,6 +145,17 @@ function removeRoles(roles) {
     return new Promise(function (resolve, reject) {
         if (roles && roles.length) {
             usrstorage.removeRoles(roles).then(() => {
+                const roleIds = new Set(roles.map(role => role.id));
+                for (const [username, user] of usersMap) {
+                    if (Array.isArray(user.info?.roles)) {
+                        usersMap.set(username, {
+                            info: Object.assign({}, user.info, {
+                                roles: user.info.roles.filter(roleId => !roleIds.has(roleId))
+                            }),
+                            groups: user.groups
+                        });
+                    }
+                }
                 resolve();
             }).catch(function (err) {
                 logger.error(`users.usrstorage-remove-role failed! ${err}`);

--- a/server/runtime/users/usrstorage.js
+++ b/server/runtime/users/usrstorage.js
@@ -27,6 +27,18 @@ function _run(sql, params = []) {
     });
 }
 
+function _all(sql, params = []) {
+    return new Promise((resolve, reject) => {
+        db_usr.all(sql, params, function (err, rows) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(rows);
+            }
+        });
+    });
+}
+
 /**
  * Init and bind the database resource
  * @param {*} _settings
@@ -230,19 +242,41 @@ function setRoles(roles) {
 /**
  * Remove roles from database
  */
-function removeRoles(roles) {
-    return new Promise(async function (resolve, reject) {
-        try {
-            const sql = "DELETE FROM roles WHERE name = ?";
-            for (const role of roles) {
-                await _run(sql, [role.id]);
+async function removeRoles(roles) {
+    const roleIds = new Set(roles.map(role => role.id));
+
+    try {
+        const users = await _all("SELECT username, info FROM users");
+        for (const user of users) {
+            if (!user.info) {
+                continue;
             }
-            resolve();
-        } catch (err) {
-            logger.error(`usrstorage.remove role failed! ${err}`);
-            reject();
+            let info;
+            try {
+                info = JSON.parse(user.info);
+            } catch (err) {
+                logger.warn(`usrstorage.remove role skipped invalid user info for ${user.username}`);
+                continue;
+            }
+            if (!Array.isArray(info.roles)) {
+                continue;
+            }
+            const filteredRoles = info.roles.filter(roleId => !roleIds.has(roleId));
+            if (filteredRoles.length !== info.roles.length) {
+                info.roles = filteredRoles;
+                user.info = JSON.stringify(info);
+                await _run("UPDATE users SET info = ? WHERE username = ?", [user.info, user.username]);
+            }
         }
-    });
+
+        const sql = "DELETE FROM roles WHERE name = ?";
+        for (const role of roles) {
+            await _run(sql, [role.id]);
+        }
+    } catch (err) {
+        logger.error(`usrstorage.remove role failed! ${err}`);
+        throw err;
+    }
 }
 
 /**

--- a/server/test/authorization/roleDeletionSecurity.test.js
+++ b/server/test/authorization/roleDeletionSecurity.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const users = require('../../runtime/users');
+const usrstorage = require('../../runtime/users/usrstorage');
+
+function makeLogger() {
+    return {
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+    };
+}
+
+describe('Security - role deletion cleanup', () => {
+    let expect;
+    let workDir;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    beforeEach(async () => {
+        workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fuxa-role-delete-'));
+        await users.init({ workDir }, makeLogger());
+    });
+
+    afterEach(() => {
+        usrstorage.close();
+        fs.rmSync(workDir, { recursive: true, force: true });
+    });
+
+    it('removes deleted role assignments from persisted users and runtime cache', async () => {
+        await users.setRoles([
+            { id: 'role-delete', name: 'Delete me' },
+            { id: 'role-keep', name: 'Keep me' }
+        ]);
+        await users.setUsers({
+            username: 'alice',
+            fullname: 'Alice',
+            groups: 1,
+            info: JSON.stringify({
+                roles: ['role-delete', 'role-keep'],
+                start: 'view-1'
+            })
+        });
+
+        await users.removeRoles([{ id: 'role-delete', name: 'Delete me' }]);
+
+        const storedUsers = await users.getUsers({ username: 'alice' });
+        const storedInfo = JSON.parse(storedUsers[0].info);
+        expect(storedInfo).to.deep.equal({
+            roles: ['role-keep'],
+            start: 'view-1'
+        });
+        expect(users.getUserCache('alice')).to.deep.equal({
+            groups: 1,
+            info: {
+                roles: ['role-keep'],
+                start: 'view-1'
+            }
+        });
+
+        const storedRoles = await users.getRoles();
+        expect(storedRoles.map(role => role.id)).to.deep.equal(['role-keep']);
+    });
+
+    it('does not rewrite users without deleted role assignments', async () => {
+        await users.setRoles([{ id: 'role-delete', name: 'Delete me' }]);
+        await users.setUsers({
+            username: 'bob',
+            fullname: 'Bob',
+            groups: 2,
+            info: JSON.stringify({ roles: ['role-other'] })
+        });
+
+        await users.removeRoles([{ id: 'role-delete', name: 'Delete me' }]);
+
+        const storedUsers = await users.getUsers({ username: 'bob' });
+        expect(JSON.parse(storedUsers[0].info).roles).to.deep.equal(['role-other']);
+        expect(users.getUserCache('bob').info.roles).to.deep.equal(['role-other']);
+    });
+
+    it('cleans the runtime cache when persisted user info is invalid', async () => {
+        await users.setRoles([{ id: 'role-delete', name: 'Delete me' }]);
+        await users.setUsers({
+            username: 'alice',
+            fullname: 'Alice',
+            groups: 1,
+            info: JSON.stringify({ roles: ['role-delete'] })
+        });
+        await usrstorage.setUser('alice', 'Alice', null, 1, '{invalid');
+
+        await users.removeRoles([{ id: 'role-delete', name: 'Delete me' }]);
+
+        const storedUsers = await users.getUsers({ username: 'alice' });
+        expect(storedUsers[0].info).to.equal('{invalid');
+        expect(users.getUserCache('alice').info.roles).to.deep.equal([]);
+        expect(await users.getRoles()).to.deep.equal([]);
+    });
+});

--- a/server/test/authorization/settingsDisclosure.test.js
+++ b/server/test/authorization/settingsDisclosure.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const apiIndex = require('../../api');
+
+let expect;
+
+function makeSettings() {
+    return {
+        language: 'en',
+        secureEnabled: true,
+        secretCode: 'jwt-secret',
+        smtp: {
+            host: 'smtp.internal',
+            port: 587,
+            username: 'smtp-user',
+            password: 'smtp-secret',
+            mailsender: 'fuxa@example.com'
+        },
+        daqstore: {
+            type: 'influxDB',
+            url: 'http://influx.internal:8086',
+            host: 'questdb.internal',
+            database: 'fuxa',
+            credentials: {
+                username: 'daq-user',
+                password: 'daq-secret'
+            }
+        }
+    };
+}
+
+describe('Security - settings disclosure', () => {
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    it('always removes passwords, credentials and the JWT secret', () => {
+        const settings = makeSettings();
+
+        for (const result of [
+            apiIndex._getSanitizedSettings(settings),
+            apiIndex._getPublicSettings(settings)
+        ]) {
+            expect(result).to.not.have.property('secretCode');
+            expect(result.smtp).to.not.have.property('password');
+            expect(result.daqstore).to.not.have.property('credentials');
+        }
+
+        expect(settings).to.deep.equal(makeSettings());
+    });
+
+    it('removes infrastructure connection details from public settings', () => {
+        const publicSettings = apiIndex._getPublicSettings(makeSettings());
+
+        expect(publicSettings.smtp).to.not.have.property('host');
+        expect(publicSettings.smtp).to.not.have.property('port');
+        expect(publicSettings.smtp).to.not.have.property('username');
+        expect(publicSettings.smtp.mailsender).to.equal('fuxa@example.com');
+        expect(publicSettings.daqstore).to.not.have.property('url');
+        expect(publicSettings.daqstore).to.not.have.property('host');
+        expect(publicSettings.daqstore).to.include({
+            type: 'influxDB',
+            database: 'fuxa'
+        });
+    });
+
+    it('keeps non-secret connection details available to admins', () => {
+        const adminSettings = apiIndex._getSanitizedSettings(makeSettings());
+
+        expect(adminSettings.smtp).to.include({
+            host: 'smtp.internal',
+            port: 587,
+            username: 'smtp-user'
+        });
+        expect(adminSettings.daqstore).to.include({
+            url: 'http://influx.internal:8086',
+            host: 'questdb.internal'
+        });
+    });
+});


### PR DESCRIPTION
## 📌 Description

Improves the handling of server settings and role deletion when FUXA security is enabled (GHSA-cqww-jqx5-p32v).

The settings API now returns sanitized data based on the user's permissions, limiting infrastructure connection details to administrators while always excluding secrets and credentials.

Deleting a role now also removes its assignments from persisted users and the runtime cache.

Includes regression tests for settings disclosure and role deletion cleanup.