### PR TITLE
fix: gauge import fallback in electron

### DIFF
--- a/client/src/app/gui-helpers/ngx-gauge/ngx-gauge.component.ts
+++ b/client/src/app/gui-helpers/ngx-gauge/ngx-gauge.component.ts
@@ -7,6 +7,15 @@ import { Subject, interval, take, takeUntil } from 'rxjs';
 declare const Gauge: any;
 declare const Donut: any;
 
+// In Electron (nodeIntegration: true), gauge.js detects module.exports and skips setting window globals.
+// Fall back to require() to get the CommonJS export directly.
+function getGaugeClasses(): { Gauge: any, Donut: any } {
+    if (typeof Gauge !== 'undefined') {
+        return { Gauge, Donut };
+    }
+    return require('../../../assets/lib/gauge/gauge.js');
+}
+
 @Component({
     selector: 'ngx-gauge',
     templateUrl: './ngx-gauge.component.html',
@@ -131,14 +140,15 @@ export class NgxGaugeComponent implements OnInit, AfterViewInit, OnDestroy, OnCh
 
     init(type: GaugeType) {
         this.type = type;
+        const { Gauge: GaugeClass, Donut: DonutClass } = getGaugeClasses();
         if (type === GaugeType.Gauge) {
-            this.gauge = new Gauge(this.canvas.nativeElement);
+            this.gauge = new GaugeClass(this.canvas.nativeElement);
             this.gauge.setTextField(this.gaugetext.nativeElement);
         } else if (type === GaugeType.Zones) {
-            this.gauge = new Gauge(this.canvas.nativeElement);
+            this.gauge = new GaugeClass(this.canvas.nativeElement);
             this.gauge.setTextField(this.gaugetext.nativeElement);
         } else if (type === GaugeType.Donut) {
-            this.gauge = new Donut(this.canvas.nativeElement);
+            this.gauge = new DonutClass(this.canvas.nativeElement);
             this.gauge.setTextField(this.gaugetext.nativeElement);
         }
         const value = Number(this.options.minValue) + 1;


### PR DESCRIPTION
## 📌 Description

**Bug:**

Gauges are not rendered in electron app.  The gauges are shown as white boxes. Gauges work otherwise normally. 


Example screenshots below from latest electron build. Left side is electron app and right side is browser:
<img width="1939" height="767" alt="fuxa gauge bug" src="https://github.com/user-attachments/assets/fc0e03d3-1e14-4ade-a6ab-76a1ba89ee16" />

Same happens in editor:
<img width="1937" height="768" alt="fuxa gauge bug editor" src="https://github.com/user-attachments/assets/5f7e47e8-72a5-40b7-99ce-c1d60c709eef" />


**Reason for the bug:** 

In `gauge.js:974` else if check
```js
} else if (typeof module !== 'undefined' && (module.exports != null)) {
```
should evaluate false but evaluates true because `nodeIntegration: true` injects Node.js globals (in this case `module`) which in electron app causes `gauge.js` to use headless version exports. 

**Solution:** 
Added fallback require to `/ngx-gauge.component.ts`  that imports the gauge for electron app.  

Alternative fix would be to check if window is defined in `gauge.js:974`
```js
} else if (typeof module !== 'undefined' && module.exports != null && typeof window === 'undefined') {
```


After fix:
<img width="1942" height="772" alt="fuxa gauge bug fixed" src="https://github.com/user-attachments/assets/2c1b52f5-81af-4182-ad6a-6f081933e147" />

And editor: 
<img width="1945" height="774" alt="fuxa gauge bug editor fixed" src="https://github.com/user-attachments/assets/773b6469-9c1d-42ae-b1e0-a0f2320e54f7" />


I tested the fix on Windows. Any Feedback on the preferred fix approach welcome.


## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [x] Documentation updated if required
- [x] Issue opened (for major changes)


## 📝 Additional Notes

Add any other context or screenshots here.