### PR TITLE
fix: re-trigger resize after async view load in grid cards

### DIFF
--- a/client/src/app/cards-view/cards-view.component.ts
+++ b/client/src/app/cards-view/cards-view.component.ts
@@ -119,6 +119,7 @@ export class CardsViewComponent implements OnInit, AfterViewInit {
                 }
                 this.itemChange(item, itemComponent);
                 this.changeDetector.detectChanges();
+                this.gridOptions.itemResizeCallback?.(item, itemComponent)
             }
         };
         this.dashboard.push(item);


### PR DESCRIPTION
## 📌 Description

**Problem:** 
Grid view cells clip instead of properly scaling, regardless of scale mode. The bug is caused by the async loading of the grid view. Gridster fires `itemResizeCallback` before item content is set. 

**How to replicate:** 
1. Create a view with text like in the screnshot below: <img width="1045" height="750" alt="fuxa grid view example 1" src="https://github.com/user-attachments/assets/6505daff-284e-4187-8e46-7a33710daf6f" />
2. Add the view to grid and scale the cell smaller than the actual size of the view: <img width="1045" height="750" alt="fuxa grid view example 2" src="https://github.com/user-attachments/assets/86bfaf2f-4d7d-405a-b2f2-e25cc0053778" />
3. The view is clipped: <img width="1045" height="748" alt="fuxa grid view broken" src="https://github.com/user-attachments/assets/789ca160-e976-40d2-8d69-4e01bc99ef8f" />

**Fix:**
 Call `this.gridOptions.itemResizeCallback` at the end of `initCallback`, after the view is loaded and change detection has run. 

What it looks like in after fix: 
<img width="1041" height="750" alt="fuxa grid view fixed" src="https://github.com/user-attachments/assets/e8e67e02-5a2d-4444-be24-b608b431ba41" />

---

## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [x] Documentation updated if required
- [x] Issue opened (for major changes)
