### PR TITLE
Fix API rate limiter middleware ordering

### DIFF
--- a/server/api/index.js
+++ b/server/api/index.js
@@ -50,6 +50,23 @@ function init(_server, _runtime) {
             apiApp.use(bodyParser.urlencoded({limit:maxApiRequestSize, extended: true}));
             authJwt.init(runtime.settings.secureEnabled, runtime.settings.secretCode, runtime.settings.tokenExpiresIn);
             const authMiddleware = verifyApiOrToken(runtime);
+
+            const authLimiter = rateLimit({
+                windowMs: runtime.settings.authRateLimitWindowMs || 5 * 60 * 1000,
+                max: runtime.settings.authRateLimitMax || 100,
+                skip: (req) => req.path !== '/api/signin' && req.path !== '/api/refresh'
+            });
+
+            const limiter = rateLimit({
+                windowMs: runtime.settings.apiRateLimitWindowMs || 5 * 60 * 1000,
+                max: runtime.settings.apiRateLimitMax || 1000,
+                skip: (req) => req.path === '/api/version'
+            });
+
+            // Apply before route handlers so sub-routers are covered too.
+            apiApp.use(authLimiter);
+            apiApp.use(limiter);
+
             prjApi.init(runtime, authMiddleware, verifyGroups);
             apiApp.use(prjApi.app());
             usersApi.init(runtime, authMiddleware, verifyGroups);
@@ -76,16 +93,6 @@ function init(_server, _runtime) {
             apiApp.use(reportsApi.app());
             apiKeysApi.init(runtime, authMiddleware, verifyGroups);
             apiApp.use(apiKeysApi.app());
-
-            const limiter = rateLimit({
-                windowMs: 5 * 60 * 1000, // 5 minutes
-                max: 100, // limit each IP to 100 requests per windowMs
-                // Keep lightweight health/version checks unthrottled
-                skip: (req) => req.path === '/api/version'
-            });
-
-            //  apply to all requests
-            apiApp.use(limiter);
 
             apiApp.use((err, req, res, next) => {
                 if (err?.type === 'entity.too.large') {
@@ -271,6 +278,18 @@ function mergeUserSettings(settings) {
     runtime.settings.broadcastAll = settings.broadcastAll;
     if (!utils.isNullOrUndefined(settings.lazyViewLoading)) {
         runtime.settings.lazyViewLoading = settings.lazyViewLoading;
+    }
+    if (!utils.isNullOrUndefined(settings.apiRateLimitWindowMs)) {
+        runtime.settings.apiRateLimitWindowMs = settings.apiRateLimitWindowMs;
+    }
+    if (!utils.isNullOrUndefined(settings.apiRateLimitMax)) {
+        runtime.settings.apiRateLimitMax = settings.apiRateLimitMax;
+    }
+    if (!utils.isNullOrUndefined(settings.authRateLimitWindowMs)) {
+        runtime.settings.authRateLimitWindowMs = settings.authRateLimitWindowMs;
+    }
+    if (!utils.isNullOrUndefined(settings.authRateLimitMax)) {
+        runtime.settings.authRateLimitMax = settings.authRateLimitMax;
     }
     runtime.settings.secureEnabled = settings.secureEnabled;
     runtime.settings.logFull = settings.logFull;

--- a/server/settings.default.js
+++ b/server/settings.default.js
@@ -88,6 +88,14 @@ module.exports = {
     // Default: 100mb
     //apiMaxLength: '100mb',
 
+    // API rate limiting.
+    // apiRateLimit* is intentionally generous for HMI/SCADA workloads and clients
+    // behind the same proxy/NAT. authRateLimit* applies only to signin/refresh.
+    apiRateLimitWindowMs: 5 * 60 * 1000,
+    apiRateLimitMax: 1000,
+    authRateLimitWindowMs: 5 * 60 * 1000,
+    authRateLimitMax: 100,
+
     // Used to disable the server API used for Backend communication (Standalone application)
     // disable to use only the Editor
     //disableServer: false,

--- a/server/test/authorization/rateLimiterOrderSecurity.test.js
+++ b/server/test/authorization/rateLimiterOrderSecurity.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Security - API rate limiter ordering', () => {
+    let expect;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    it('registers the rate limiter before API sub-routers', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../../api/index.js'), 'utf8');
+        const limiterIndex = source.indexOf('apiApp.use(limiter)');
+        const authLimiterIndex = source.indexOf('apiApp.use(authLimiter)');
+
+        expect(limiterIndex).to.be.greaterThan(-1);
+        expect(authLimiterIndex).to.be.greaterThan(-1);
+        for (const marker of [
+            'apiApp.use(prjApi.app())',
+            'apiApp.use(usersApi.app())',
+            'apiApp.use(authApi.app())',
+            'apiApp.use(commandApi.app())',
+            'apiApp.use(apiKeysApi.app())'
+        ]) {
+            expect(source.indexOf(marker), marker).to.be.greaterThan(limiterIndex);
+        }
+        expect(source.indexOf('apiApp.use(authApi.app())')).to.be.greaterThan(authLimiterIndex);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes API rate limiter middleware ordering so rate limiting is applied before API route handlers (GHSA-f2c8-x9gv-37m8).

This ensures API sub-routers are covered by the limiter instead of only routes registered after it.

## Changes

- Move API rate limiter registration before API routers
- Add a separate auth-focused limiter for `/api/signin` and `/api/refresh`
- Make global/auth rate limit values configurable through settings
- Add regression coverage for middleware ordering

## Defaults

- Global API limit: `1000` requests / 5 minutes
- Auth endpoints limit: `100` requests / 5 minutes
- `/api/version` remains excluded from the global limiter
