### PR TITLE
Bind runscript execution to authorized script ID

### DIFF
--- a/server/api/scripts/index.js
+++ b/server/api/scripts/index.js
@@ -39,6 +39,9 @@ module.exports = {
             } else if (script?.test && (!req.isAuthenticated || !authJwt.haveAdminPermission(permission))) {
                 res.status(401).json({ error: "unauthorized_error", message: "Unauthorized!" });
                 runtime.logger.error("api post runscript: Unauthorized test mode");
+            } else if (!script?.test && !script?.id) {
+                res.status(400).json({ error: "invalid_request", message: "Script id is required!" });
+                runtime.logger.error("api post runscript: Missing script id");
             } else if (!runtime.scriptsMgr.isAuthorised(script, permission)) {
                 res.status(400).json({ error: "unauthorized_error", message: "Unauthorized!" });
                 runtime.logger.error("api post runscript: Unauthorized");

--- a/server/runtime/scripts/msm.js
+++ b/server/runtime/scripts/msm.js
@@ -58,7 +58,7 @@ function MyScriptsModule(_events, _logger) {
     this.runScript = function (_script) {
         if (scriptsModule) {
             var paramValues = _script.parameters.map(p => utils.isNullOrUndefined(p.value) ? p : p.value);
-            if (!_script.name) {
+            if (_script.id) {
                 _script = Object.values(scriptsMap).find(s => s.id === _script.id);
             }
             try {

--- a/server/test/authorization/runscriptSecurity.test.js
+++ b/server/test/authorization/runscriptSecurity.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const http = require('http');
+const express = require('express');
+
+const scriptsApi = require('../../api/scripts');
+const MyScriptModule = require('../../runtime/scripts/msm');
+
+function makeLogger() {
+    return {
+        warn: () => {},
+        error: () => {}
+    };
+}
+
+function request(app, method, path, body) {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, () => {
+            const data = body ? JSON.stringify(body) : '';
+            const options = {
+                method,
+                port: server.address().port,
+                path,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(data)
+                }
+            };
+
+            const req = http.request(options, (res) => {
+                let responseBody = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => { responseBody += chunk; });
+                res.on('end', () => {
+                    server.close(() => resolve({
+                        statusCode: res.statusCode,
+                        body: responseBody ? JSON.parse(responseBody) : null
+                    }));
+                });
+            });
+
+            req.on('error', (err) => {
+                server.close(() => reject(err));
+            });
+
+            if (data) {
+                req.write(data);
+            }
+            req.end();
+        });
+    });
+}
+
+describe('Security - runscript authorization target binding', () => {
+    let expect;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    function makeScriptModule() {
+        return MyScriptModule.create(
+            { emit: () => {} },
+            {
+                warn: () => {},
+                error: () => {}
+            }
+        );
+    }
+
+    it('executes the script identified by id even when a different name is supplied', async () => {
+        const scriptModule = makeScriptModule();
+        scriptModule.init({});
+        scriptModule.loadScripts([
+            {
+                id: 'public-script-id',
+                name: 'public_script',
+                sync: false,
+                parameters: [],
+                code: 'return "public";'
+            },
+            {
+                id: 'admin-script-id',
+                name: 'admin_script',
+                sync: false,
+                parameters: [],
+                code: 'return "admin";'
+            }
+        ]);
+
+        const result = await scriptModule.runScript({
+            id: 'public-script-id',
+            name: 'admin_script',
+            parameters: []
+        });
+
+        expect(result).to.equal('public');
+    });
+
+    it('rejects normal /api/runscript requests without a script id', async () => {
+        const calls = { authorised: 0, run: 0 };
+        const app = express();
+        app.use(express.json());
+
+        scriptsApi.init(
+            {
+                project: {},
+                logger: makeLogger(),
+                scriptsMgr: {
+                    isAuthorised: () => {
+                        calls.authorised += 1;
+                        return true;
+                    },
+                    runScript: () => {
+                        calls.run += 1;
+                        return Promise.resolve('executed');
+                    }
+                }
+            },
+            (req, res, next) => {
+                req.isAuthenticated = true;
+                next();
+            },
+            () => -1
+        );
+
+        app.use(scriptsApi.app());
+
+        const res = await request(app, 'POST', '/api/runscript', {
+            params: {
+                script: {
+                    name: 'admin_script',
+                    parameters: []
+                }
+            }
+        });
+
+        expect(res.statusCode).to.equal(400);
+        expect(res.body.error).to.equal('invalid_request');
+        expect(calls.authorised).to.equal(0);
+        expect(calls.run).to.equal(0);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes runscript authorization so the script that is executed is bound to the authorized script ID, not only to a caller-supplied script name.

## Changes

- Require normal `/api/runscript` requests to include a script `id`
- Preserve the authorized script identity when dispatching script execution
- Ensure script execution resolves by `id` even if a different `name` is supplied
- Add regression tests for the authorization target binding