### PR TITLE
Add tag value support to alarm text

### DIFF
--- a/client/src/app/_models/alarm.ts
+++ b/client/src/app/_models/alarm.ts
@@ -140,6 +140,7 @@ export interface AlarmBaseType {
     bkcolor: string;
     color: string;
     toack: boolean;
+    value: any;
 }
 
 export enum AlarmActionsType {

--- a/client/src/app/alarms/alarm-view/alarm-view.component.ts
+++ b/client/src/app/alarms/alarm-view/alarm-view.component.ts
@@ -197,6 +197,7 @@ export class AlarmViewComponent implements OnInit, AfterViewInit, OnDestroy {
         ).subscribe(result => {
             if (result) {
                 result.forEach(alr => {
+                    alr.text = this.formatAlarmText(alr.text, alr.value);
                     alr.status = this.getStatus(alr.status);
                     alr.type = this.getPriority(alr.type);
                 });

--- a/client/src/app/alarms/alarm-view/alarm-view.component.ts
+++ b/client/src/app/alarms/alarm-view/alarm-view.component.ts
@@ -122,7 +122,7 @@ export class AlarmViewComponent implements OnInit, AfterViewInit, OnDestroy {
     updateAlarmsList(alr: AlarmBaseType[]) {
         if (this.showType === AlarmShowType.alarms) {
             alr.forEach(alr => {
-                alr.text = this.languageService.getTranslation(alr.text) ?? alr.text;
+                alr.text = this.formatAlarmText(alr.text, alr.value);
                 alr.group = this.languageService.getTranslation(alr.group) ?? alr.group;
                 alr.status = this.getStatus(alr.status);
                 alr.type = this.getPriority(alr.type);
@@ -204,6 +204,14 @@ export class AlarmViewComponent implements OnInit, AfterViewInit, OnDestroy {
             }
 		    this.alarmsLoading = false;
         });
+    }
+
+    private formatAlarmText(text: string, value: any): string {
+        const translatedText = this.languageService.getTranslation(text) ?? text;
+        if (translatedText && value !== undefined && value !== null) {
+            return translatedText.split('%d').join(String(value));
+        }
+        return translatedText;
     }
 }
 

--- a/client/src/app/gauges/controls/html-table/data-table/data-table.component.ts
+++ b/client/src/app/gauges/controls/html-table/data-table/data-table.component.ts
@@ -315,7 +315,7 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy {
                 type: { stringValue: this.priorityText[alr.type] },
                 name: { stringValue: alr.name },
                 status: { stringValue: this.statusText[alr.status] },
-                text: { stringValue: this.languageService.getTranslation(alr.text) ?? alr.text },
+                text: { stringValue: this.formatAlarmText(alr.text, alr.value) },
                 group: { stringValue: this.languageService.getTranslation(alr.group) ?? alr.group },
                 ontime: { stringValue: format(new Date(alr.ontime), 'YYYY.MM.DD HH:mm:ss') },
                 color: alr.color,
@@ -339,6 +339,14 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy {
         }
         this.lastRenderedSignature = nextSignature;
         this.dataSource.data = rows;
+    }
+
+    private formatAlarmText(text: string, value: any): string {
+        const translatedText = this.languageService.getTranslation(text) ?? text;
+        if (translatedText && value !== undefined && value !== null) {
+            return translatedText.split('%d').join(String(value));
+        }
+        return translatedText;
     }
 
     updateReportsTable(reports: ReportFile[]) {

--- a/server/runtime/alarms/alarmstorage.js
+++ b/server/runtime/alarms/alarmstorage.js
@@ -54,14 +54,38 @@ function _bind() {
         });
         // prepare query
         var sql = "CREATE TABLE if not exists alarms (nametype TEXT PRIMARY KEY, type TEXT, status TEXT, ontime INTEGER, offtime INTEGER, acktime INTEGER);";
-        sql += "CREATE TABLE if not exists chronicle (Sn INTEGER, nametype TEXT, type TEXT, status TEXT, text TEXT, grp TEXT, ontime INTEGER, offtime INTEGER, acktime INTEGER, userack TEXT, PRIMARY KEY(Sn AUTOINCREMENT));";
+        sql += "CREATE TABLE if not exists chronicle (Sn INTEGER, nametype TEXT, type TEXT, status TEXT, text TEXT, grp TEXT, ontime INTEGER, offtime INTEGER, acktime INTEGER, userack TEXT, value TEXT, PRIMARY KEY(Sn AUTOINCREMENT));";
         db_alarms.exec(sql, function (err) {
             if (err) {
                 logger.error('alarmsstorage.failed-to-bind: ' + err);
                 reject();
             } else {
-                resolve(dbfileExist);
+                _ensureColumn('chronicle', 'value', 'TEXT').then(() => {
+                    resolve(dbfileExist);
+                }).catch(reject);
             }
+        });
+    });
+}
+
+function _ensureColumn(table, column, definition) {
+    return new Promise((resolve, reject) => {
+        db_alarms.all(`PRAGMA table_info(${table})`, function (err, rows) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            if (rows.some(row => row.name === column)) {
+                resolve();
+                return;
+            }
+            db_alarms.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`, function (alterErr) {
+                if (alterErr) {
+                    reject(alterErr);
+                } else {
+                    resolve();
+                }
+            });
         });
     });
 }
@@ -164,8 +188,8 @@ function setAlarms(alarms) {
                     [alarmId, alr.type, status, alr.ontime, alr.offtime, alr.acktime]
                 );
                 await _run(
-                    "INSERT OR REPLACE INTO chronicle (Sn, nametype, type, status, text, grp, ontime, offtime, acktime, userack) VALUES ((SELECT Sn from chronicle WHERE ontime = ? AND nametype = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    [alr.ontime, alarmId, alarmId, alr.type, status, alr.subproperty.text, grp, alr.ontime, alr.offtime, alr.acktime, userack]
+                    "INSERT OR REPLACE INTO chronicle (Sn, nametype, type, status, text, grp, ontime, offtime, acktime, userack, value) VALUES ((SELECT Sn from chronicle WHERE ontime = ? AND nametype = ?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    [alr.ontime, alarmId, alarmId, alr.type, status, alr.subproperty.text, grp, alr.ontime, alr.offtime, alr.acktime, userack, alr.value]
                 );
                 if (alr.toremove) {
                     await _run("DELETE FROM alarms WHERE nametype = ?", [alarmId]);

--- a/server/runtime/alarms/index.js
+++ b/server/runtime/alarms/index.js
@@ -101,7 +101,7 @@ function AlarmsManager(_runtime) {
                 if (alr.status && alr.type !== AlarmsTypes.ACTION) {
                     var alritem = { name: alr.getId(), type: alr.type, ontime: alr.ontime, offtime: alr.offtime, acktime: alr.acktime,
                         status: alr.status, text: alr.subproperty.text, group: alr.subproperty.group,
-                        bkcolor: alr.subproperty.bkcolor, color: alr.subproperty.color, toack: alr.isToAck() };
+                        bkcolor: alr.subproperty.bkcolor, color: alr.subproperty.color, toack: alr.isToAck(), value: alr.value };
                     var alrPermission = { show: true, enabled: true };
                     if (alr.tagproperty) {
                         alrPermission = runtime.checkPermission(permission, alr.tagproperty);
@@ -303,7 +303,7 @@ function AlarmsManager(_runtime) {
                 if (tag !== null) {
                     groupalarms.forEach(alr => {
                         var value = _checkBitmask(alr, tag.value);
-                        if (alr.check(time, tag.ts, value)) {
+                        if (alr.check(time, tag.ts, value, tag.value)) {
                             changed.push(alr);
                         }
                     });
@@ -558,12 +558,13 @@ function Alarm(name, type, subprop, tagprop) {
     this.lastcheck = 0;
     this.toremove = false;
     this.userack;
+    this.value;
 
     this.getId = function () {
         return this.name + '^~^' + this.type;
     }
 
-    this.check = function (time, dt, value) {
+    this.check = function (time, dt, value, displayValue) {
         if (this.lastcheck + (this.subproperty.checkdelay * TimeMultiplier) > time) {
             return false;
         }
@@ -582,6 +583,7 @@ function Alarm(name, type, subprop, tagprop) {
                 }
                 if (this.ontime + (this.subproperty.timedelay * TimeMultiplier) <= time) {
                     this.status = AlarmStatusEnum.ON;
+                    this.value = displayValue;
                     return true;
                 }
             case AlarmStatusEnum.ON:
@@ -610,6 +612,7 @@ function Alarm(name, type, subprop, tagprop) {
 					this.offtime = 0;
                     this.ontime = time;
                     this.userack = '';
+                    this.value = displayValue;
                     return true;
                 }
                 // remove if acknowledged
@@ -639,6 +642,7 @@ function Alarm(name, type, subprop, tagprop) {
         this.status = AlarmStatusEnum.VOID;
         this.lastcheck = 0;
         this.userack = '';
+        this.value = undefined;
     }
 
     this.toRemove = function () {

--- a/server/runtime/alarms/index.js
+++ b/server/runtime/alarms/index.js
@@ -147,6 +147,7 @@ function AlarmsManager(_runtime) {
                     alr.acktime = result[i].acktime;
                     alr.userack = result[i].userack;
                     alr.group = result[i].grp;
+                    alr.value = result[i].value;
                     if (alr.ontime) {
                         var alrPermission = { show: true, enabled: true };
                         if (alarmsProperty[alr.name]) {

--- a/server/test/storage/storage-insert-select.test.js
+++ b/server/test/storage/storage-insert-select.test.js
@@ -3,10 +3,29 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
 
 const prjstorage = require('../../runtime/project/prjstorage');
 const apiKeysStorage = require('../../runtime/apikeys/apikeysStorage');
 const alarmstorage = require('../../runtime/alarms/alarmstorage');
+
+function runSql(db, sql, params = []) {
+    return new Promise((resolve, reject) => {
+        db.run(sql, params, function (err) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(this);
+            }
+        });
+    });
+}
+
+function closeDb(db) {
+    return new Promise((resolve, reject) => {
+        db.close(err => err ? reject(err) : resolve());
+    });
+}
 
 function makeLogger() {
     return {
@@ -120,6 +139,7 @@ describe('Storage insert/select regression', () => {
                 offtime: 0,
                 acktime: 0,
                 userack: '',
+                value: 42,
                 toremove: false,
                 subproperty: { group: 'default', text: 'High temperature' }
             };
@@ -134,6 +154,36 @@ describe('Storage insert/select regression', () => {
             const history = await alarmstorage.getAlarmsHistory(0, Number.MAX_SAFE_INTEGER);
             expect(history.length).to.be.greaterThan(0);
             expect(history[0].nametype).to.equal('dev1.tag1');
+            expect(history[0].value).to.equal('42');
+        });
+
+        it('migrates old chronicle schema without value column', async () => {
+            alarmstorage.close();
+            const dbfile = path.join(workDir, 'alarms.fuxap.db');
+            fs.unlinkSync(dbfile);
+            const db = new sqlite3.Database(dbfile);
+            await runSql(db, 'CREATE TABLE alarms (nametype TEXT PRIMARY KEY, type TEXT, status TEXT, ontime INTEGER, offtime INTEGER, acktime INTEGER)');
+            await runSql(db, 'CREATE TABLE chronicle (Sn INTEGER, nametype TEXT, type TEXT, status TEXT, text TEXT, grp TEXT, ontime INTEGER, offtime INTEGER, acktime INTEGER, userack TEXT, PRIMARY KEY(Sn AUTOINCREMENT))');
+            await closeDb(db);
+
+            await alarmstorage.init({ workDir }, makeLogger());
+
+            const alarm = {
+                getId: () => 'dev1.tag2',
+                type: 'analog',
+                status: 'active',
+                ontime: 1710000001000,
+                offtime: 0,
+                acktime: 0,
+                userack: '',
+                value: 73,
+                toremove: false,
+                subproperty: { group: 'default', text: 'Pressure %d' }
+            };
+
+            await alarmstorage.setAlarms([alarm]);
+            const history = await alarmstorage.getAlarmsHistory(0, Number.MAX_SAFE_INTEGER);
+            expect(history.find(row => row.nametype === 'dev1.tag2').value).to.equal('73');
         });
     });
 });


### PR DESCRIPTION
## Description

Adds support for replacing %d in alarm text with the tag value captured when the alarm becomes active.

---

## Changes

* Captures the tag value at alarm activation time, so active alarm text behaves like an event message and does not change with live tag updates.
* Applies %d replacement after the existing language placeholder resolution.
* Stores the captured value in alarm history using a nullable chronicle.value column.
* Adds an idempotent migration for existing alarm history databases.
* Keeps stored alarm text unchanged.
* Keeps old history rows compatible; if no stored value exists, %d remains unchanged.

