### PR TITLE
Add PLUM ecoNEXT Gateway integration

### DIFF
--- a/client/src/app/_models/device.ts
+++ b/client/src/app/_models/device.ts
@@ -40,7 +40,7 @@ export class Device {
         id: 'Device id, GUID',
         name: 'Device name',
         enabled: 'Enabled',
-        type: 'Device Type: FuxaServer | SiemensS7 | OPCUA | BACnet | ModbusRTU | ModbusTCP | WebAPI | MQTTclient | internal | EthernetIP | ADSclient | Gpio | WebCam | MELSEC | REDIS',
+        type: 'Device Type: FuxaServer | SiemensS7 | OPCUA | BACnet | PlumEconextGateway | ModbusRTU | ModbusTCP | WebAPI | MQTTclient | internal | EthernetIP | ADSclient | Gpio | WebCam | MELSEC | REDIS',
         polling: 'Polling interval in millisec., check changed value after ask value, by OPCUA there is a monitor',
         property: 'Connection property depending of type',
         tags: 'Tags list of Tag',
@@ -189,6 +189,8 @@ export class DeviceNetProperty {
     method: string;
     /** Data format flag used for WebAPI (CSV/JSON) */
     format: string;
+    /** HTTP timeout used by REST based device drivers. */
+    timeout?: number;
     /** Connection option used for Modbus RTU/TCP, Redis for readMode */
     connectionOption: string;
     /** Delay used for Modbus RTU/TCP delay between frame*/
@@ -240,6 +242,7 @@ export enum DeviceType {
     SiemensS7 = 'SiemensS7',
     OPCUA = 'OPCUA',
     BACnet = 'BACnet',
+    PlumEconextGateway = 'PlumEconextGateway',
     ModbusRTU = 'ModbusRTU',
     ModbusTCP = 'ModbusTCP',
     WebAPI = 'WebAPI',

--- a/client/src/app/_models/plugin.ts
+++ b/client/src/app/_models/plugin.ts
@@ -1,4 +1,6 @@
 export class Plugin {
+    id: string;
+    displayName: string;
     name: string;
     type: PluginType | PluginGroupType;
     version: string;

--- a/client/src/app/_services/hmi.service.ts
+++ b/client/src/app/_services/hmi.service.ts
@@ -117,6 +117,32 @@ export class HmiService {
         }
     }
 
+    /** Write a device value and wait for the backend/driver acknowledgement. */
+    putSignalValueWithResult(sigId: string, value: any): Promise<{ success: boolean; error?: string; details?: any }> {
+        sigId = this.deviceAdapaterService.resolveAdapterTagsId([sigId])[0];
+        const device = this.projectService.getDeviceFromTagId(sigId);
+        if (!device) return Promise.resolve({ success: false, error: 'Device not found' });
+        const variable = new Variable(sigId, null, null);
+        variable.value = value;
+        variable.source = device.id;
+        if (this.socket) {
+            return new Promise(resolve => {
+                this.socket.timeout(15000).emit(IoEventTypes.DEVICE_VALUES,
+                    { cmd: 'set', var: variable, fnc: [null, value] },
+                    (error, response) => {
+                        if (error) resolve({ success: false, error: 'Write acknowledgement timeout' });
+                        else resolve(response || { success: false, error: 'Empty write acknowledgement' });
+                    });
+            });
+        }
+        if (this.bridge) {
+            return Promise.resolve(this.bridge.setDeviceValue(variable, { fnc: [null, value] }))
+                .then(success => ({ success: success === true }))
+                .catch(error => ({ success: false, error: error?.message || String(error) }));
+        }
+        return Promise.resolve({ success: false, error: 'No backend connection' });
+    }
+
     public getAllSignals() {
         return this.variables;
     }

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -188,6 +188,7 @@ import { TagPropertyEditModbusComponent } from './device/tag-property/tag-proper
 import { TagPropertyEditInternalComponent } from './device/tag-property/tag-property-edit-internal/tag-property-edit-internal.component';
 import { TagPropertyEditOpcuaComponent } from './device/tag-property/tag-property-edit-opcua/tag-property-edit-opcua.component';
 import { TagPropertyEditBacnetComponent } from './device/tag-property/tag-property-edit-bacnet/tag-property-edit-bacnet.component';
+import { TagPropertyEditPlumEconetComponent } from './device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component';
 import { TagPropertyEditWebapiComponent } from './device/tag-property/tag-property-edit-webapi/tag-property-edit-webapi.component';
 import { TagPropertyEditEthernetipComponent } from './device/tag-property/tag-property-edit-ethernetip/tag-property-edit-ethernetip.component';
 import { ViewPropertyComponent } from './editor/view-property/view-property.component';
@@ -268,6 +269,7 @@ export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
         TagPropertyEditInternalComponent,
         TagPropertyEditOpcuaComponent,
         TagPropertyEditBacnetComponent,
+        TagPropertyEditPlumEconetComponent,
         TagPropertyEditWebapiComponent,
         TagPropertyEditEthernetipComponent,
         TagPropertyEditADSclientComponent,

--- a/client/src/app/device/device-list/device-list.component.ts
+++ b/client/src/app/device/device-list/device-list.component.ts
@@ -203,7 +203,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
     }
 
     onAddTag() {
-        if (this.deviceSelected.type === DeviceType.OPCUA || this.deviceSelected.type === DeviceType.BACnet || this.deviceSelected.type === DeviceType.WebAPI) {
+        if (this.deviceSelected.type === DeviceType.OPCUA || this.deviceSelected.type === DeviceType.BACnet || this.deviceSelected.type === DeviceType.PlumEconextGateway || this.deviceSelected.type === DeviceType.WebAPI) {
             this.addOpcTags();
         } else if (this.deviceSelected.type === DeviceType.MQTTclient) {
             this.editTopics();
@@ -226,6 +226,12 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
             });
             return;
         }
+        if (this.deviceSelected.type === DeviceType.PlumEconextGateway) {
+            this.tagPropertyService.editTagPropertyPlumEconext(this.deviceSelected, this.tagsMap).subscribe(() => {
+                this.bindToTable(this.deviceSelected.tags);
+            });
+            return;
+        }
         if (this.deviceSelected.type === DeviceType.WebAPI) {
             this.tagPropertyService.editTagPropertyWebapi(this.deviceSelected, this.tagsMap).subscribe(result => {
                 this.bindToTable(this.deviceSelected.tags);
@@ -243,7 +249,7 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
     }
 
     getTagLabel(tag: Tag) {
-        if (this.deviceSelected.type === DeviceType.BACnet || this.deviceSelected.type === DeviceType.WebAPI) {
+        if (this.deviceSelected.type === DeviceType.BACnet || this.deviceSelected.type === DeviceType.PlumEconextGateway || this.deviceSelected.type === DeviceType.WebAPI) {
             return tag.label || tag.name;
         } else if (this.deviceSelected.type === DeviceType.OPCUA) {
             return tag.label;
@@ -276,7 +282,8 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
         if (type === DeviceType.SiemensS7 || type === DeviceType.ModbusTCP || type === DeviceType.ModbusRTU ||
             type === DeviceType.internal || type === DeviceType.EthernetIP || type === DeviceType.OmronEthernetIP || type === DeviceType.FuxaServer ||
             type === DeviceType.OPCUA || type === DeviceType.GPIO || type === DeviceType.ADSclient ||
-            type === DeviceType.WebCam || type === DeviceType.MELSEC || type === DeviceType.REDIS) {
+            type === DeviceType.WebCam || type === DeviceType.MELSEC || type === DeviceType.REDIS ||
+            type === DeviceType.PlumEconextGateway) {
             return true;
         } else if (type === DeviceType.MQTTclient) {
             if (tag && tag.options && (tag.options.pubs || tag.options.subs)) {
@@ -286,8 +293,15 @@ export class DeviceListComponent implements OnInit, AfterViewInit {
         return false;
     }
 
-    editTag(tag: Tag, checkToAdd: boolean) {
-        if (this.deviceSelected.type === DeviceType.SiemensS7) {
+      editTag(tag: Tag, checkToAdd: boolean) {
+          if (this.deviceSelected.type === DeviceType.PlumEconextGateway) {
+              this.tagPropertyService.editTagPropertyPlumEconext(this.deviceSelected, this.tagsMap, tag).subscribe(() => {
+                  this.tagsMap[tag.id] = tag;
+                  this.bindToTable(this.deviceSelected.tags);
+              });
+              return;
+          }
+          if (this.deviceSelected.type === DeviceType.SiemensS7) {
             this.tagPropertyService.editTagPropertyS7(this.deviceSelected, tag, checkToAdd).subscribe(result => {
                 this.tagsMap[tag.id] = tag;
                 this.bindToTable(this.deviceSelected.tags);

--- a/client/src/app/device/device-property/device-property.component.html
+++ b/client/src/app/device/device-property/device-property.component.html
@@ -118,6 +118,20 @@
                             placeholder="{{'device.property-adpu-timeout-ph' | translate}}" class="adpu" type="number">
                     </div>
                 </div>
+                <div *ngSwitchCase="deviceType.PlumEconextGateway">
+                    <!-- Address of the REST service exposed by econext-gateway. -->
+                    <div class="my-form-field block mb10">
+                        <span>{{'device.property-plum-econext-gateway' | translate}}</span>
+                        <input [(ngModel)]="data.device.property.address"
+                            placeholder="http://192.168.1.10:8000" style="width: 350px" type="text"
+                            (click)="onAddressChanged()">
+                    </div>
+                    <div class="my-form-field block">
+                        <span>{{'device.property-http-timeout' | translate}} (ms)</span>
+                        <input numberOnly [(ngModel)]="data.device.property.timeout"
+                            placeholder="5000" style="width: 100px" type="text">
+                    </div>
+                </div>
                 <div *ngSwitchCase="deviceType.SiemensS7">
                     <div class="my-form-field" style="display: block;margin-bottom: 10px;">
                         <span>{{'device.property-address-s7' | translate}}</span>

--- a/client/src/app/device/device-property/device-property.component.ts
+++ b/client/src/app/device/device-property/device-property.component.ts
@@ -286,8 +286,12 @@ export class DevicePropertyComponent implements OnInit, OnDestroy {
 	}
 
 	onDeviceTypeChanged() {
-		if (this.data.device.type === DeviceType.WebAPI ) {
+		if (this.data.device.type === DeviceType.WebAPI || this.data.device.type === DeviceType.PlumEconextGateway) {
 			this.pollingType = this.pollingWebApiType;
+			if (this.data.device.type === DeviceType.PlumEconextGateway && !this.data.device.polling) {
+				// ecoNEXT recommends clients poll every 5-10 seconds.
+				this.data.device.polling = 5000;
+			}
 		} else if (this.data.device.type === DeviceType.WebCam) {
             this.pollingType = this.pollingWebCamType;
         } else {

--- a/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
+++ b/client/src/app/device/device-tag-selection/device-tag-selection.component.ts
@@ -136,6 +136,10 @@ export class DeviceTagSelectionComponent implements OnInit, AfterViewInit, OnDes
             this.tagPropertyService.editTagPropertyBacnet(device).subscribe(result => {
                 this.loadDevicesTags();
             });
+        } else if (device.type === DeviceType.PlumEconextGateway) {
+            this.tagPropertyService.editTagPropertyPlumEconext(device).subscribe(() => {
+                this.loadDevicesTags();
+            });
         } else if (device.type === DeviceType.WebAPI) {
             this.tagPropertyService.editTagPropertyWebapi(device).subscribe(result => {
                 this.loadDevicesTags();

--- a/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.html
+++ b/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.html
@@ -1,0 +1,85 @@
+<div>
+    <h1 mat-dialog-title class="dialog-title" mat-dialog-draggable>
+        <ng-container *ngIf="data.tag; else browseTitle">{{'device.tag-property-title' | translate}}</ng-container>
+        <ng-template #browseTitle>{{'device.browsetag-property-title' | translate}} — {{'device.property-plum-econext-gateway' | translate}}</ng-template>
+    </h1>
+    <mat-icon (click)="onNoClick()" class="dialog-close-btn">clear</mat-icon>
+    <form [formGroup]="formGroup" *ngIf="data.tag" class="tag-editor" mat-dialog-content>
+        <div class="my-form-field item-block">
+            <span>{{'device.tag-property-device' | translate}}</span>
+            <input formControlName="deviceName" type="text" readonly>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>Gateway parameter name</span>
+            <input formControlName="gatewayName" type="text" readonly>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>Gateway parameter index</span>
+            <input formControlName="tagAddress" type="text" readonly>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>FUXA tag name</span>
+            <input formControlName="tagName" type="text">
+            <span *ngIf="formGroup.controls.tagName.errors?.name" class="form-input-error">{{formGroup.controls.tagName.errors?.name}}</span>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-type' | translate}}</span>
+            <mat-select formControlName="tagType">
+                <mat-option *ngFor="let type of tagType | enumToArray" [value]="type.key">{{type.value}}</mat-option>
+            </mat-select>
+        </div>
+        <div class="my-form-field item-block mt10">
+            <span>{{'device.tag-property-description' | translate}}</span>
+            <input formControlName="tagDescription" type="text">
+        </div>
+        <div class="value-editor">
+            <div><strong>Current value:</strong> {{currentValue ?? '—'}}</div>
+            <div><strong>Access:</strong> {{data.tag.options?.writable ? 'read/write' : 'read-only'}}</div>
+            <div *ngIf="data.tag.options?.min != null || data.tag.options?.max != null">
+                <strong>Range:</strong> {{data.tag.options?.min ?? '—'}} – {{data.tag.options?.max ?? '—'}}
+            </div>
+            <mat-form-field appearance="fill">
+                <mat-label>New value</mat-label>
+                <input matInput [(ngModel)]="manualValue" [ngModelOptions]="{standalone: true}"
+                       [disabled]="!data.tag.options?.writable">
+            </mat-form-field>
+            <button mat-raised-button color="accent" type="button"
+                    [disabled]="!data.tag.options?.writable" (click)="writeValue()">
+                Write to controller
+            </button>
+            <div class="write-message" *ngIf="writeMessage">{{writeMessage}}</div>
+            <div class="write-log" *ngIf="writeLogVisible">
+                <div class="write-log-title">Controller response log</div>
+                <div class="write-log-empty" *ngIf="!writeLog.length">Waiting for controller response...</div>
+                <div class="write-log-entry" *ngFor="let entry of writeLog" [class.write-log-error]="!entry.success">
+                    <span class="write-log-time">{{entry.time}}</span>
+                    <span>{{entry.message}}</span>
+                    <pre *ngIf="entry.details">{{entry.details | json}}</pre>
+                </div>
+            </div>
+        </div>
+    </form>
+    <div mat-dialog-content *ngIf="!data.tag" class="browse-content">
+        <div class="parameter-search">
+            <mat-form-field appearance="outline">
+                <mat-label>Search by index or name</mat-label>
+                <input matInput [(ngModel)]="searchText" (keyup.enter)="search()" placeholder="e.g. 103 or HDWTSetPoint">
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="sort-field">
+                <mat-label>Index order</mat-label>
+                <mat-select [(value)]="sortDirection" (selectionChange)="search()">
+                    <mat-option value="asc">Lowest first</mat-option>
+                    <mat-option value="desc">Highest first</mat-option>
+                </mat-select>
+            </mat-form-field>
+            <button mat-raised-button color="primary" type="button" (click)="search()">Search</button>
+        </div>
+        <div class="tree-wrapper">
+            <ngx-treetable #treetable [config]="config" (expand)="queryNext($event)"></ngx-treetable>
+        </div>
+    </div>
+    <div mat-dialog-actions class="dialog-action">
+        <button mat-raised-button (click)="onNoClick()">{{'dlg.cancel' | translate}}</button>
+        <button mat-raised-button color="primary" (click)="onOkClick()" [disabled]="data.tag && formGroup?.invalid">{{'dlg.ok' | translate}}</button>
+    </div>
+</div>

--- a/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.scss
+++ b/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.scss
@@ -1,0 +1,72 @@
+:host {
+    display: block;
+}
+
+.tag-editor {
+    padding: 16px;
+    width: 400px;
+    max-width: 100%;
+    max-height: none !important;
+    overflow: visible !important;
+    box-sizing: border-box;
+}
+.tag-editor .item-block { display: block; }
+.tag-editor .item-block mat-select,
+.tag-editor .item-block input,
+.tag-editor .item-block span { width: calc(100% - 5px); }
+.value-editor { margin-top: 20px; display: grid; gap: 10px; }
+.value-editor mat-form-field { margin-top: 8px; }
+.write-message { min-height: 20px; }
+.write-log {
+    height: 78px;
+    max-height: 78px;
+    overflow: auto;
+    padding: 6px;
+    border: 1px solid rgba(127, 127, 127, .45);
+    border-radius: 3px;
+    background: rgba(127, 127, 127, .08);
+    font-size: 11px;
+}
+.write-log-title { margin-bottom: 4px; font-weight: 600; }
+.write-log-empty { opacity: .7; }
+.write-log-entry { padding: 3px 0; border-top: 1px solid rgba(127, 127, 127, .2); }
+.write-log-entry:first-of-type { border-top: 0; }
+.write-log-time { margin-right: 6px; opacity: .75; }
+.write-log-error { color: #d32f2f; }
+.write-log pre { margin: 3px 0 0; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 10px; }
+.browse-content { width: 100%; max-height: 68vh; padding: 0 12px; box-sizing: border-box; }
+.tree-wrapper { width: 100%; overflow: auto; }
+.parameter-search { display: flex; gap: 10px; align-items: flex-start; margin: 8px 0 2px; }
+.parameter-search mat-form-field {
+    flex: 1;
+    min-width: 0;
+    --mat-form-field-container-height: 45px;
+    --mat-form-field-container-vertical-padding: 10px;
+}
+:host ::ng-deep .parameter-search .mat-mdc-form-field-infix {
+    min-height: 45px;
+    padding-top: 11px;
+    padding-bottom: 8px;
+}
+:host ::ng-deep .parameter-search .mat-mdc-form-field,
+:host ::ng-deep .parameter-search .mat-mdc-floating-label,
+:host ::ng-deep .parameter-search input.mat-mdc-input-element,
+:host ::ng-deep .parameter-search input.mat-mdc-input-element::placeholder,
+:host ::ng-deep .parameter-search .mat-mdc-select-trigger,
+:host ::ng-deep .parameter-search .mat-mdc-select-value,
+:host ::ng-deep .parameter-search .mat-mdc-select-value-text {
+    font-size: 16px !important;
+}
+.parameter-search .sort-field { max-width: 165px; }
+.parameter-search button {
+    height: 45px;
+    min-height: 45px;
+    margin-top: 0;
+    flex: 0 0 auto;
+}
+
+@media (max-width: 650px) {
+    .parameter-search { flex-wrap: wrap; }
+    .parameter-search .sort-field { max-width: none; }
+    .parameter-search button { margin-top: 0; width: 100%; }
+}

--- a/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.ts
+++ b/client/src/app/device/tag-property/tag-property-edit-plum-econext/tag-property-edit-plum-econext.component.ts
@@ -1,0 +1,196 @@
+import { Component, Inject, OnDestroy, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Subject, takeUntil } from 'rxjs';
+import { Device, Tag, TagType } from '../../../_models/device';
+import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { HmiService } from '../../../_services/hmi.service';
+import { Node, NodeType, TreetableComponent } from '../../../gui-helpers/treetable/treetable.component';
+
+/** Browser dedicated to parameters discovered by PLUM ecoNEXT Gateway. */
+@Component({
+    selector: 'app-tag-property-edit-plum-econext',
+    templateUrl: './tag-property-edit-plum-econext.component.html',
+    styleUrls: ['./tag-property-edit-plum-econext.component.scss']
+})
+export class TagPropertyEditPlumEconetComponent implements OnInit, OnDestroy {
+    @Output() result = new EventEmitter<TagPropertyPlumEconextData>();
+    @ViewChild(TreetableComponent, { static: false }) treetable: TreetableComponent;
+
+    private destroy$ = new Subject<void>();
+    // Roughly 30% smaller than the original 1000x640 browser and constrained
+    // to the viewport so the dialog remains usable on smaller screens.
+    config = { height: 'min(400px, 45vh)', width: '100%' };
+    currentValue: any = null;
+    manualValue: any = null;
+    writeMessage = '';
+    writeLog: Array<{ time: string; success: boolean; message: string; details?: any }> = [];
+    writeLogVisible = false;
+    searchText = '';
+    sortDirection: 'asc' | 'desc' = 'asc';
+    formGroup: UntypedFormGroup;
+    tagType = TagType;
+    existingNames: string[] = [];
+
+    constructor(
+        private hmiService: HmiService,
+        private fb: UntypedFormBuilder,
+        private translateService: TranslateService,
+        public dialogRef: MatDialogRef<TagPropertyEditPlumEconetComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: TagPropertyPlumEconextData
+    ) { }
+
+    ngOnInit() {
+        if (this.data.tag) {
+            this.existingNames = Object.values(this.data.device.tags || {})
+                .filter((tag: Tag) => tag.id !== this.data.tag.id)
+                .map((tag: Tag) => tag.name);
+            this.formGroup = this.fb.group({
+                deviceName: [this.data.device.name, Validators.required],
+                gatewayName: [this.data.tag.options?.gatewayName || this.data.tag.name],
+                tagName: [this.data.tag.name, [Validators.required, this.validateName()]],
+                tagType: [this.data.tag.type, Validators.required],
+                tagAddress: [this.data.tag.address, Validators.required],
+                tagDescription: [this.data.tag.description]
+            });
+            const signal = this.hmiService.getAllSignals()[this.data.tag.id];
+            this.currentValue = signal?.value;
+            this.manualValue = signal?.value;
+            this.hmiService.onVariableChanged.pipe(takeUntil(this.destroy$)).subscribe(changed => {
+                if (changed.id === this.data.tag.id) {
+                    this.currentValue = changed.value;
+                    this.writeMessage = `Confirmed value: ${changed.value}`;
+                    if (this.writeLogVisible) this.addWriteLog(true, `Polled value: ${changed.value}`);
+                }
+            });
+            this.hmiService.askDeviceValues();
+            return;
+        }
+        this.hmiService.onDeviceBrowse.pipe(takeUntil(this.destroy$)).subscribe(response => {
+            if (this.data.device.id !== response.device || response.error) {
+                return;
+            }
+            this.addNodes(response.node?.search != null ? null : response.node, response.result);
+        });
+        this.queryNext(null);
+    }
+
+    ngOnDestroy() {
+        this.destroy$.next();
+        this.destroy$.complete();
+    }
+
+    queryNext(node: Node) {
+        const request = node ? { id: node.id, parent: node.parent?.id || null, sort: this.sortDirection } : null;
+        this.hmiService.askDeviceBrowse(this.data.device.id, request);
+    }
+
+    search() {
+        const search = this.searchText.trim();
+        this.treetable.nodes = {};
+        this.treetable.list = [];
+        this.hmiService.askDeviceBrowse(this.data.device.id, search ? { search, sort: this.sortDirection } : null);
+    }
+
+    addNodes(parent: Node, nodes: any[]) {
+        if (!nodes) return;
+        const tags = Object.values(this.data.device.tags || {});
+        nodes.forEach(item => {
+            // Prefix variables with their immutable gateway index so similarly
+            // named ecoMAX parameters can be distinguished and searched easily.
+            const displayName = item.class === 'Variable' ? `[${item.id}] ${item.name}` : item.name;
+            const node = new Node(item.id, displayName);
+            node.class = Node.strToType(item.class);
+            node.type = item.type;
+            const existingTag = tags.find((tag: Tag) => tag.address === item.id);
+            const access = item.writable ? 'read/write' : 'read-only';
+            const range = item.min != null || item.max != null ? `, range: ${item.min ?? '-'}..${item.max ?? '-'}` : '';
+            node.property = item.class === 'Variable'
+                ? `FUXA tag: ${existingTag?.name || item.name} | ${item.type}, ${access}${item.unit != null ? `, unit: ${item.unit}` : ''}${range}`
+                : '';
+            node.todefine = {
+                writable: item.writable,
+                unit: item.unit,
+                min: item.min,
+                max: item.max,
+                econextType: item.econextType,
+                gatewayName: item.name
+            };
+            const enabled = node.class !== NodeType.Variable || !existingTag;
+            this.treetable.addNode(node, parent, enabled, false);
+        });
+        // The gateway already returns parameters in numeric index order.
+        this.treetable.update(false);
+    }
+
+    onNoClick() {
+        this.dialogRef.close();
+    }
+
+    onOkClick() {
+        if (this.data.tag) {
+            this.data.tagProperty = this.formGroup.getRawValue();
+            this.result.emit(this.data);
+            return;
+        }
+        this.data.nodes = (<Node[]>Object.values(this.treetable.nodes)).filter((node: Node) =>
+            node.checked && node.enabled && (node.type || !node.childs || node.childs.length === 0)
+        );
+        this.result.emit(this.data);
+    }
+
+    async writeValue() {
+        this.writeLogVisible = true;
+        const tag = this.data.tag;
+        if (!tag?.options?.writable) {
+            this.writeMessage = 'This gateway parameter is read-only.';
+            return;
+        }
+        let value: any = this.manualValue;
+        if (String(tag.type).toLowerCase() === 'number') {
+            value = Number(value);
+            if (!Number.isFinite(value)) {
+                this.writeMessage = 'Enter a valid number.';
+                return;
+            }
+            if (tag.options.min != null && value < tag.options.min) {
+                this.writeMessage = `Minimum value is ${tag.options.min}.`;
+                return;
+            }
+            if (tag.options.max != null && value > tag.options.max) {
+                this.writeMessage = `Maximum value is ${tag.options.max}.`;
+                return;
+            }
+        }
+        this.writeMessage = 'Writing value...';
+        const result = await this.hmiService.putSignalValueWithResult(tag.id, value);
+        this.writeMessage = result.success ? 'Write successful: true' : `Write successful: false${result.error ? ` — ${result.error}` : ''}`;
+        this.addWriteLog(result.success, result.success ? `Sent value: ${value}` : (result.error || `Write rejected: ${value}`), result.details);
+        if (result.success) this.hmiService.askDeviceValues();
+    }
+
+    private addWriteLog(success: boolean, message: string, details?: any) {
+        this.writeLog.unshift({ time: new Date().toLocaleTimeString(), success, message, details });
+        this.writeLog = this.writeLog.slice(0, 4);
+    }
+
+    validateName(): ValidatorFn {
+        return (control: AbstractControl): ValidationErrors | null => {
+            const name = control?.value;
+            if (this.existingNames.includes(name)) {
+                return { name: this.translateService.instant('msg.device-tag-exist') };
+            }
+            if (name?.includes('@')) {
+                return { name: this.translateService.instant('msg.device-tag-invalid-char') };
+            }
+            return null;
+        };
+    }
+}
+
+export interface TagPropertyPlumEconextData {
+    device: Device;
+    nodes?: Node[];
+    tag?: Tag;
+    tagProperty?: any;
+}

--- a/client/src/app/device/tag-property/tag-property.service.ts
+++ b/client/src/app/device/tag-property/tag-property.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialog as MatDialog } from '@angular/material/dialog';
-import { Device, TAG_PREFIX, Tag, ServerTagType } from '../../_models/device';
+import { Device, DeviceType, TAG_PREFIX, Tag, ServerTagType } from '../../_models/device';
 import { Utils } from '../../_helpers/utils';
 import { TagPropertyEditS7Component } from './tag-property-edit-s7/tag-property-edit-s7.component';
 import { Observable, map } from 'rxjs';
@@ -11,6 +11,7 @@ import { TagPropertyEditInternalComponent, TagPropertyInternalData } from './tag
 import { TagPropertyEditOpcuaComponent, TagPropertyOpcUaData } from './tag-property-edit-opcua/tag-property-edit-opcua.component';
 import { Node, NodeType } from '../../gui-helpers/treetable/treetable.component';
 import { TagPropertyBacNetData, TagPropertyEditBacnetComponent } from './tag-property-edit-bacnet/tag-property-edit-bacnet.component';
+import { TagPropertyEditPlumEconetComponent, TagPropertyPlumEconextData } from './tag-property-edit-plum-econext/tag-property-edit-plum-econext.component';
 import { TagPropertyEditWebapiComponent, TagPropertyWebApiData } from './tag-property-edit-webapi/tag-property-edit-webapi.component';
 import { TagPropertyEditEthernetipComponent, TagPropertyEthernetIpData } from './tag-property-edit-ethernetip/tag-property-edit-ethernetip.component';
 import { TagPropertyEditADSclientComponent } from './tag-property-edit-adsclient/tag-property-edit-adsclient.component';
@@ -296,6 +297,41 @@ export class TagPropertyService {
                 return result;
             })
         );
+    }
+
+    public editTagPropertyPlumEconext(device: Device, tagsMap?: any, tag?: Tag): Observable<any> {
+        const dialogRef = this.dialog.open(TagPropertyEditPlumEconetComponent, {
+            disableClose: true,
+            position: { top: '60px' },
+            width: '700px',
+            maxWidth: '92vw',
+            maxHeight: '88vh',
+            data: <TagPropertyPlumEconextData>{ device, tag }
+        });
+        return dialogRef.componentInstance.result.pipe(map(result => {
+            if (result?.tag && result.tagProperty) {
+                result.tag.name = result.tagProperty.tagName;
+                result.tag.label = result.tagProperty.tagName;
+                result.tag.type = result.tagProperty.tagType;
+                result.tag.description = result.tagProperty.tagDescription;
+                result.tag.options = result.tag.options || {};
+                result.tag.options.gatewayName = result.tagProperty.gatewayName;
+            }
+            result?.nodes?.forEach((node: Node) => {
+                const tag = new Tag(Utils.getGUID(TAG_PREFIX));
+                tag.name = node.todefine?.gatewayName || node.text;
+                tag.label = tag.name;
+                tag.type = node.type;
+                tag.address = node.id;
+                tag.memaddress = node.parent?.id;
+                tag.options = node.todefine;
+                this.checkToAdd(tag, result.device);
+                if (tagsMap) tagsMap[tag.id] = tag;
+            });
+            this.projectService.setDeviceTags(device);
+            dialogRef.close();
+            return result;
+        }));
     }
 
     public editTagPropertyWebapi(device: Device, tagsMap?: any): Observable<any> {

--- a/client/src/app/plugins/plugins-list/plugins-list.component.html
+++ b/client/src/app/plugins/plugins-list/plugins-list.component.html
@@ -23,7 +23,7 @@
                     </div>
                     <div class="card-headline">
                         <div class="card-type">{{ plugin.type }}</div>
-                        <div class="card-name">{{ plugin.name }}</div>
+                        <div class="card-name">{{ plugin.displayName || plugin.name }}</div>
                     </div>
                     <div class="state-badge" [ngClass]="{ 'ready': isInstalled(plugin), 'available': !isInstalled(plugin) }">
                         <mat-icon>{{ isInstalled(plugin) ? 'check_circle' : 'download' }}</mat-icon>

--- a/client/src/app/plugins/plugins-list/plugins-list.component.ts
+++ b/client/src/app/plugins/plugins-list/plugins-list.component.ts
@@ -131,6 +131,6 @@ export class PluginsListComponent implements OnInit, OnDestroy {
         if (!!a.dinamic !== !!b.dinamic) {
             return a.dinamic ? -1 : 1;
         }
-        return `${a.group}-${a.name}`.localeCompare(`${b.group}-${b.name}`);
+        return `${a.group}-${a.displayName || a.name}`.localeCompare(`${b.group}-${b.displayName || b.name}`);
     }
 }

--- a/client/src/assets/i18n/de.json
+++ b/client/src/assets/i18n/de.json
@@ -759,6 +759,8 @@
     "device.property-format": "Format",
     "device.property-internal": "Nur Frontend",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT Gateway",
+    "device.property-http-timeout": "HTTP-Zeitüberschreitung",
     "device.property-webapi-result": "Ergebnis der Anfrage",
     "device.not-webapi-result": "WebAPI-Ergebnis konfigurieren",
     "device.property-show": "Geräteeigenschaft anzeigen",

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1039,6 +1039,8 @@
     "device.property-format": "Format",
     "device.property-internal": "Frontend only",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT Gateway",
+    "device.property-http-timeout": "HTTP timeout",
     "device.property-webapi-result": "Result of request",
     "device.property-ads-target": "Target AmsNetId (e.g. 192.168.1.10.1.1:851)",
     "device.property-ads-local": "Local AmsNetId (e.g. 192.168.1.10.1.1:32750)",

--- a/client/src/assets/i18n/es.json
+++ b/client/src/assets/i18n/es.json
@@ -487,6 +487,8 @@
     "device.property-method": "Metodo",
     "device.property-format": "Formato",
     "device.property-url": "URL (http://[servidor]:[puerto])",
+    "device.property-plum-econext-gateway": "Puerta de enlace PLUM ecoNEXT",
+    "device.property-http-timeout": "Tiempo de espera HTTP",
     "device.property-webapi-result": "Resultado de la solicitud",
     "device.not-webapi-result": "Configurar resultado de la WebAPI",
     "device.property-show": "Mostrar las propiedades del dispositivo",

--- a/client/src/assets/i18n/fr.json
+++ b/client/src/assets/i18n/fr.json
@@ -914,6 +914,8 @@
   "device.property-format": "Format",
   "device.property-internal": "Frontend uniquement",
   "device.property-url": "URL (http: // [serveur]: [port])",
+  "device.property-plum-econext-gateway": "Passerelle PLUM ecoNEXT",
+  "device.property-http-timeout": "Délai d’attente HTTP",
   "device.property-webapi-result": "Résultat de la demande",
   "device.property-ads-target": "Target AmsNetId (e.g. 192.168.1.10.1.1:851)",
   "device.property-ads-local": "Local AmsNetId (e.g. 192.168.1.10.1.1:32750)",

--- a/client/src/assets/i18n/ja.json
+++ b/client/src/assets/i18n/ja.json
@@ -935,6 +935,8 @@
     "device.property-format": "フォーマット",
     "device.property-internal": "フロントエンド専用",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT ゲートウェイ",
+    "device.property-http-timeout": "HTTP タイムアウト",
     "device.property-webapi-result": "リクエスト結果",
     "device.property-ads-target": "ターゲット AmsNetId (例: 192.168.1.10.1.1:851)",
     "device.property-ads-local": "ローカル AmsNetId (例: 192.168.1.10.1. 1:32750)",

--- a/client/src/assets/i18n/ko.json
+++ b/client/src/assets/i18n/ko.json
@@ -487,6 +487,8 @@
     "device.property-method": "방법",
     "device.property-format": "형식",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT 게이트웨이",
+    "device.property-http-timeout": "HTTP 시간 초과",
     "device.property-webapi-result": "요청 결과",
     "device.not-webapi-result": "구성 WebAPI 결과",
     "device.property-show": "장치 속성 보이기",

--- a/client/src/assets/i18n/pt.json
+++ b/client/src/assets/i18n/pt.json
@@ -443,6 +443,8 @@
     "device.property-method": "Método",
     "device.property-format": "Formato",
     "device.property-url": "URL",
+    "device.property-plum-econext-gateway": "Gateway PLUM ecoNEXT",
+    "device.property-http-timeout": "Tempo limite HTTP",
     "device.property-webapi-result": "Resultado do pedido",
     "device.not-webapi-result": "Configurar resultado do WebAPI",
     "device.property-show": "Mostrar propriedade do Aparelho",

--- a/client/src/assets/i18n/ru.json
+++ b/client/src/assets/i18n/ru.json
@@ -719,6 +719,8 @@
     "device.property-format": "Формат",
     "device.property-internal": "Только интерфейс",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "Шлюз PLUM ecoNEXT",
+    "device.property-http-timeout": "Тайм-аут HTTP",
     "device.property-webapi-result": "Результат запроса",
     "device.not-webapi-result": "Настроить результат WebAPI",
     "device.property-show": "Отобразить свойство устройства",

--- a/client/src/assets/i18n/sv.json
+++ b/client/src/assets/i18n/sv.json
@@ -912,6 +912,8 @@
     "device.property-format": "Format",
     "device.property-internal": "Endast frontend",
     "device.property-url": "URL (http://[server]:[port])",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT Gateway",
+    "device.property-http-timeout": "HTTP-tidsgräns",
     "device.property-webapi-result": "Resultat av förfrågan",
     "device.not-webapi-result": "Konfigurera WebAPI-resultat",
     "device.property-show": "Visa anslutningsegenskaper",

--- a/client/src/assets/i18n/tr.json
+++ b/client/src/assets/i18n/tr.json
@@ -440,6 +440,8 @@
 	"device.property-method": "Metod",
 	"device.property-format": "Format",
 	"device.property-url": "URL",
+	"device.property-plum-econext-gateway": "PLUM ecoNEXT Ağ Geçidi",
+	"device.property-http-timeout": "HTTP zaman aşımı",
 	"device.property-webapi-result": "Talebin sonucu",
 
 	"device.not-webapi-result": "WebAPI talebini yapılandır",

--- a/client/src/assets/i18n/ua.json
+++ b/client/src/assets/i18n/ua.json
@@ -413,6 +413,8 @@
     "device.property-method": "Метод",
     "device.property-format": "Формат",
     "device.property-url": "URL",
+    "device.property-plum-econext-gateway": "Шлюз PLUM ecoNEXT",
+    "device.property-http-timeout": "Тайм-аут HTTP",
     "device.property-webapi-result": "Результат запиту",
     "device.not-webapi-result": "Конфігурація WebAPI результату",
     "device.property-show": "Показати властивості пристрою",

--- a/client/src/assets/i18n/zh-cn.json
+++ b/client/src/assets/i18n/zh-cn.json
@@ -915,6 +915,8 @@
     "device.property-format": "格式",
     "device.property-internal": "仅限前端",
     "device.property-url": "URL（http://[服务器]:[端口]）",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT 网关",
+    "device.property-http-timeout": "HTTP 超时",
     "device.property-webapi-result": "请求的结果",
     "device.property-ads-target": "目标AmsNetId（例如192.168.1.10.1.1:851）",
     "device.property-ads-local": "本地AmsNetId（例如192.168.1.10.1.1:32750）",

--- a/client/src/assets/i18n/zh-tw.json
+++ b/client/src/assets/i18n/zh-tw.json
@@ -915,6 +915,8 @@
     "device.property-format": "格式",
     "device.property-internal": "僅限前端",
     "device.property-url": "URL（http://[伺服器]:[連接埠]）",
+    "device.property-plum-econext-gateway": "PLUM ecoNEXT 閘道",
+    "device.property-http-timeout": "HTTP 逾時",
     "device.property-webapi-result": "請求的結果",
     "device.property-ads-target": "目標 AmsNetId（例如 192.168.1.10.1.1:851）",
     "device.property-ads-local": "本地 AmsNetId（例如 192.168.1.10.1.1:32750）",

--- a/server/integrations/plum-econext-gateway/index.js
+++ b/server/integrations/plum-econext-gateway/index.js
@@ -1,0 +1,315 @@
+/**
+ * FUXA device plugin for PLUM ecoMAX controllers exposed by econext-gateway.
+ * The gateway owns the physical RS-485 communication; this plugin translates
+ * its REST resources into FUXA tags, browse nodes and write operations.
+ */
+'use strict';
+
+const axios = require('axios');
+
+// DataType codes exposed by the gateway in GET /api/parameters.  FUXA has
+// only number/boolean/string tag types, so the protocol-specific constraints
+// are retained here and applied before POST /api/parameters/{name}.
+const ECONEXT_DATA_TYPES = {
+    1: { name: 'int8', fuxaType: 'number', integer: true, min: -128, max: 127 },
+    2: { name: 'int16', fuxaType: 'number', integer: true, min: -32768, max: 32767 },
+    3: { name: 'int32', fuxaType: 'number', integer: true, min: -2147483648, max: 2147483647 },
+    4: { name: 'uint8', fuxaType: 'number', integer: true, min: 0, max: 255 },
+    5: { name: 'uint16', fuxaType: 'number', integer: true, min: 0, max: 65535 },
+    6: { name: 'uint32', fuxaType: 'number', integer: true, min: 0, max: 4294967295 },
+    7: { name: 'float', fuxaType: 'number' },
+    9: { name: 'double', fuxaType: 'number' },
+    10: { name: 'bool', fuxaType: 'boolean' },
+    12: { name: 'string', fuxaType: 'string' },
+    // JSON numbers outside the safe JavaScript integer range lose precision.
+    13: { name: 'int64', fuxaType: 'number', integer: true, min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+    14: { name: 'uint64', fuxaType: 'number', integer: true, min: 0, max: Number.MAX_SAFE_INTEGER }
+};
+
+function PlumEconextGatewayClient(_data, logger, events, runtime) {
+    let data = clone(_data);
+    let connected = false;
+    let working = false;
+    let lastStatus = 'connect-off';
+    let lastTimestampValue = 0;
+    // Tag ids are GUID-like strings, therefore values must be a plain map.
+    let values = {};
+    let parameters = {};
+    let lastWriteResult = null;
+
+    const baseUrl = () => String(data.property.address || '').replace(/\/$/, '');
+    const parametersUrl = () => `${baseUrl()}/api/parameters`;
+
+    function clone(value) { return JSON.parse(JSON.stringify(value)); }
+
+    function emitStatus(status) {
+        connected = status === 'connect-ok';
+        if (status !== lastStatus) {
+            lastStatus = status;
+            events.emit('device-status:changed', { id: data.id, status });
+        }
+    }
+
+    function dataType(parameter) {
+        return ECONEXT_DATA_TYPES[Number(parameter.type)];
+    }
+
+    function parameterType(parameter) {
+        const descriptor = dataType(parameter);
+        if (descriptor) return descriptor.fuxaType;
+        if (typeof parameter.value === 'boolean') return 'boolean';
+        if (typeof parameter.value === 'number') return 'number';
+        return 'string';
+    }
+
+    function coerceWriteValue(value, parameter) {
+        const descriptor = dataType(parameter);
+        const type = descriptor?.fuxaType || parameterType(parameter);
+
+        if (type === 'boolean') {
+            if (value === true || value === false) return value;
+            if (value === 1 || String(value).trim().toLowerCase() === 'true' || String(value).trim() === '1') return true;
+            if (value === 0 || String(value).trim().toLowerCase() === 'false' || String(value).trim() === '0') return false;
+            throw new Error(`Invalid boolean value for '${parameter.name}'`);
+        }
+        if (type === 'string') return String(value);
+
+        const output = Number(value);
+        if (!Number.isFinite(output)) throw new Error(`Invalid numeric value for '${parameter.name}'`);
+        if (descriptor?.integer && !Number.isInteger(output)) {
+            throw new Error(`Value for '${parameter.name}' must be an integer (${descriptor.name})`);
+        }
+        if (descriptor?.min != null && output < descriptor.min) {
+            throw new Error(`Value for '${parameter.name}' is below ${descriptor.name} minimum ${descriptor.min}`);
+        }
+        if (descriptor?.max != null && output > descriptor.max) {
+            throw new Error(`Value for '${parameter.name}' is above ${descriptor.name} maximum ${descriptor.max}`);
+        }
+        return output;
+    }
+
+    function parameterGroup(parameter) {
+        if (parameter.group) return String(parameter.group);
+        const name = String(parameter.name || 'Other');
+        const separated = name.match(/^([^_]+)_/);
+        if (separated) return separated[1];
+        const camelCase = name.match(/^([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+)/);
+        return camelCase ? camelCase[1] : 'Other';
+    }
+
+    async function readParameters() {
+        const response = await axios.get(parametersUrl(), {
+            timeout: Number(data.property.timeout) || 5000
+        });
+        parameters = response.data?.parameters || {};
+        return parameters;
+    }
+
+    function findParameter(tag) {
+        return Object.values(parameters).find(parameter =>
+            String(parameter.index) === String(tag.address) || parameter.name === tag.address);
+    }
+
+    function shouldSaveDaq(item, timestamp) {
+        const daq = item.daq;
+        if (!daq || (!daq.enabled && !daq.restored)) return false;
+        item.timestamp = timestamp;
+        if (item.changed && (daq.changed || daq.restored)) return true;
+        if (!daq.lastDaqSaved || (daq.interval && timestamp - Number(daq.interval) * 1000 > daq.lastDaqSaved)) {
+            daq.lastDaqSaved = timestamp;
+            return true;
+        }
+        return false;
+    }
+
+    async function composeValue(value, previous, tag) {
+        if (tag.scaleReadFunction && runtime?.scriptsMgr) {
+            value = await runtime.scriptsMgr.runScript({
+                id: tag.scaleReadFunction,
+                parameters: [{ name: 'value', type: 'value', value }],
+                notLog: true
+            }, false);
+        }
+        if (typeof value === 'number' && tag.scale?.mode === 'linear') {
+            value = (tag.scale.scaledHigh - tag.scale.scaledLow) *
+                (value - tag.scale.rawLow) / (tag.scale.rawHigh - tag.scale.rawLow) + tag.scale.scaledLow;
+        }
+        if (typeof value === 'number' && tag.deadband?.value && previous != null &&
+            Math.abs(value - previous) <= tag.deadband.value) value = previous;
+        if (typeof value === 'number' && tag.format) value = Number(value.toFixed(tag.format));
+        return value;
+    }
+
+    async function rawValue(value, tag) {
+        if (tag.scale?.mode === 'linear') {
+            value = tag.scale.rawLow + (tag.scale.rawHigh - tag.scale.rawLow) *
+                (value - tag.scale.scaledLow) / (tag.scale.scaledHigh - tag.scale.scaledLow);
+        }
+        if (tag.scaleWriteFunction && runtime?.scriptsMgr) {
+            value = await runtime.scriptsMgr.runScript({
+                id: tag.scaleWriteFunction,
+                parameters: [{ name: 'value', type: 'value', value }],
+                notLog: true
+            }, false);
+        }
+        return value;
+    }
+
+    this.connect = async function () {
+        if (!baseUrl()) {
+            emitStatus('connect-failed');
+            throw new Error('PLUM ecoNEXT Gateway address is missing');
+        }
+        try {
+            await readParameters();
+            emitStatus('connect-ok');
+        } catch (error) {
+            emitStatus('connect-error');
+            throw error;
+        }
+    };
+
+    this.disconnect = async function () {
+        working = false;
+        values = {};
+        emitStatus('connect-off');
+        events.emit('device-value:changed', { id: data.id, values });
+    };
+
+    this.isConnected = () => connected;
+    this.lastReadTimestamp = () => lastTimestampValue;
+    this.getStatus = () => lastStatus;
+    this.getValues = () => values;
+    this.getLastWriteResult = () => lastWriteResult;
+    this.bindAddDaq = function (fnc) { this.addDaq = fnc; };
+    this.addDaq = null;
+
+    this.load = function (_data) {
+        data = clone(_data);
+        values = {};
+    };
+
+    this.polling = async function () {
+        if (working) return;
+        working = true;
+        try {
+            await readParameters();
+            const timestamp = Date.now();
+            const changed = {};
+            for (const tagId in data.tags) {
+                const tag = data.tags[tagId];
+                const parameter = findParameter(tag);
+                if (!parameter) continue;
+                const previous = values[tagId]?.value ?? null;
+                const value = await composeValue(parameter.value, previous, tag);
+                const item = { id: tagId, value, timestamp, daq: tag.daq, changed: !!values[tagId] && previous !== value };
+                values[tagId] = item;
+                if (this.addDaq && shouldSaveDaq(item, timestamp)) changed[tagId] = item;
+                item.changed = false;
+            }
+            lastTimestampValue = timestamp;
+            events.emit('device-value:changed', { id: data.id, values });
+            if (this.addDaq && Object.keys(changed).length) this.addDaq(changed, data.name, data.id);
+            emitStatus('connect-ok');
+        } catch (error) {
+            logger.error(`'${data.name}' PLUM ecoNEXT Gateway polling error: ${error.message || error}`);
+            emitStatus('connect-error');
+        } finally {
+            working = false;
+        }
+    };
+
+    this.getValue = function (tagId) {
+        return values[tagId] ? { id: tagId, value: values[tagId].value, ts: lastTimestampValue } : null;
+    };
+
+    this.getTagProperty = function (tagId) {
+        const tag = data.tags[tagId];
+        return tag ? { id: tagId, name: tag.name, type: tag.type, format: tag.format } : null;
+    };
+
+    this.setValue = async function (tagId, value) {
+        const tag = data.tags[tagId];
+        if (!tag) return false;
+        const parameter = findParameter(tag);
+        if (!parameter?.writable) {
+            logger.warn(`'${data.name}' parameter '${tag.name}' is read-only`);
+            return false;
+        }
+        let output = await rawValue(value, tag);
+        const type = parameterType(parameter);
+        output = coerceWriteValue(output, parameter);
+        if (type === 'number' && parameter.min != null && output < parameter.min) throw new Error(`Value for '${parameter.name}' is below minimum ${parameter.min}`);
+        if (type === 'number' && parameter.max != null && output > parameter.max) throw new Error(`Value for '${parameter.name}' is above maximum ${parameter.max}`);
+        let response;
+        try {
+            response = await axios.post(`${parametersUrl()}/${encodeURIComponent(parameter.name)}`, { value: output }, {
+                timeout: Number(data.property.timeout) || 5000
+            });
+            lastWriteResult = {
+                timestamp: Date.now(), parameter: parameter.name, index: parameter.index,
+                requestedValue: output, status: response.status || 200, response: response.data
+            };
+        } catch (error) {
+            lastWriteResult = {
+                timestamp: Date.now(), parameter: parameter.name, index: parameter.index,
+                requestedValue: output, status: error.response?.status,
+                response: error.response?.data, error: error.message || String(error)
+            };
+            throw error;
+        }
+        if (response.data?.success === false) return false;
+        const timestamp = Date.now();
+        values[tagId] = { id: tagId, value: await composeValue(output, values[tagId]?.value, tag), timestamp, daq: tag.daq, changed: false };
+        lastTimestampValue = timestamp;
+        events.emit('device-value:changed', { id: data.id, values });
+        return true;
+    };
+
+    /** Return a group/parameter tree compatible with the FUXA BACnet browser. */
+    this.browse = async function (node) {
+        await readParameters();
+        if (!node) {
+            return [...new Set(Object.values(parameters).map(parameterGroup))].sort()
+                .map(group => ({ id: group, name: group, class: 'Object' }));
+        }
+        const search = node.search != null ? String(node.search).trim().toLowerCase() : null;
+        const allParameters = Object.values(parameters);
+        let matching = allParameters.filter(parameter => {
+            if (search != null) {
+                return String(parameter.index).toLowerCase().includes(search) ||
+                    String(parameter.name).toLowerCase().includes(search);
+            }
+            return parameterGroup(parameter) === node.id;
+        });
+        // A numeric query is normally an exact gateway index. Prefer the exact
+        // record when it exists instead of returning indices that merely contain it.
+        if (search != null && /^\d+$/.test(search)) {
+            const exact = allParameters.filter(parameter => String(parameter.index) === search);
+            if (exact.length) matching = exact;
+        }
+        const indexDirection = node.sort === 'desc' ? -1 : 1;
+        return matching
+            .sort((a, b) => {
+                const aIndex = Number(a.index);
+                const bIndex = Number(b.index);
+                if (Number.isFinite(aIndex) && Number.isFinite(bIndex) && aIndex !== bIndex) {
+                    return (aIndex - bIndex) * indexDirection;
+                }
+                return String(a.name).localeCompare(String(b.name)) * indexDirection;
+            })
+            .map(parameter => ({
+                id: String(parameter.index), name: parameter.name, class: 'Variable',
+                type: parameterType(parameter), writable: !!parameter.writable,
+                unit: parameter.unit, min: parameter.min, max: parameter.max,
+                econextType: parameter.type,
+                econextTypeName: dataType(parameter)?.name
+            }));
+    };
+}
+
+module.exports = {
+    create(data, logger, events, runtime) {
+        return new PlumEconextGatewayClient(data, logger, events, runtime);
+    }
+};

--- a/server/integrations/plum-econext-gateway/package.json
+++ b/server/integrations/plum-econext-gateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fuxa-plugin-plum-econext-gateway",
+  "version": "0.1.0",
+  "description": "FUXA device plugin for PLUM ecoNEXT Gateway and PLUM ecoMAX controllers",
+  "main": "index.js",
+  "license": "MIT",
+  "keywords": ["fuxa", "scada", "plum", "ecomax", "econext"],
+  "dependencies": {
+    "axios": "^1.16.1"
+  },
+  "peerDependencies": {
+    "axios": ">=1.6.0"
+  }
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fuxa-server",
-  "version": "1.3.3-2855",
+  "version": "1.3.4-2860",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fuxa-server",
-      "version": "1.3.3-2855",
+      "version": "1.3.4-2860",
       "license": "MIT",
       "dependencies": {
         "@influxdata/influxdb-client": "1.25.0",
@@ -25,6 +25,7 @@
         "express-rate-limit": "5.5.1",
         "fontkit": "^2.0.2",
         "fs-extra": "7.0.1",
+        "fuxa-plugin-plum-econext-gateway": "file:integrations/plum-econext-gateway",
         "influx": "5.9.3",
         "jsonwebtoken": "^9.0.3",
         "morgan": "1.10.1",
@@ -50,6 +51,17 @@
         "mocha": "^10.8.2",
         "sinon": "^19.0.2",
         "typescript": "^5.6.3"
+      }
+    },
+    "integrations/plum-econext-gateway": {
+      "name": "fuxa-plugin-plum-econext-gateway",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.16.1"
+      },
+      "peerDependencies": {
+        "axios": ">=1.6.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3337,6 +3349,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fuxa-plugin-plum-econext-gateway": {
+      "resolved": "integrations/plum-econext-gateway",
+      "link": true
     },
     "node_modules/gauge": {
       "version": "3.0.2",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,7 +25,6 @@
         "express-rate-limit": "5.5.1",
         "fontkit": "^2.0.2",
         "fs-extra": "7.0.1",
-        "fuxa-plugin-plum-econext-gateway": "file:integrations/plum-econext-gateway",
         "influx": "5.9.3",
         "jsonwebtoken": "^9.0.3",
         "morgan": "1.10.1",
@@ -51,17 +50,6 @@
         "mocha": "^10.8.2",
         "sinon": "^19.0.2",
         "typescript": "^5.6.3"
-      }
-    },
-    "integrations/plum-econext-gateway": {
-      "name": "fuxa-plugin-plum-econext-gateway",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.16.1"
-      },
-      "peerDependencies": {
-        "axios": ">=1.6.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3349,10 +3337,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/fuxa-plugin-plum-econext-gateway": {
-      "resolved": "integrations/plum-econext-gateway",
-      "link": true
     },
     "node_modules/gauge": {
       "version": "3.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/frangoteam/FUXA.git"
   },
   "dependencies": {
+    "fuxa-plugin-plum-econext-gateway": "file:integrations/plum-econext-gateway",
     "@influxdata/influxdb-client": "1.25.0",
     "@questdb/nodejs-client": "^3.0.0",
     "@tdengine/rest": "3.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/frangoteam/FUXA.git"
   },
   "dependencies": {
-    "fuxa-plugin-plum-econext-gateway": "file:integrations/plum-econext-gateway",
     "@influxdata/influxdb-client": "1.25.0",
     "@questdb/nodejs-client": "^3.0.0",
     "@tdengine/rest": "3.0.2",

--- a/server/runtime/devices/device.js
+++ b/server/runtime/devices/device.js
@@ -7,6 +7,8 @@ var S7client = require('./s7');
 var OpcUAclient = require('./opcua');
 var MODBUSclient = require('./modbus');
 var BACNETclient = require('./bacnet');
+// Loaded dynamically when the PLUM ecoNEXT plugin package is installed.
+var PlumEconextGatewayClient = null;
 var HTTPclient = require('./httprequest');
 var MQTTclient = require('./mqtt');
 var EthernetIPclient = require('./ethernetip');
@@ -69,6 +71,11 @@ function Device(data, runtime) {
             return null;
         }
         comm = BACNETclient.create(data, logger, events, manager, runtime);
+    } else if (data.type === DeviceEnum.PlumEconextGateway) {
+        if (!PlumEconextGatewayClient) {
+            return null;
+        }
+        comm = PlumEconextGatewayClient.create(data, logger, events, runtime);
     } else if (data.type === DeviceEnum.WebAPI) {
         if (!HTTPclient) {
             return null;
@@ -285,6 +292,12 @@ function Device(data, runtime) {
         return await comm.setValue(id, value);
     }
 
+    // Optional diagnostic details exposed by integrations that can return a
+    // richer write acknowledgement (for example an HTTP gateway response).
+    this.getLastWriteResult = function () {
+        return comm.getLastWriteResult ? comm.getLastWriteResult() : null;
+    }
+
     /**
      * Call Device to return browser result Tags/Nodes (only OPCUA)
      */
@@ -296,7 +309,7 @@ function Device(data, runtime) {
                 }).catch(function (err) {
                     reject(err);
                 });
-            } else if (data.type === DeviceEnum.BACnet) {
+            } else if (data.type === DeviceEnum.BACnet || data.type === DeviceEnum.PlumEconextGateway) {
                 comm.browse(path).then(function (result) {
                     resolve(result);
                 }).catch(function (err) {
@@ -532,6 +545,8 @@ function loadPlugin(type, module) {
         MODBUSclient = require(module);
     } else if (type === DeviceEnum.BACnet) {
         BACNETclient = require(module);
+    } else if (type === DeviceEnum.PlumEconextGateway) {
+        PlumEconextGatewayClient = require(module);
     } else if (type === DeviceEnum.WebAPI) {
         HTTPclient = require(module);
     } else if (type === DeviceEnum.MQTTclient) {
@@ -583,6 +598,7 @@ var DeviceEnum = {
     ModbusRTU: 'ModbusRTU',
     ModbusTCP: 'ModbusTCP',
     BACnet: 'BACnet',
+    PlumEconextGateway: 'PlumEconextGateway',
     WebAPI: 'WebAPI',
     MQTTclient: 'MQTTclient',
     EthernetIP: 'EthernetIP',

--- a/server/runtime/devices/index.js
+++ b/server/runtime/devices/index.js
@@ -434,8 +434,13 @@ function isWoking() {
  */
 async function setDeviceValue(deviceid, sigid, value, fnc) {
     if (activeDevices[deviceid]) {
-        await activeDevices[deviceid].setValue(sigid, value, fnc);
+        return await activeDevices[deviceid].setValue(sigid, value, fnc);
     }
+    return false;
+}
+
+function getLastWriteResult(deviceid) {
+    return activeDevices[deviceid]?.getLastWriteResult?.() || null;
 }
 
 /**
@@ -557,6 +562,7 @@ var devices = module.exports = {
     getTagValue: getTagValue,
     setTagValue: setTagValue,
     setDeviceValue: setDeviceValue,
+    getLastWriteResult: getLastWriteResult,
     getDeviceIdFromTag: getDeviceIdFromTag,
     browseDevice: browseDevice,
     readNodeAttribute: readNodeAttribute,

--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -183,9 +183,9 @@ function init(_io, _api, _settings, _log, eventsMain) {
             }
         });
         // client ask device values
-        socket.on(Events.IoEventTypes.DEVICE_VALUES, (message) => {
+        socket.on(Events.IoEventTypes.DEVICE_VALUES, async (message, acknowledge) => {
             try {
-                if (message === 'get') {
+                if (message === 'get' || message?.cmd === 'get') {
                     var adevs = devices.getDevicesValues();
                     for (var id in adevs) {
                         updateDeviceValues({ id: id, values: adevs[id] || {} });
@@ -193,12 +193,22 @@ function init(_io, _api, _settings, _log, eventsMain) {
                 } else if (message.cmd === 'set' && message.var) {
                     if (!isSocketWriteAuthorized(socket)) {
                         logger.warn(`${Events.IoEventTypes.DEVICE_VALUES}: unauthorized write attempt from ${socket.userId || 'guest'}`);
+                        if (acknowledge) acknowledge({ success: false, error: 'Write not authorized' });
                         return;
                     }
-                    devices.setDeviceValue(message.var.source, message.var.id, message.var.value, message.fnc);
+                    const success = await devices.setDeviceValue(message.var.source, message.var.id, message.var.value, message.fnc);
+                    if (acknowledge) acknowledge({
+                        success: success === true,
+                        details: devices.getLastWriteResult(message.var.source)
+                    });
                 }
             } catch (err) {
                 logger.error(`${Events.IoEventTypes.DEVICE_VALUES}: ${err}`);
+                if (acknowledge) acknowledge({
+                    success: false,
+                    error: err?.message || String(err),
+                    details: message?.var?.source ? devices.getLastWriteResult(message.var.source) : null
+                });
             }
         });
         // client ask device browse

--- a/server/runtime/plugins/index.js
+++ b/server/runtime/plugins/index.js
@@ -293,6 +293,16 @@ function createDefaultPlugins() {
     registry['node-opcua'] = new Plugin('node-opcua', './opcua', 'OPCUA', '2.149.0', PluginGroupType.connectionDevice, true);
     registry['modbus-serial'] = new Plugin('modbus-serial', './modbus', 'Modbus', '8.0.19', PluginGroupType.connectionDevice, true);
     registry['node-bacnet'] = new Plugin('node-bacnet', './bacnet', 'BACnet', '0.2.4', PluginGroupType.connectionDevice, true);
+    registry['fuxa-plugin-plum-econext-gateway'] = new Plugin(
+        'fuxa-plugin-plum-econext-gateway',
+        'fuxa-plugin-plum-econext-gateway',
+        'PlumEconextGateway',
+        '0.1.0',
+        PluginGroupType.connectionDevice,
+        true,
+        'plum-econext-gateway',
+        'PLUM ecoNEXT Gateway'
+    );
     registry['node-snap7'] = new Plugin('node-snap7', './s7', 'SiemensS7', '1.0.9', PluginGroupType.connectionDevice, true);
     registry['ads-client'] = new Plugin('ads-client', './adsclient', 'ADSclient', '2.1.0', PluginGroupType.connectionDevice, true);
     registry['nodepccc'] = new Plugin('nodepccc', './ethernetip', 'EthernetIP', '0.1.17', PluginGroupType.connectionDevice, true);
@@ -318,7 +328,9 @@ module.exports = {
     get manager() { return manager },
 };
 
-function Plugin(name, module, type, version, group, dinamic) {
+function Plugin(name, module, type, version, group, dinamic, id, displayName) {
+    this.id = id || name;
+    this.displayName = displayName || name;
     this.name = name;
     this.module = module;
     this.type = type;

--- a/server/runtime/plugins/index.js
+++ b/server/runtime/plugins/index.js
@@ -151,7 +151,11 @@ async function addPlugin(plugin, options) {
     const needsRuntimeInstall = normalized.pkg || normalized.dynamicPackage || !isInstalled;
 
     if (needsRuntimeInstall && !isInstalled) {
-        normalized.current = await manager.installPackage(normalized.name, normalized.version);
+        normalized.current = await manager.installPackage(
+            normalized.name,
+            normalized.version,
+            normalized.installSource
+        );
         normalized.pkg = true;
     } else if (current) {
         normalized.current = current.current;
@@ -159,7 +163,10 @@ async function addPlugin(plugin, options) {
     }
 
     if (normalized.group !== PluginGroupType.service && normalized.module && normalized.type) {
-        await device.loadPlugin(normalized.type, normalized.module);
+        const modulePath = normalized.module.startsWith('.')
+            ? normalized.module
+            : manager.resolve(normalized.module);
+        await device.loadPlugin(normalized.type, modulePath);
     }
     plugins[normalized.name] = normalized;
     if (addOptions.refreshInstalled !== false) {
@@ -256,7 +263,7 @@ function _normalizePlugin(plugin) {
     }
     if (plugin.name && plugins[plugin.name]) {
         const knownPlugin = plugins[plugin.name];
-        return Object.assign(new Plugin(
+        const normalized = Object.assign(new Plugin(
             knownPlugin.name,
             knownPlugin.module,
             knownPlugin.type,
@@ -264,6 +271,10 @@ function _normalizePlugin(plugin) {
             plugin.group || knownPlugin.group,
             true
         ), knownPlugin, plugin);
+        // Installation sources are server-controlled metadata. Do not allow a
+        // client request to replace the path of a known bundled plugin.
+        normalized.installSource = knownPlugin.installSource;
+        return normalized;
     }
     if (plugin.name) {
         const customPlugin = new Plugin(
@@ -302,6 +313,12 @@ function createDefaultPlugins() {
         true,
         'plum-econext-gateway',
         'PLUM ecoNEXT Gateway'
+    );
+    // The source ships with FUXA, but installation is explicitly selected by
+    // the user in Plugin Manager. It is not a server dependency.
+    registry['fuxa-plugin-plum-econext-gateway'].installSource = path.resolve(
+        __dirname,
+        '../../integrations/plum-econext-gateway'
     );
     registry['node-snap7'] = new Plugin('node-snap7', './s7', 'SiemensS7', '1.0.9', PluginGroupType.connectionDevice, true);
     registry['ads-client'] = new Plugin('ads-client', './adsclient', 'ADSclient', '2.1.0', PluginGroupType.connectionDevice, true);
@@ -342,4 +359,5 @@ function Plugin(name, module, type, version, group, dinamic, id, displayName) {
     this.dynamicPackage = false;
     this.custom = false;
     this.canRemove = false;
+    this.installSource = '';
 }

--- a/server/runtime/plugins/npm-runtime-service.js
+++ b/server/runtime/plugins/npm-runtime-service.js
@@ -93,9 +93,11 @@ function createRuntimeService(options) {
         return !!listInstalledPackages(runtimeDir)[name];
     }
 
-    async function installPackage(name, version) {
+    async function installPackage(name, version, installSource) {
         init();
-        const spec = version && version !== 'latest' ? `${name}@${version}` : name;
+        // Known bundled plugins can be installed from a local source directory.
+        // Other plugins retain the existing npm registry installation flow.
+        const spec = installSource || (version && version !== 'latest' ? `${name}@${version}` : name);
         await _runNpmCommand(runtimeDir, ['install', '--no-audit', '--no-fund', '--save-exact', spec], logger);
         const installed = getInstalledPackages();
         return installed[name] || version || 'latest';

--- a/server/runtime/plugins/npm-runtime-service.js
+++ b/server/runtime/plugins/npm-runtime-service.js
@@ -15,13 +15,14 @@ function listInstalledPackages(baseDir) {
 
     const entries = fs.readdirSync(nodeModulesDir, { withFileTypes: true });
     entries.forEach((entry) => {
-        if (!entry.isDirectory()) {
+        // npm installs local `file:` dependencies as symlinks/junctions.
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) {
             return;
         }
         if (entry.name.startsWith('@')) {
             const scopeDir = path.join(nodeModulesDir, entry.name);
             fs.readdirSync(scopeDir, { withFileTypes: true }).forEach((scopedEntry) => {
-                if (!scopedEntry.isDirectory()) {
+                if (!scopedEntry.isDirectory() && !scopedEntry.isSymbolicLink()) {
                     return;
                 }
                 _readPackageInfo(path.join(scopeDir, scopedEntry.name), packages);
@@ -41,13 +42,13 @@ function listLegacyPackages(packageDir) {
     }
     const entries = fs.readdirSync(packageDir, { withFileTypes: true });
     entries.forEach((entry) => {
-        if (!entry.isDirectory() || entry.name === 'runtime') {
+        if ((!entry.isDirectory() && !entry.isSymbolicLink()) || entry.name === 'runtime') {
             return;
         }
         if (entry.name.startsWith('@')) {
             const scopeDir = path.join(packageDir, entry.name);
             fs.readdirSync(scopeDir, { withFileTypes: true }).forEach((scopedEntry) => {
-                if (!scopedEntry.isDirectory()) {
+                if (!scopedEntry.isDirectory() && !scopedEntry.isSymbolicLink()) {
                     return;
                 }
                 _readPackageInfo(path.join(scopeDir, scopedEntry.name), packages);

--- a/server/test/devices/plumEconextGateway.test.js
+++ b/server/test/devices/plumEconextGateway.test.js
@@ -3,8 +3,8 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const axios = require('axios');
-// Resolve through node_modules to verify the same package path used by FUXA.
-const driver = require('fuxa-plugin-plum-econext-gateway');
+// Test the bundled source without installing this optional plugin globally.
+const driver = require('../../integrations/plum-econext-gateway');
 
 describe('PLUM ecoNEXT Gateway device plugin', function () {
     let getStub;

--- a/server/test/devices/plumEconextGateway.test.js
+++ b/server/test/devices/plumEconextGateway.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+// Resolve through node_modules to verify the same package path used by FUXA.
+const driver = require('fuxa-plugin-plum-econext-gateway');
+
+describe('PLUM ecoNEXT Gateway device plugin', function () {
+    let getStub;
+    let postStub;
+
+    const response = {
+        data: {
+            parameters: {
+                42: { index: 42, name: 'DHW_Temperature', value: 45.5, type: 7, unit: 1, writable: false },
+                43: { index: 43, name: 'DHW_SetPoint', value: 50, type: 4, unit: 1, writable: true, min: 30, max: 60 },
+                44: { index: 44, name: 'DHW_Enabled', value: false, type: 10, writable: true },
+                45: { index: 45, name: 'DHW_Mode', value: 'comfort', type: 12, writable: true },
+                46: { index: 46, name: 'currentWebPage', value: 661, type: 5, writable: true }
+            }
+        }
+    };
+
+    beforeEach(function () {
+        getStub = sinon.stub(axios, 'get').resolves(response);
+        postStub = sinon.stub(axios, 'post').resolves({ data: { ok: true } });
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function createClient() {
+        const events = { emit: sinon.spy() };
+        const data = {
+            id: 'dev1', name: 'ecoMAX 360i', polling: 1000,
+            property: { address: 'http://127.0.0.1:8000' },
+            tags: {
+                writable: { id: 'writable', name: 'DHW set point', address: '43', type: 'number', daq: {} },
+                readonly: { id: 'readonly', name: 'DHW temperature', address: '42', type: 'number', daq: {} },
+                enabled: { id: 'enabled', name: 'Hot water enabled', address: '44', type: 'boolean', daq: {} },
+                mode: { id: 'mode', name: 'Hot water mode', address: '45', type: 'string', daq: {} },
+                page: { id: 'page', name: 'Panel page', address: '46', type: 'number', daq: {} }
+            }
+        };
+        const runtime = { scriptsMgr: { runScript: sinon.stub() } };
+        return { client: driver.create(data, { info() {}, warn() {}, error() {} }, events, runtime), events };
+    }
+
+    it('discovers groups and parameters', async function () {
+        const { client } = createClient();
+        const groups = await client.browse(null);
+        expect(groups).to.deep.include({ id: 'DHW', name: 'DHW', class: 'Object' });
+
+        const parameters = await client.browse({ id: 'DHW' });
+        expect(parameters).to.have.length(4);
+        expect(parameters.find(item => item.id === '43')).to.include({
+            name: 'DHW_SetPoint', class: 'Variable', type: 'number', writable: true
+        });
+    });
+
+    it('searches parameters directly by index or name', async function () {
+        const { client } = createClient();
+        const byIndex = await client.browse({ search: '43' });
+        expect(byIndex.map(item => item.name)).to.deep.equal(['DHW_SetPoint']);
+        const byName = await client.browse({ search: 'enabled' });
+        expect(byName.map(item => item.id)).to.deep.equal(['44']);
+    });
+
+    it('prefers an exact numeric index and sorts numeric results', async function () {
+        const { client } = createClient();
+        const exact = await client.browse({ search: '43', sort: 'desc' });
+        expect(exact.map(item => item.id)).to.deep.equal(['43']);
+        const ascending = await client.browse({ search: 'DHW', sort: 'asc' });
+        expect(ascending.map(item => item.id)).to.deep.equal(['42', '43', '44', '45']);
+        const descending = await client.browse({ search: 'DHW', sort: 'desc' });
+        expect(descending.map(item => item.id)).to.deep.equal(['45', '44', '43', '42']);
+    });
+
+    it('writes only writable parameters', async function () {
+        const { client } = createClient();
+        await client.connect();
+        expect(await client.setValue('readonly', 48)).to.equal(false);
+        expect(await client.setValue('writable', 52)).to.equal(true);
+        expect(postStub.calledOnceWith(
+            'http://127.0.0.1:8000/api/parameters/DHW_SetPoint',
+            { value: 52 },
+            sinon.match.object
+        )).to.equal(true);
+        expect(client.getValue('writable').value).to.equal(52);
+        expect(client.getLastWriteResult()).to.include({
+            parameter: 'DHW_SetPoint', index: 43, requestedValue: 52, status: 200
+        });
+        expect(client.getLastWriteResult().response).to.deep.equal({ ok: true });
+    });
+
+    it('keeps a FUXA-only alias independent from the gateway parameter name', async function () {
+        const { client } = createClient();
+        await client.connect();
+        expect(client.getTagProperty('writable').name).to.equal('DHW set point');
+        expect(await client.setValue('writable', 51)).to.equal(true);
+        expect(postStub.firstCall.args[0]).to.equal('http://127.0.0.1:8000/api/parameters/DHW_SetPoint');
+    });
+
+    it('validates numeric limits', async function () {
+        const { client } = createClient();
+        await client.connect();
+        for (const [value, message] of [[29, 'below minimum'], [61, 'above maximum']]) {
+            let error;
+            try { await client.setValue('writable', value); } catch (caught) { error = caught; }
+            expect(error.message).to.include(message);
+        }
+        expect(postStub.notCalled).to.equal(true);
+    });
+
+    it('writes boolean and string values using their gateway types', async function () {
+        const { client } = createClient();
+        await client.connect();
+        expect(await client.setValue('enabled', 'true')).to.equal(true);
+        expect(await client.setValue('mode', 'eco')).to.equal(true);
+        expect(postStub.firstCall.args[1]).to.deep.equal({ value: true });
+        expect(postStub.secondCall.args[1]).to.deep.equal({ value: 'eco' });
+    });
+
+    it('accepts an OpenAPI JSON number for a uint16 parameter', async function () {
+        const { client } = createClient();
+        await client.connect();
+        expect(await client.setValue('page', '696')).to.equal(true);
+        expect(postStub.firstCall.args[1]).to.deep.equal({ value: 696 });
+    });
+
+    it('enforces integer protocol types and their ranges', async function () {
+        const { client } = createClient();
+        await client.connect();
+        for (const [value, message] of [[696.5, 'must be an integer'], [65536, 'uint16 maximum']]) {
+            let error;
+            try { await client.setValue('page', value); } catch (caught) { error = caught; }
+            expect(error.message).to.include(message);
+        }
+        expect(postStub.notCalled).to.equal(true);
+    });
+
+    it('rejects ambiguous boolean values instead of converting them to false', async function () {
+        const { client } = createClient();
+        await client.connect();
+        let error;
+        try { await client.setValue('enabled', 'enabled'); } catch (caught) { error = caught; }
+        expect(error.message).to.include('Invalid boolean value');
+        expect(postStub.notCalled).to.equal(true);
+    });
+
+    it('maps FUXA types from ecoNEXT protocol type codes', async function () {
+        const { client } = createClient();
+        const parameters = await client.browse({ search: 'DHW' });
+        expect(parameters.find(item => item.id === '42').type).to.equal('number');
+        expect(parameters.find(item => item.id === '44').type).to.equal('boolean');
+        expect(parameters.find(item => item.id === '45').type).to.equal('string');
+        expect(parameters.find(item => item.id === '44').econextType).to.equal(10);
+        const page = await client.browse({ search: 'currentWebPage' });
+        expect(page[0].econextTypeName).to.equal('uint16');
+    });
+
+    it('publishes polled values as an object keyed by string tag ids', async function () {
+        const { client, events } = createClient();
+        await client.connect();
+        await client.polling();
+        expect(client.getValues()).to.include.keys('writable', 'readonly', 'enabled', 'mode');
+        const valueEvent = events.emit.getCalls().find(call => call.args[0] === 'device-value:changed');
+        expect(valueEvent.args[1].values).to.be.an('object').and.not.an('array');
+        expect(valueEvent.args[1].values.readonly.value).to.equal(45.5);
+    });
+});

--- a/server/test/plugins/npmRuntimeService.test.js
+++ b/server/test/plugins/npmRuntimeService.test.js
@@ -56,6 +56,28 @@ describe('npm runtime service', () => {
         expect(fs.existsSync(paths.runtimePackageJson)).to.equal(true);
     });
 
+    it('installs and removes a bundled plugin only when requested', async function () {
+        this.timeout(20000);
+        const source = path.join(tempDir, 'bundled-plugin');
+        fs.mkdirSync(source, { recursive: true });
+        fs.writeFileSync(path.join(source, 'package.json'), JSON.stringify({
+            name: 'bundled-local-plugin',
+            version: '1.0.0',
+            main: 'index.js',
+        }));
+        fs.writeFileSync(path.join(source, 'index.js'), 'module.exports = { installed: true };');
+
+        const service = createRuntimeService({ packageDir: path.join(tempDir, '_pkg') });
+        expect(service.getInstalledPackages()).not.to.have.property('bundled-local-plugin');
+
+        const version = await service.installPackage('bundled-local-plugin', '1.0.0', source);
+        expect(version).to.equal('1.0.0');
+        expect(service.require('bundled-local-plugin').installed).to.equal(true);
+
+        await service.uninstallPackage('bundled-local-plugin');
+        expect(service.getInstalledPackages()).not.to.have.property('bundled-local-plugin');
+    });
+
     it('lists a local package installed as a Linux symlink', function () {
         if (process.platform === 'win32') this.skip();
         const source = path.join(tempDir, 'source-linux-plugin');

--- a/server/test/plugins/npmRuntimeService.test.js
+++ b/server/test/plugins/npmRuntimeService.test.js
@@ -55,4 +55,33 @@ describe('npm runtime service', () => {
         expect(fs.existsSync(paths.runtimeDir)).to.equal(true);
         expect(fs.existsSync(paths.runtimePackageJson)).to.equal(true);
     });
+
+    it('lists a local package installed as a Linux symlink', function () {
+        if (process.platform === 'win32') this.skip();
+        const source = path.join(tempDir, 'source-linux-plugin');
+        const link = path.join(tempDir, 'node_modules', 'linux-local-plugin');
+        fs.mkdirSync(source, { recursive: true });
+        fs.mkdirSync(path.dirname(link), { recursive: true });
+        fs.writeFileSync(path.join(source, 'package.json'), JSON.stringify({
+            name: 'linux-local-plugin', version: '1.0.0'
+        }));
+        fs.symlinkSync(source, link, 'dir');
+
+        expect(listInstalledPackages(tempDir)['linux-local-plugin']).to.equal('1.0.0');
+    });
+
+    it('lists a local package installed as a Windows junction', function () {
+        if (process.platform !== 'win32') this.skip();
+        const source = path.join(tempDir, 'source-windows-plugin');
+        const link = path.join(tempDir, 'node_modules', 'windows-local-plugin');
+        fs.mkdirSync(source, { recursive: true });
+        fs.mkdirSync(path.dirname(link), { recursive: true });
+        fs.writeFileSync(path.join(source, 'package.json'), JSON.stringify({
+            name: 'windows-local-plugin', version: '1.0.0'
+        }));
+        // npm uses a junction for local `file:` dependencies on Windows.
+        fs.symlinkSync(source, link, 'junction');
+
+        expect(listInstalledPackages(tempDir)['windows-local-plugin']).to.equal('1.0.0');
+    });
 });

--- a/server/test/plugins/plumEconextGatewayPlugin.test.js
+++ b/server/test/plugins/plumEconextGatewayPlugin.test.js
@@ -18,5 +18,7 @@ describe('PLUM ecoNEXT Gateway plugin registration', function () {
             type: 'PlumEconextGateway',
             group: 'connection-device'
         });
+        expect(registered.dinamic).to.equal(true);
+        expect(registered.installSource).to.match(/[\\/]integrations[\\/]plum-econext-gateway$/);
     });
 });

--- a/server/test/plugins/plumEconextGatewayPlugin.test.js
+++ b/server/test/plugins/plumEconextGatewayPlugin.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const plugins = require('../../runtime/plugins');
+
+describe('PLUM ecoNEXT Gateway plugin registration', function () {
+    before(async function () {
+        const chai = await import('chai');
+        global.expect = chai.expect;
+    });
+
+    it('exposes the required id, display name and package name', async function () {
+        const registered = (await plugins.getPlugins()).find(plugin => plugin.id === 'plum-econext-gateway');
+        expect(registered).to.include({
+            id: 'plum-econext-gateway',
+            displayName: 'PLUM ecoNEXT Gateway',
+            name: 'fuxa-plugin-plum-econext-gateway',
+            module: 'fuxa-plugin-plum-econext-gateway',
+            type: 'PlumEconextGateway',
+            group: 'connection-device'
+        });
+    });
+});


### PR DESCRIPTION
## What changed

- add the local `fuxa-plugin-plum-econext-gateway` device integration
- register plugin id `plum-econext-gateway` with display name PLUM ecoNEXT Gateway
- support browse, grouped parameter discovery, polling, reads and validated writes
- map ecoNEXT OpenAPI protocol types to FUXA tag types
- add a dedicated PLUM tag-property editor with index/name search, numeric sorting and write feedback
- add translations for PLUM ecoNEXT Gateway and HTTP timeout
- support local plugin discovery and cover Windows junction behavior

## Why

This integrates FUXA with the local REST API exposed by LeeNuss/econext-gateway for PLUM ecoMAX controllers. The implementation keeps gateway parameter names and indices visible while allowing a FUXA-only tag alias.

## Validation

- backend TypeScript build: passed
- server tests: 99 passing, 1 pending (Linux symlink test skipped on Windows)
- frontend production build: passed
- physical ecoMAX 360i: browse/read/write and polling confirmed; panel service writes require the corresponding gateway fix in LeeNuss/econext-gateway PR #10

## Device testing still recommended

- long-running polling and reconnect behavior
- firmware variants and complete parameter/type coverage
- Raspberry Pi deployment and Linux symlink discovery
- min/max and read-only enforcement across the full physical parameter set