### PR TITLE
fix(client): allow clearing button icons

### DIFF
--- a/client/src/app/framework/icon-selector/icon-selector.component.html
+++ b/client/src/app/framework/icon-selector/icon-selector.component.html
@@ -8,9 +8,12 @@
     <mat-select-trigger>
         <img *ngIf="image; else iconTrigger" class="icon-selector-image" [src]="image" alt="">
         <ng-template #iconTrigger>
-            <mat-icon>{{iconsel.value}}</mat-icon>
+            <mat-icon *ngIf="iconsel.value">{{iconsel.value}}</mat-icon>
         </ng-template>
     </mat-select-trigger>
+    <mat-option *ngIf="allowClear" [value]="''" (click)="onClear()">
+        {{ clearLabel | translate }}
+    </mat-option>
     <mat-option *ngIf="allowImage" [value]="'image'" (click)="imagefile.value = '';imagefile.click();">
         {{ imageLabel | translate }}
         <input #imagefile type="file" style="display: none;" (change)="onImageSelected($event)" accept="image/png|jpg|svg" />

--- a/client/src/app/framework/icon-selector/icon-selector.component.ts
+++ b/client/src/app/framework/icon-selector/icon-selector.component.ts
@@ -19,7 +19,9 @@ export class IconSelectorComponent implements OnInit {
     @Input() height = '30px';
     @Input() image: string;
     @Input() allowImage = false;
+    @Input() allowClear = true;
     @Input() imageLabel = 'dlg.menuitem-image';
+    @Input() clearLabel = 'gauges.property-icon-none';
     @Output() imageSelected = new EventEmitter<Event>();
 
     icons$: Observable<string[]>;
@@ -52,6 +54,13 @@ export class IconSelectorComponent implements OnInit {
         this.value = icon;
         this.valueChange.emit(icon);
         this.selected.emit(icon);
+    }
+
+    onClear() {
+        this.value = '';
+        this.image = undefined;
+        this.valueChange.emit('');
+        this.selected.emit('');
     }
 
     onImageSelected(event: Event) {

--- a/client/src/assets/i18n/de.json
+++ b/client/src/assets/i18n/de.json
@@ -1332,7 +1332,8 @@
     "msg.export-alarms-error": "Alarme exportieren fehlgeschlagen!",
     "msg.report-build-forced": "Senden zum Erstellen des Berichts erfolgreich",
     "msg.report-build-error": "Senden zum Erstellen des Berichts fehlgeschlagen!",
-    "msg.device-tags-request-result": "Lade {{value}} von {{current}}"
+    "msg.device-tags-request-result": "Lade {{value}} von {{current}}",
+    "gauges.property-icon-none": "Kein Symbol"
 }
 
 

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1313,6 +1313,7 @@
     "gauges.property-input-maxlength": "Max length",
     "gauges.property-input-readonly": "Readonly",
     "gauges.property-icon": "Icon",
+    "gauges.property-icon-none": "No icon",
     "gauges.property-icons-filter": "Icons Filter",
 
     "gauges.property-update-enabled": "Enable update",

--- a/client/src/assets/i18n/es.json
+++ b/client/src/assets/i18n/es.json
@@ -800,7 +800,8 @@
     "msg.signin-failed": "Desautorizado",
     "msg.get-project-void": "Proyecto no encontrado!",
     "msg.editor-mode-locked": "El editor ya esta abierto!",
-    "msg.alarms-clear-success": "Todas las alarmas han sido canceladas!"
+    "msg.alarms-clear-success": "Todas las alarmas han sido canceladas!",
+    "gauges.property-icon-none": "Sin icono"
   }
 
 

--- a/client/src/assets/i18n/fr.json
+++ b/client/src/assets/i18n/fr.json
@@ -1743,7 +1743,8 @@
   "msg.maps-location-name-exist": "Le nom de l'emplacement sur la carte existe déjà !",
   "msg.text-name-exist": "Le nom du texte existe déjà !",
   "msg.texts-text-remove": "Souhaitez-vous supprimer le texte '{{value}}' ?",
-  "msg.operation-unauthorized": "Opération non autorisée !"
+  "msg.operation-unauthorized": "Opération non autorisée !",
+    "gauges.property-icon-none": "Aucune icône"
 }
 
 

--- a/client/src/assets/i18n/ja.json
+++ b/client/src/assets/i18n/ja.json
@@ -1778,6 +1778,7 @@
     "msg.maps-location-name-exist": "マップ位置名が既に存在します！",
     "msg.text-name-exist": "テキスト名が既に存在します！",
     "msg.texts-text-remove": "テキスト '{{value}}' を削除しますか？",
-    "msg.operation-unauthorized": "操作が許可されていません！"
+    "msg.operation-unauthorized": "操作が許可されていません！",
+    "gauges.property-icon-none": "アイコンなし"
 }
 

--- a/client/src/assets/i18n/ko.json
+++ b/client/src/assets/i18n/ko.json
@@ -798,7 +798,8 @@
     "msg.signin-failed": "권한 없음",
     "msg.get-project-void": "프로젝트가 발견되지 않았습니다.!",
     "msg.editor-mode-locked": "편집자가 이미 열려있습니다!",
-    "msg.alarms-clear-success": "모든 알림이 취소되었습니다!"
+    "msg.alarms-clear-success": "모든 알림이 취소되었습니다!",
+    "gauges.property-icon-none": "아이콘 없음"
 }
 
 

--- a/client/src/assets/i18n/pt.json
+++ b/client/src/assets/i18n/pt.json
@@ -682,5 +682,6 @@
     "msg.login-username-required": "Entra o Utilizador",
     "msg.login-password-required": "Entra uma palavra-passe",
     "msg.signin-failed": "Não autorizado",
-    "device.tag-uns-path": "UNS Path"
+    "device.tag-uns-path": "UNS Path",
+    "gauges.property-icon-none": "Sem ícone"
 }

--- a/client/src/assets/i18n/ru.json
+++ b/client/src/assets/i18n/ru.json
@@ -1251,7 +1251,8 @@
     "msg.export-alarms-error": "Export alarms failed!",
     "msg.report-build-forced": "Send to build Report successful",
     "msg.report-build-error": "Send to build Report failed!",
-    "msg.device-tags-request-result": "Загружено {{value}} из {{current}}"
+    "msg.device-tags-request-result": "Загружено {{value}} из {{current}}",
+    "gauges.property-icon-none": "Без значка"
 }
 
 

--- a/client/src/assets/i18n/sv.json
+++ b/client/src/assets/i18n/sv.json
@@ -1721,6 +1721,7 @@
     "msg.maps-location-name-exist": "Kartplatsnamnet finns redan!",
     "msg.text-name-exist": "Textnamnet finns redan!",
     "msg.texts-text-remove": "Vill du ta bort texten '{{value}}'?",
-    "msg.operation-unauthorized": "Operation obehörig!"
+    "msg.operation-unauthorized": "Operation obehörig!",
+    "gauges.property-icon-none": "Ingen ikon"
 }
 

--- a/client/src/assets/i18n/tr.json
+++ b/client/src/assets/i18n/tr.json
@@ -695,5 +695,6 @@
 	"msg.login-username-required": "Kullanıcı adı girin",
 	"msg.login-password-required": "Şifre girin",
 	"msg.signin-failed": "Yetkisiz giriş.",
-    "device.tag-uns-path": "UNS Path"
+    "device.tag-uns-path": "UNS Path",
+    "gauges.property-icon-none": "Simge yok"
 }

--- a/client/src/assets/i18n/ua.json
+++ b/client/src/assets/i18n/ua.json
@@ -636,5 +636,6 @@
     "msg.login-username-required": "Користувач",
     "msg.login-password-required": "Пароль",
     "msg.signin-failed": "Не авторизований",
-    "device.tag-uns-path": "UNS Path"
+    "device.tag-uns-path": "UNS Path",
+    "gauges.property-icon-none": "Без значка"
 }

--- a/client/src/assets/i18n/zh-cn.json
+++ b/client/src/assets/i18n/zh-cn.json
@@ -1745,7 +1745,8 @@
     "msg.maps-location-name-exist": "位置名称已经存在！",
     "msg.text-name-exist": "文本名称已经存在！",
     "msg.texts-text-remove": "您是否想删除文本'{{value}}'?",
-    "msg.operation-unauthorized": "操作未经授权！"
+    "msg.operation-unauthorized": "操作未经授权！",
+    "gauges.property-icon-none": "无图标"
 }
 
 

--- a/client/src/assets/i18n/zh-tw.json
+++ b/client/src/assets/i18n/zh-tw.json
@@ -1744,7 +1744,8 @@
     "msg.maps-location-name-exist": "位置名稱已存在！",
     "msg.text-name-exist": "文字名稱已存在！",
     "msg.texts-text-remove": "您是否要刪除文字 '{{value}}'？",
-    "msg.operation-unauthorized": "操作未授權！"
+    "msg.operation-unauthorized": "操作未授權！",
+    "gauges.property-icon-none": "無圖示"
 }
 
 


### PR DESCRIPTION
## Description

Button properties could set an icon but not clear it. `app-icon-selector` now has a **No icon** option that clears `property.icon` (and any image preview). Label is translated in all locale files.

## Validation

- Manual: place button → set icon → OK → reopen → choose **No icon** → OK → icon gone without server restart

Fixes #2426

### AI/LLM disclosure
- AI coding tools were used to help draft this change and PR description.
- I reviewed the complete change and understand the reasoning before submitting.