### PR TITLE
Fix: keep fixed navigation side menu open on Esc

### DIFF
--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -3,7 +3,8 @@
 	</mat-progress-bar>
 </div>
 <mat-sidenav-container class="sidenav-container" [hasBackdrop]="false">
-	<mat-sidenav #matsidenav *ngIf="showNavigation && showSidenav" class="sidenav" [mode]="showSidenav">
+	<mat-sidenav #matsidenav *ngIf="showNavigation && showSidenav" class="sidenav" [mode]="showSidenav"
+		[disableClose]="showSidenav === 'side'">
 		<app-sidenav #sidenav [sidenav]="matsidenav" (goToPage)="onGoToPage($event)" (goToLink)="onGoToLink($event)"></app-sidenav>
 	</mat-sidenav>
 	<mat-sidenav-content


### PR DESCRIPTION
## Description

When Side Mode is Fixed (`mat-sidenav` mode `side`), Escape closed the navigation menu via Angular Material’s default drawer behavior. Fixed mode has no hamburger control, so the menu could not be reopened.

Sets `[disableClose]` for Fixed/side mode so Esc no longer dismisses the nav. Over/push modes are unchanged.

## Validation

- Reviewed Angular Material `mat-sidenav` Esc/`disableClose` behavior against Fixed mode in `home.component.html`
- Confirmed click-to-close already skipped Fixed mode (`checkToCloseSideNav`); only Esc needed the fix

Fixes #2427

### AI/LLM disclosure
- AI coding tools were used to help draft this change and PR description.
- I reviewed the complete change and understand the reasoning before submitting.