### PR TITLE
fix(client): guard clientAccess before reading scriptSystemFunctions

### DIFF
--- a/client/src/app/_services/script.service.ts
+++ b/client/src/app/_services/script.service.ts
@@ -43,7 +43,7 @@ export class ScriptService {
         const api: any = {};
 
         for (const fn of systemFunctions.functions) {
-            if (clientAccess.scriptSystemFunctions.includes(fn.name)) {
+            if (clientAccess?.scriptSystemFunctions?.includes(fn.name)) {
                 const methodName = fn.name.replace('$', '');
                 if (typeof this[fn.name] === 'function') {
                     api[methodName] = this[fn.name].bind(this);


### PR DESCRIPTION
### Problem

`ProjectService.getClientAccess()` can return `null`:

```ts
// client/src/app/_services/project.service.ts
getClientAccess(): ClientAccess {
    return (this.projectData) ? (this.projectData.clientAccess) ? this.projectData.clientAccess : new ClientAccess() : null;
}
```

A missing `clientAccess` key is handled — it falls back to `new ClientAccess()`, whose `scriptSystemFunctions` defaults to `[]`. But when `projectData` itself is not yet set, the method returns bare `null`.

`ScriptService.loadScriptApi()` then dereferences it without a guard:

```ts
// client/src/app/_services/script.service.ts
const clientAccess = this.projectService.getClientAccess();
...
if (clientAccess.scriptSystemFunctions.includes(fn.name)) {
```

which throws `TypeError: Cannot read properties of null (reading 'scriptSystemFunctions')`.

`loadScriptApi()` is called from the `onLoadClientAccess` and `onLoadHmi` subscriptions in the constructor, so it can run before project data is populated.

### Why it is worth guarding

The failure is quiet and points at the wrong layer. The throw aborts the load before any gauge binds, but the SVG still renders — so it looks like a data-binding problem rather than an exception, and the console error is easy to miss among socket noise. I lost a good few hours to this while building an MQTT-driven HMI before finding it.

### Change

One line, optional chaining:

```diff
-            if (clientAccess.scriptSystemFunctions.includes(fn.name)) {
+            if (clientAccess?.scriptSystemFunctions?.includes(fn.name)) {
```

Behaviour is unchanged on every path that works today. When there is no client access configured, no system function is exposed — which is exactly what the existing empty-array default already produces. `window.fuxaScriptAPI` is still assigned, so callers see an empty API rather than a half-initialised one.

### Verification

`npx tsc --noEmit -p tsconfig.json` in `client/` reports **5 errors before the change and 5 after** — all pre-existing, all in `e2e/` from missing `protractor` types. Nothing new, and nothing in `script.service.ts`.

I have not reproduced the null path in a running instance; the report is from reading the two files above. Happy to add a regression test or take a different shape if you would prefer an early return over optional chaining.