### PR TITLE
Security: scope admin socket responses

### DIFF
--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -211,14 +211,14 @@ function init(_io, _api, _settings, _log, eventsMain) {
                 if (message) {
                     if (message.device) {
                         devices.browseDevice(message.device, message.node, function (nodes) {
-                            io.emit(Events.IoEventTypes.DEVICE_BROWSE, nodes);
+                            socket.emit(Events.IoEventTypes.DEVICE_BROWSE, nodes);
                         }).then(result => {
                             message.result = result;
-                            io.emit(Events.IoEventTypes.DEVICE_BROWSE, message);
+                            socket.emit(Events.IoEventTypes.DEVICE_BROWSE, message);
                         }).catch(function (err) {
                             logger.error(`${Events.IoEventTypes.DEVICE_BROWSE}: ${err}`);
                             message.error = err;
-                            io.emit(Events.IoEventTypes.DEVICE_BROWSE, message);
+                            socket.emit(Events.IoEventTypes.DEVICE_BROWSE, message);
                         });
                     }
                 }
@@ -236,11 +236,11 @@ function init(_io, _api, _settings, _log, eventsMain) {
                 if (message) {
                     if (message.device) {
                         devices.readNodeAttribute(message.device, message.node).then(result => {
-                            io.emit(Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE, message);
+                            socket.emit(Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE, message);
                         }).catch(function (err) {
                             logger.error(`${Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE}: ${err}`);
                             message.error = err;
-                            io.emit(Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE, message);
+                            socket.emit(Events.IoEventTypes.DEVICE_NODE_ATTRIBUTE, message);
                         });
                     }
                 }
@@ -301,16 +301,16 @@ function init(_io, _api, _settings, _log, eventsMain) {
                     message = {};
                     utils.getHostInterfaces().then(result => {
                         message.result = result;
-                        io.emit(Events.IoEventTypes.HOST_INTERFACES, message);
+                        socket.emit(Events.IoEventTypes.HOST_INTERFACES, message);
                     }).catch(function (err) {
                         logger.error(`${Events.IoEventTypes.HOST_INTERFACES}: ${err}`);
                         message.error = err;
-                        io.emit(Events.IoEventTypes.HOST_INTERFACES, message);
+                        socket.emit(Events.IoEventTypes.HOST_INTERFACES, message);
                     });
                 } else {
                     logger.error(`${Events.IoEventTypes.HOST_INTERFACES}: wrong message`);
                     message.error = 'wrong message';
-                    io.emit(Events.IoEventTypes.HOST_INTERFACES, message);
+                    socket.emit(Events.IoEventTypes.HOST_INTERFACES, message);
                 }
             } catch (err) {
                 logger.error(`${Events.IoEventTypes.HOST_INTERFACES}: ${err}`);
@@ -352,16 +352,16 @@ function init(_io, _api, _settings, _log, eventsMain) {
                 if (message && message.deviceId) {
                     devices.getDeviceTagsResult(message.deviceId).then(result => {
                         message.result = result;
-                        io.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
+                        socket.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
                     }).catch(function (err) {
                         logger.error(`${Events.IoEventTypes.DEVICE_TAGS_REQUEST}: ${err}`);
                         message.error = err;
-                        io.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
+                        socket.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
                     });
                 } else {
                     logger.error(`${Events.IoEventTypes.DEVICE_TAGS_REQUEST}: wrong message`);
                     message.error = 'wrong message';
-                    io.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
+                    socket.emit(Events.IoEventTypes.DEVICE_TAGS_REQUEST, message);
                 }
             } catch (err) {
                 logger.error(`${Events.IoEventTypes.DEVICE_TAGS_REQUEST}: ${err}`);

--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -150,10 +150,10 @@ function init(_io, _api, _settings, _log, eventsMain) {
             if (message === 'get') {
                 var adevs = devices.getDevicesStatus();
                 for (var id in adevs) {
-                    updateDeviceStatus({ id: id, status: adevs[id] });
+                    socket.emit(Events.IoEventTypes.DEVICE_STATUS, { id: id, status: adevs[id] });
                 }
             } else {
-                updateDeviceStatus(message);
+                logger.warn(`${Events.IoEventTypes.DEVICE_STATUS}: rejected client status update from ${socket.userId || 'guest'}`);
             }
         });
         // client ask device property

--- a/server/test/authorization/socketResponseScopeSecurity.test.js
+++ b/server/test/authorization/socketResponseScopeSecurity.test.js
@@ -35,4 +35,13 @@ describe('Security - Socket.IO admin response scoping', () => {
             expect(handler).to.contain(`socket.emit(Events.IoEventTypes.${eventName}`);
         });
     });
+
+    it('does not accept client-published device status updates', () => {
+        const handler = getHandlerSource('DEVICE_STATUS');
+
+        expect(handler).to.contain("message === 'get'");
+        expect(handler).to.contain('socket.emit(Events.IoEventTypes.DEVICE_STATUS');
+        expect(handler).to.not.contain('updateDeviceStatus(message)');
+        expect(handler).to.contain('rejected client status update');
+    });
 });

--- a/server/test/authorization/socketResponseScopeSecurity.test.js
+++ b/server/test/authorization/socketResponseScopeSecurity.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Security - Socket.IO admin response scoping', () => {
+    let expect;
+    let source;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+        source = fs.readFileSync(path.join(__dirname, '..', '..', 'runtime', 'index.js'), 'utf8');
+    });
+
+    function getHandlerSource(eventName) {
+        const start = source.indexOf(`socket.on(Events.IoEventTypes.${eventName}`);
+        expect(start).to.be.greaterThan(-1);
+
+        const nextHandler = source.indexOf('socket.on(Events.IoEventTypes.', start + 1);
+        return source.slice(start, nextHandler === -1 ? source.length : nextHandler);
+    }
+
+    [
+        'DEVICE_BROWSE',
+        'DEVICE_NODE_ATTRIBUTE',
+        'HOST_INTERFACES',
+        'DEVICE_TAGS_REQUEST'
+    ].forEach(eventName => {
+        it(`scopes ${eventName} responses to the requesting socket`, () => {
+            const handler = getHandlerSource(eventName);
+
+            expect(handler).to.contain('isSocketAdminAuthorized(socket)');
+            expect(handler).to.not.contain(`io.emit(Events.IoEventTypes.${eventName}`);
+            expect(handler).to.contain(`socket.emit(Events.IoEventTypes.${eventName}`);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Hardens Socket.IO admin handling by scoping admin responses to the requesting socket and rejecting client-published device status updates.

## Changes

- Replace admin response broadcasts with per-socket emits.
- Reject unsolicited `DEVICE_STATUS` update payloads.
- Add regression coverage.