### PR TITLE
Security: normalize signin failure responses

### DIFF
--- a/server/api/auth/index.js
+++ b/server/api/auth/index.js
@@ -73,6 +73,10 @@ function clearRefreshCookie(res) {
     res.clearCookie(refreshCookieName, { path: '/api/refresh' });
 }
 
+function sendInvalidSignInResponse(res) {
+    res.status(401).json({ status: 'error', message: 'Invalid email/password!!!', data: null });
+}
+
 module.exports = {
     init: function (_runtime, _secretCode, _tokenExpires, _enableRefreshCookieAuth, _refreshTokenExpires) {
         runtime = _runtime;
@@ -119,12 +123,12 @@ module.exports = {
                         });
                         runtime.logger.info('api-signin: ' + userInfo[0].username + ' ' + userInfo[0].fullname + ' ' + userInfo[0].groups);
                     } else {
-                        res.status(401).json({ status: 'error', message: 'Invalid email/password!!!', data: null });
+                        sendInvalidSignInResponse(res);
                         runtime.logger.error('api post signin: Invalid email/password!!!');
                     }
                 } else {
-                    res.status(404).end();
-                    runtime.logger.error('api post signin: Not Found!');
+                    sendInvalidSignInResponse(res);
+                    runtime.logger.error('api post signin: Invalid email/password!!!');
                 }
             }).catch(function (err) {
                 if (err.code) {

--- a/server/test/authorization/jwtLifecycleSecurity.test.js
+++ b/server/test/authorization/jwtLifecycleSecurity.test.js
@@ -3,6 +3,7 @@
 const http = require('http');
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 
 const apiIndex = require('../../api');
 const authApi = require('../../api/auth');
@@ -58,6 +59,61 @@ describe('Security - JWT lifecycle', () => {
     before(async () => {
         const chai = await import('chai');
         expect = chai.expect;
+    });
+
+    it('returns the same signin failure response for unknown users and bad passwords', async () => {
+        const passwordHash = bcrypt.hashSync('correct-password', 4);
+        const runtime = {
+            project: {},
+            users: {
+                findOne(credentials) {
+                    if (credentials.username === 'admin') {
+                        return Promise.resolve([
+                            {
+                                username: 'admin',
+                                fullname: 'Administrator',
+                                password: passwordHash,
+                                groups: -1,
+                                info: '{}'
+                            }
+                        ]);
+                    }
+                    return Promise.resolve([]);
+                }
+            },
+            logger: {
+                error() {},
+                info() {}
+            }
+        };
+
+        authApi.init(runtime, SECRET, '1h', false, '7d');
+        const app = express();
+        app.use(express.json());
+        app.use(authApi.app());
+        const server = await listen(app);
+
+        try {
+            const headers = { 'Content-Type': 'application/json' };
+            const existingUser = await request(server, {
+                method: 'POST',
+                path: '/api/signin',
+                headers,
+                body: JSON.stringify({ username: 'admin', password: 'wrong-password' })
+            });
+            const unknownUser = await request(server, {
+                method: 'POST',
+                path: '/api/signin',
+                headers,
+                body: JSON.stringify({ username: 'user_does_not_exist_999', password: 'wrong-password' })
+            });
+
+            expect(existingUser.statusCode).to.equal(401);
+            expect(unknownUser.statusCode).to.equal(401);
+            expect(unknownUser.json).to.deep.equal(existingUser.json);
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
     });
 
     it('rejects refresh cookies for deleted users instead of reusing token groups', async () => {


### PR DESCRIPTION
## Summary

Hardens authentication by returning the same signin failure response for unknown users and invalid passwords (GHSA-pmp3-h22v-22vv).

## Changes

- Use a shared invalid signin response.
- Avoid different status codes for failed signin attempts.
- Add regression coverage for consistent signin failures.