### PR TITLE
fix(resources): recurse image groups so nested files appear in picker

### DIFF
--- a/server/api/resources/index.js
+++ b/server/api/resources/index.js
@@ -49,7 +49,9 @@ module.exports = {
                         var group = { name: resourcesDirs[i], items: [] };
                         var dirPath = path.resolve(runtime.settings.imagesFileDir, resourcesDirs[i]);
                         var wwwSubDir = path.join('_images', resourcesDirs[i]);
-                        var files = getFiles(dirPath, ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp4', '.webm', '.ogg', '.ogv']);
+                        // Recurse so nested assets under each group appear in the editor picker
+                        // (relative path kept in name/path to avoid collisions).
+                        var files = getFilesRecursive(dirPath, ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp4', '.webm', '.ogg', '.ogv']);
                         for (var x = 0; x < files.length; x++) {
                             var filename = files[x].replace(/\.[^\/.]+$/, '');
                             group.items.push({ path: path.join(wwwSubDir, files[x]).split(path.sep).join(path.posix.sep), name: filename });


### PR DESCRIPTION
### Summary
Resources images API now recurses into subfolders so nested assets appear in the editor picker.

### Validation
- Local Node check: nested fixture `server/_images/Symbols/family/orientation/state.svg` is returned by recursive listing with path `_images/Symbols/family/orientation/state.svg` and name `family/orientation/state` (relative path avoids collisions). Flat first-level files under `Pipes`/`Tanks` still list as before.
- No existing server tests for the resources API; change reuses the same `getFilesRecursive` helper already used by `/api/resources/widgets`.

Fixes #2484

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.