### PR TITLE
Fix alarm permissions for reports and active status

### DIFF
--- a/server/runtime/alarms/index.js
+++ b/server/runtime/alarms/index.js
@@ -67,16 +67,21 @@ function AlarmsManager(_runtime) {
     /**
      * Return the alarms status (active/passive alarms count), { highhigh: <count>, high: <count>, low: <count>, info: <count> }
      */
-    this.getAlarmsStatus = function () {
+    this.getAlarmsStatus = function (permission) {
         return new Promise(function (resolve, reject) {
             alarmstorage.getAlarms().then(function (alrs) {
                 var result = { highhigh: 0, high: 0, low: 0, info: 0, actions: [] };
                 if (alrs) {
                     Object.values(alrs).forEach(alr => {
-                        result[alr.type]++;
+                        if (!_canShowAlarmStatus(alr, permission)) {
+                            return;
+                        }
+                        if (Object.prototype.hasOwnProperty.call(result, alr.type)) {
+                            result[alr.type]++;
+                        }
                         if (alr.type === AlarmsTypes.ACTION && !alr.offtime) {
                             var action = actionsProperty[alr.nametype];
-                            if (action.subproperty) {
+                            if (action && action.subproperty) {
                                 if (action.subproperty.type === ActionsTypes.POPUP || action.subproperty.type === ActionsTypes.SET_VIEW || action.subproperty.type === ActionsTypes.TOAST_MESSAGE) {
                                     result.actions.push({ type: action.subproperty.type, params: action.subproperty.actparam, options: action.subproperty.actoptions });
                                 }
@@ -357,6 +362,7 @@ function AlarmsManager(_runtime) {
         return new Promise(function (resolve, reject) {
             alarms = {};
             alarmsProperty = {};
+            actionsProperty = {};
             runtime.project.getAlarms().then(function (result) {
                 var alarmsFound = 0;
                 if (result) {
@@ -524,6 +530,18 @@ function AlarmsManager(_runtime) {
             }
         }
         return available;
+    }
+
+    var _canShowAlarmStatus = function (alarm, permission) {
+        var property = null;
+        if (alarm.type === AlarmsTypes.ACTION) {
+            property = actionsProperty[alarm.nametype]?.tagproperty;
+        } else if (alarm.nametype) {
+            var alarmName = alarm.nametype.split(SEPARATOR)[0];
+            property = alarmsProperty[alarmName]?.property;
+        }
+        var alrPermission = property ? runtime.checkPermission(permission, property) : { show: true, enabled: true };
+        return !!alrPermission.show;
     }
 
     var _formatDateTime = function (dt) {

--- a/server/runtime/index.js
+++ b/server/runtime/index.js
@@ -287,7 +287,7 @@ function init(_io, _api, _settings, _log, eventsMain) {
         // client ask alarms status
         socket.on(Events.IoEventTypes.ALARMS_STATUS, (message) => {
             if (message === 'get') {
-                updateAlarmsStatus();
+                updateAlarmsStatus(socket);
             }
         });
         // client ask host interfaces
@@ -608,15 +608,37 @@ function updateDeviceStatus(event) {
 /**
  * Transmit the alarms status to all frontend
  */
-function updateAlarmsStatus() {
+function getSocketPermission(socket) {
+    if (!settings || !settings.secureEnabled) {
+        return -1;
+    }
+    if (settings.userRole && socket?.userId !== 'admin') {
+        return users.getUserCache(socket?.userId);
+    }
+    return socket?.userGroups;
+}
+
+function updateAlarmsStatus(socket) {
     try {
-        alarmsMgr.getAlarmsStatus().then(function (result) {
-            io.emit(Events.IoEventTypes.ALARMS_STATUS, result);
-        }).catch(function (err) {
-            if (err) {
-                logger.error('runtime.failed-to-update-alarms: ' + err);
-            }
-        });
+        if (socket) {
+            alarmsMgr.getAlarmsStatus(getSocketPermission(socket)).then(function (result) {
+                socket.emit(Events.IoEventTypes.ALARMS_STATUS, result);
+            }).catch(function (err) {
+                if (err) {
+                    logger.error('runtime.failed-to-update-alarms: ' + err);
+                }
+            });
+        } else {
+            Array.from(io.sockets.sockets.values()).forEach((clientSocket) => {
+                alarmsMgr.getAlarmsStatus(getSocketPermission(clientSocket)).then(function (result) {
+                    clientSocket.emit(Events.IoEventTypes.ALARMS_STATUS, result);
+                }).catch(function (err) {
+                    if (err) {
+                        logger.error('runtime.failed-to-update-alarms: ' + err);
+                    }
+                });
+            });
+        }
     } catch (err) {
         logger.error('runtime.failed-to-update-alarms: ' + err);
     }

--- a/server/runtime/jobs/report.js
+++ b/server/runtime/jobs/report.js
@@ -42,7 +42,7 @@ function Report(_property, _runtime) {
                 }
             } catch (err) {
                 reject(err);
-            }  
+            }
         });
     }
 
@@ -107,9 +107,9 @@ function Report(_property, _runtime) {
             try {
                 let docDefinition = {...report.docproperty };
                 docDefinition['header'] = { text: 'FUXA by frangoteam', style:[{fontSize: 6}]};
-                docDefinition['footer'] = function(currentPage, pageCount) { 
-                    return { text: currentPage.toString() + ' / ' + pageCount, style:[{alignment: 'right', fontSize: 8}]} ; 
-                },                
+                docDefinition['footer'] = function(currentPage, pageCount) {
+                    return { text: currentPage.toString() + ' / ' + pageCount, style:[{alignment: 'right', fontSize: 8}]} ;
+                },
                 docDefinition['content'] = [];
                 for (let i = 0; i < report.content.items.length; i++) {
                     let item = report.content.items[i];
@@ -146,7 +146,7 @@ function Report(_property, _runtime) {
         return new Promise(async function (resolve, reject) {
             try {
                 let content = { layout: 'lightHorizontalLines', fontSize: item.size }; // optional
-                let header = item.columns.map(col => { 
+                let header = item.columns.map(col => {
                     return { text: col.label || col.tag.label || col.tag.name, bold: true, style: [{ alignment: col.align }] }
                 });
                 //item.columns.map(col => col.tag.address || '');
@@ -178,7 +178,7 @@ function Report(_property, _runtime) {
                 resolve(content);
             } catch (err) {
                 reject(err);
-            }                
+            }
         });
     }
 
@@ -212,7 +212,7 @@ function Report(_property, _runtime) {
                 });
             } catch (err) {
                 reject(err);
-            }                
+            }
         });
     }
 
@@ -230,7 +230,7 @@ function Report(_property, _runtime) {
                     reject(err);
                     logger.error("createImage: " + err);
                 });
-            }  catch { 
+            }  catch {
                 reject('TODO node create image from canvas is not supported!');
             }
         });
@@ -240,8 +240,8 @@ function Report(_property, _runtime) {
         if (dateRange === ReportDateRangeType.day) {
             var yesterday = new Date(currentTime || Date.now());
             yesterday.setDate(yesterday.getDate() - 1);
-            return { 
-                begin: new Date(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate()), 
+            return {
+                begin: new Date(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate()),
                 end: new Date(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate(), 23, 59, 59)
             };
         } else if (dateRange === ReportDateRangeType.week) {
@@ -249,19 +249,19 @@ function Report(_property, _runtime) {
             lastWeek = new Date(lastWeek.setDate(lastWeek.getDate() - 7 - (lastWeek.getDay() + 6 ) % 7));
             var diff = lastWeek.getDate() - lastWeek.getDay() + (lastWeek.getDay() == 0 ? -6 : 1); // adjust when day is sunday
             lastWeek = new Date(lastWeek.setDate(diff));
-            return { 
-                begin: new Date(lastWeek.getFullYear(), lastWeek.getMonth(), lastWeek.getDate()), 
+            return {
+                begin: new Date(lastWeek.getFullYear(), lastWeek.getMonth(), lastWeek.getDate()),
                 end: new Date(lastWeek.getFullYear(), lastWeek.getMonth(), lastWeek.getDate() + 6, 23, 59, 59)
             };
         } else if (dateRange === ReportDateRangeType.month) {
             var lastMonth = new Date(currentTime || Date.now());
-            return { 
+            return {
                 begin: new Date(lastMonth.getFullYear(), lastMonth.getMonth() - 1, 1, 0, 0, 0),
                 end: new Date(lastMonth.getFullYear(), lastMonth.getMonth(), 0, 23, 59, 59)
             };
         } else {
-            return { 
-                begin: new Date(currentTime || Date.now()), 
+            return {
+                begin: new Date(currentTime || Date.now()),
                 end: new Date(currentTime || Date.now())
             };
         }
@@ -271,22 +271,22 @@ function Report(_property, _runtime) {
         return new Promise(async function (resolve, reject) {
             try {
                 let content = { layout: 'lightHorizontalLines', fontSize: item.size }; // optional
-                let header = Object.values(item.propertyText).map(col => { 
+                let header = Object.values(item.propertyText).map(col => {
                     return { text: col, bold: true, style: [{ alignment: 'left' }] }
                 });
                 let values = [];
                 const timeRange = _getDateRange(item.range);
                 const query = { start: timeRange.begin.getTime(), end: timeRange.end.getTime() };
-                await runtime.alarmsMgr.getAlarmsHistory(query).then(result => {
+                await runtime.alarmsMgr.getAlarmsHistory(query, -1).then(result => {
                     if (!result || !result.length) {
-                        values = [Object.values(item.propertyText).map(col => { 
+                        values = [Object.values(item.propertyText).map(col => {
                             return { text: '', style: [{ alignment: 'left' }] }
                         })];
                      } else {
                         const property = Object.keys(item.property).filter(prop => { if (item.property[prop]) return prop; });
-                        values = result.filter(alr => { 
+                        values = result.filter(alr => {
                             if (item.priority[alr.type] && (!item.alarmFilter || !!item.alarmFilter.find(name => name === alr.name))) {
-                                return alr; 
+                                return alr;
                             }
                         });
                         values = values.map(alr => {

--- a/server/test/alarms/alarmHistory.test.js
+++ b/server/test/alarms/alarmHistory.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const alarmstorage = require('../../runtime/alarms/alarmstorage');
+const alarms = require('../../runtime/alarms');
+const Report = require('../../runtime/jobs/report');
+
+function makeLogger() {
+    return {
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+    };
+}
+
+function makeStoredAlarm(id, type, ontime, value = 1) {
+    return {
+        getId: () => id,
+        type,
+        status: 'active',
+        ontime,
+        offtime: 0,
+        acktime: 0,
+        userack: '',
+        value,
+        toremove: false,
+        subproperty: { group: 'default', text: id }
+    };
+}
+
+function makeRuntime(settings, projectAlarms) {
+    return {
+        settings,
+        logger: makeLogger(),
+        project: {
+            getAlarms: () => Promise.resolve(projectAlarms)
+        },
+        devices: {
+            getDeviceIdFromTag: () => 'device-a'
+        },
+        checkPermission(userPermission, context) {
+            if (userPermission === -1 || userPermission === 255 || !context) {
+                return { show: true, enabled: true };
+            }
+            const contextPermission = settings.userRole ? context.permissionRoles : context.permission;
+            if (settings.userRole) {
+                if (!userPermission?.info?.roles) {
+                    return { show: !contextPermission?.show?.length, enabled: !contextPermission?.enabled?.length };
+                }
+                return {
+                    show: contextPermission?.show?.length ? userPermission.info.roles.some(role => contextPermission.show.includes(role)) : true,
+                    enabled: contextPermission?.enabled?.length ? userPermission.info.roles.some(role => contextPermission.enabled.includes(role)) : true
+                };
+            }
+            const showMask = contextPermission >> 8;
+            const enabledMask = contextPermission & 255;
+            return {
+                show: showMask ? !!(showMask & userPermission) : true,
+                enabled: enabledMask ? !!(enabledMask & userPermission) : true
+            };
+        }
+    };
+}
+
+function makeProjectAlarm(name, variableId, property, highhigh = {}) {
+    return {
+        name,
+        property: Object.assign({ variableId }, property),
+        highhigh: Object.assign({
+            enabled: true,
+            checkdelay: 1,
+            timedelay: 0,
+            min: 90,
+            max: 100,
+            ackmode: 'ackactive',
+            text: `${name} highhigh`,
+            group: 'default',
+            bkcolor: '#ffffff',
+            color: '#000000'
+        }, highhigh),
+        high: { enabled: false },
+        low: { enabled: false },
+        info: { enabled: false }
+    };
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('Alarms history', () => {
+    let expect;
+    let workDir;
+    let manager;
+    let storageOpen;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    afterEach(() => {
+        if (manager) {
+            manager.stop();
+        }
+        if (storageOpen) {
+            alarmstorage.close();
+        }
+        if (workDir) {
+            try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {}
+        }
+        workDir = null;
+        manager = null;
+        storageOpen = false;
+    });
+
+    async function initManager(settings, projectAlarms, storedAlarms) {
+        workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fuxa-alarm-history-'));
+        const runtime = makeRuntime(Object.assign({ workDir }, settings), projectAlarms);
+        manager = alarms.create(runtime);
+        await alarmstorage.init(runtime.settings, runtime.logger);
+        storageOpen = true;
+        await alarmstorage.setAlarms(storedAlarms || projectAlarms.map((alarm, index) =>
+            makeStoredAlarm(`${alarm.name}^~^highhigh`, 'highhigh', 1710000000000 + index)
+        ));
+        manager.start();
+        await delay(2300);
+        manager.stop();
+    }
+
+    describe('manager history', () => {
+        it('maps stored alarm rows to alarm history entries', async () => {
+            const projectAlarm = makeProjectAlarm(
+                'temperature-alarm',
+                'device-a^~^temperature',
+                {},
+                { text: 'Temperature high', group: 'boiler', bkcolor: '#ff0000', color: '#ffffff' }
+            );
+
+            await initManager({}, [projectAlarm], [
+                makeStoredAlarm('temperature-alarm^~^highhigh', 'highhigh', 1710000000000, 42)
+            ]);
+
+            const history = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER });
+
+            expect(history).to.have.length(1);
+            expect(history[0]).to.include({
+                name: 'temperature-alarm',
+                type: 'highhigh',
+                status: 'active',
+                text: 'temperature-alarm^~^highhigh',
+                group: 'default',
+                value: '42',
+                bkcolor: '#ff0000',
+                color: '#ffffff'
+            });
+            expect(history[0].ontime).to.equal(1710000000000);
+        });
+
+        it('returns only history entries inside the requested time range', async () => {
+            const alarmA = makeProjectAlarm('old-alarm', 'device-a^~^tag-a', {});
+            const alarmB = makeProjectAlarm('current-alarm', 'device-a^~^tag-b', {});
+
+            await initManager({}, [alarmA, alarmB], [
+                makeStoredAlarm('old-alarm^~^highhigh', 'highhigh', 1710000000000),
+                makeStoredAlarm('current-alarm^~^highhigh', 'highhigh', 1710000001000)
+            ]);
+
+            const history = await manager.getAlarmsHistory({ start: 1710000001000, end: 1710000001000 });
+
+            expect(history.map(alarm => alarm.name)).to.deep.equal(['current-alarm']);
+        });
+    });
+
+    describe('authorization', () => {
+        it('filters alarm history by group permission bitmask', async () => {
+            const alarmA = makeProjectAlarm('visible-alarm', 'device-a^~^tag-a', { permission: 1 << 8 });
+            const alarmB = makeProjectAlarm('hidden-alarm', 'device-a^~^tag-b', { permission: 2 << 8 });
+
+            await initManager({ secureEnabled: true, userRole: false }, [alarmA, alarmB]);
+
+            const group1History = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, 1);
+            const group2History = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, 2);
+            const group3History = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, 4);
+
+            expect(group1History.map(alarm => alarm.name)).to.deep.equal(['visible-alarm']);
+            expect(group2History.map(alarm => alarm.name)).to.deep.equal(['hidden-alarm']);
+            expect(group3History).to.deep.equal([]);
+        });
+
+        it('filters alarm history by role permission', async () => {
+            const alarmA = makeProjectAlarm('operator-alarm', 'device-a^~^tag-a', { permissionRoles: { show: ['operator'], enabled: [] } });
+            const alarmB = makeProjectAlarm('engineer-alarm', 'device-a^~^tag-b', { permissionRoles: { show: ['engineer'], enabled: [] } });
+
+            await initManager({ secureEnabled: true, userRole: true }, [alarmA, alarmB]);
+
+            const operatorHistory = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, { info: { roles: ['operator'] }, groups: 1 });
+            const engineerHistory = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, { info: { roles: ['engineer'] }, groups: 2 });
+            const viewerHistory = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, { info: { roles: ['viewer'] }, groups: 4 });
+
+            expect(operatorHistory.map(alarm => alarm.name)).to.deep.equal(['operator-alarm']);
+            expect(engineerHistory.map(alarm => alarm.name)).to.deep.equal(['engineer-alarm']);
+            expect(viewerHistory).to.deep.equal([]);
+        });
+
+        it('keeps admin alarm history unfiltered', async () => {
+            const alarmA = makeProjectAlarm('visible-alarm', 'device-a^~^tag-a', { permission: 1 << 8 });
+            const alarmB = makeProjectAlarm('hidden-alarm', 'device-a^~^tag-b', { permission: 2 << 8 });
+
+            await initManager({ secureEnabled: true, userRole: false }, [alarmA, alarmB]);
+
+            const adminHistory = await manager.getAlarmsHistory({ start: 0, end: Number.MAX_SAFE_INTEGER }, -1);
+
+            expect(adminHistory.map(alarm => alarm.name).sort()).to.deep.equal(['hidden-alarm', 'visible-alarm']);
+        });
+    });
+
+    describe('report integration', () => {
+        it('loads alarm history with admin permission', async () => {
+            workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fuxa-report-alarms-'));
+            const calls = [];
+            const runtime = {
+                settings: { reportsDir: workDir },
+                logger: makeLogger(),
+                alarmsMgr: {
+                    getAlarmsHistory: (query, permission) => {
+                        calls.push({ query, permission });
+                        return Promise.resolve([{
+                            name: 'hidden-alarm',
+                            type: 'highhigh',
+                            status: 'active',
+                            text: 'Hidden alarm',
+                            group: 'default',
+                            ontime: 1710000000000,
+                            bkcolor: '#ffffff',
+                            color: '#000000'
+                        }]);
+                    }
+                }
+            };
+            const report = Report.create({
+                name: 'alarm-report',
+                scheduling: 'none',
+                docproperty: {},
+                content: {
+                    items: [{
+                        type: 'alarms',
+                        range: 'day',
+                        size: 8,
+                        propertyText: { ontime: 'On time', text: 'Text' },
+                        property: { ontime: true, text: true },
+                        priority: { highhigh: true },
+                        priorityText: { highhigh: 'High high' },
+                        statusText: { active: 'Active' }
+                    }]
+                }
+            }, runtime);
+
+            const filepath = await report.execute(new Date(2024, 2, 10, 2, 30, 0), true);
+
+            expect(calls).to.have.length(1);
+            expect(calls[0].permission).to.equal(-1);
+            expect(fs.existsSync(filepath)).to.equal(true);
+        });
+    });
+});

--- a/server/test/alarms/alarmStatusAuthorization.test.js
+++ b/server/test/alarms/alarmStatusAuthorization.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const alarmstorage = require('../../runtime/alarms/alarmstorage');
+const alarms = require('../../runtime/alarms');
+
+function makeLogger() {
+    return {
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+    };
+}
+
+function makeStoredAlarm(id, type) {
+    return {
+        getId: () => id,
+        type,
+        status: 'N',
+        ontime: 1710000000000,
+        offtime: 0,
+        acktime: 0,
+        userack: '',
+        value: 1,
+        toremove: false,
+        subproperty: { group: 'default', text: id }
+    };
+}
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function makeRuntime(settings, projectAlarms) {
+    return {
+        settings,
+        logger: makeLogger(),
+        project: {
+            getAlarms: () => Promise.resolve(projectAlarms)
+        },
+        devices: {
+            getDeviceIdFromTag: () => 'device-a'
+        },
+        checkPermission(userPermission, context) {
+            if (userPermission === -1 || userPermission === 255 || !context) {
+                return { show: true, enabled: true };
+            }
+            const contextPermission = settings.userRole ? context.permissionRoles : context.permission;
+            if (settings.userRole) {
+                if (!userPermission?.info?.roles) {
+                    return { show: !contextPermission?.show?.length, enabled: !contextPermission?.enabled?.length };
+                }
+                return {
+                    show: contextPermission?.show?.length ? userPermission.info.roles.some(role => contextPermission.show.includes(role)) : true,
+                    enabled: contextPermission?.enabled?.length ? userPermission.info.roles.some(role => contextPermission.enabled.includes(role)) : true
+                };
+            }
+            const showMask = contextPermission >> 8;
+            const enabledMask = contextPermission & 255;
+            return {
+                show: showMask ? !!(showMask & userPermission) : true,
+                enabled: enabledMask ? !!(enabledMask & userPermission) : true
+            };
+        }
+    };
+}
+
+function makeProjectAlarm(name, variableId, property) {
+    return {
+        name,
+        property: Object.assign({ variableId }, property),
+        highhigh: { enabled: true, checkdelay: 1, timedelay: 0, min: 90, max: 100, ackmode: 'ackactive', text: `${name} highhigh` },
+        high: { enabled: false },
+        low: { enabled: false },
+        info: { enabled: false }
+    };
+}
+
+describe('Alarms status authorization', () => {
+    let expect;
+    let workDir;
+    let manager;
+
+    before(async () => {
+        const chai = await import('chai');
+        expect = chai.expect;
+    });
+
+    afterEach(() => {
+        if (manager) {
+            manager.stop();
+        }
+        alarmstorage.close();
+        if (workDir) {
+            try { fs.rmSync(workDir, { recursive: true, force: true }); } catch (_) {}
+        }
+        workDir = null;
+        manager = null;
+    });
+
+    async function initManager(settings, projectAlarms) {
+        workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fuxa-alarm-status-'));
+        const runtime = makeRuntime(Object.assign({ workDir }, settings), projectAlarms);
+        manager = alarms.create(runtime);
+        await alarmstorage.init(runtime.settings, runtime.logger);
+        await alarmstorage.setAlarms(projectAlarms.map(alarm => makeStoredAlarm(`${alarm.name}^~^highhigh`, 'highhigh')));
+        manager.start();
+        await delay(2300);
+        manager.stop();
+    }
+
+    it('filters alarm status counts by group permission bitmask', async () => {
+        const alarmA = makeProjectAlarm('visible-alarm', 'device-a^~^tag-a', { permission: 1 << 8 });
+        const alarmB = makeProjectAlarm('hidden-alarm', 'device-a^~^tag-b', { permission: 2 << 8 });
+
+        await initManager({ secureEnabled: true, userRole: false }, [alarmA, alarmB]);
+
+        const visibleToGroup1 = await manager.getAlarmsStatus(1);
+        const visibleToGroup2 = await manager.getAlarmsStatus(2);
+        const visibleToGroup3 = await manager.getAlarmsStatus(4);
+
+        expect(visibleToGroup1.highhigh).to.equal(1);
+        expect(visibleToGroup2.highhigh).to.equal(1);
+        expect(visibleToGroup3.highhigh).to.equal(0);
+        expect(visibleToGroup1.actions).to.deep.equal([]);
+        expect(visibleToGroup2.actions).to.deep.equal([]);
+    });
+
+    it('filters alarm status counts by role permission', async () => {
+        const alarmA = makeProjectAlarm('operator-alarm', 'device-a^~^tag-a', { permissionRoles: { show: ['operator'], enabled: [] } });
+        const alarmB = makeProjectAlarm('engineer-alarm', 'device-a^~^tag-b', { permissionRoles: { show: ['engineer'], enabled: [] } });
+
+        await initManager({ secureEnabled: true, userRole: true }, [alarmA, alarmB]);
+
+        const operatorStatus = await manager.getAlarmsStatus({ info: { roles: ['operator'] }, groups: 1 });
+        const engineerStatus = await manager.getAlarmsStatus({ info: { roles: ['engineer'] }, groups: 2 });
+        const viewerStatus = await manager.getAlarmsStatus({ info: { roles: ['viewer'] }, groups: 4 });
+
+        expect(operatorStatus.highhigh).to.equal(1);
+        expect(engineerStatus.highhigh).to.equal(1);
+        expect(viewerStatus.highhigh).to.equal(0);
+    });
+
+    it('keeps admin alarm status unfiltered', async () => {
+        const alarmA = makeProjectAlarm('visible-alarm', 'device-a^~^tag-a', { permission: 1 << 8 });
+        const alarmB = makeProjectAlarm('hidden-alarm', 'device-a^~^tag-b', { permission: 2 << 8 });
+
+        await initManager({ secureEnabled: true, userRole: false }, [alarmA, alarmB]);
+
+        const adminStatus = await manager.getAlarmsStatus(-1);
+
+        expect(adminStatus.highhigh).to.equal(2);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix alarm history reports so server-side report generation is not filtered by alarm permissions
- Load alarm history for reports with admin permissions, since reports are server processes
- Fix active alarm status counts to respect the current user's permissions

## Context
Alarm history reports previously excluded alarms that had permissions configured, because the history lookup was using the same permission-aware path used by the frontend without an admin context.
