### PR TITLE
Add JavaScript syntax validation to script editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "@ctrl/ngx-codemirror": "^5.1.1",
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
+        "acorn": "^8.15.0",
         "angular-gridster2": "^18.0.1",
         "angular2-draggable": "^16.0.0",
         "bcryptjs": "^2.4.3",
@@ -5842,7 +5843,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "@ctrl/ngx-codemirror": "^5.1.1",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
+    "acorn": "^8.15.0",
     "angular-gridster2": "^18.0.1",
     "angular2-draggable": "^16.0.0",
     "bcryptjs": "^2.4.3",

--- a/client/src/app/scripts/script-editor/javascript-linter.ts
+++ b/client/src/app/scripts/script-editor/javascript-linter.ts
@@ -1,0 +1,48 @@
+import * as CodeMirror from 'codemirror';
+import { parse } from 'acorn';
+import type { Annotation } from 'codemirror/addon/lint/lint';
+
+interface AcornSyntaxError extends SyntaxError {
+    loc?: {
+        line: number;
+        column: number;
+    };
+}
+
+/**
+ * Validates the editor content as a function body and maps Acorn's position
+ * from the generated wrapper back to the CodeMirror document.
+ */
+export function getJavaScriptSyntaxAnnotations(
+    code: string,
+    parameters: string[],
+    isAsync: boolean
+): Annotation[] {
+    const asyncKeyword = isAsync ? 'async ' : '';
+    const source = `${asyncKeyword}function __fuxa_script__(${parameters.join(', ')}) {\n${code}\n}`;
+
+    try {
+        parse(source, {
+            ecmaVersion: 'latest',
+            sourceType: 'script'
+        });
+        return [];
+    } catch (error) {
+        const syntaxError = error as AcornSyntaxError;
+        const codeLines = code.split('\n');
+        const parsedLine = syntaxError.loc?.line ?? 2;
+        const line = Math.min(Math.max(parsedLine - 2, 0), codeLines.length - 1);
+        const parsedColumn = syntaxError.loc?.column ?? 0;
+        const column = parsedLine > codeLines.length + 1
+            ? codeLines[line].length
+            : Math.min(parsedColumn, codeLines[line].length);
+        const fromColumn = Math.min(column, Math.max(codeLines[line].length - 1, 0));
+
+        return [{
+            from: CodeMirror.Pos(line, fromColumn),
+            to: CodeMirror.Pos(line, Math.min(fromColumn + 1, codeLines[line].length)),
+            message: syntaxError.message.replace(/ \(\d+:\d+\)$/, ''),
+            severity: 'error'
+        }];
+    }
+}

--- a/client/src/app/scripts/script-editor/script-editor.component.ts
+++ b/client/src/app/scripts/script-editor/script-editor.component.ts
@@ -14,6 +14,7 @@ import { ScriptParamType, Script, ScriptTest, SCRIPT_PREFIX, SystemFunctions, Sy
 import { DevicesUtils, DeviceType } from '../../_models/device';
 import { DeviceTagSelectionComponent, DeviceTagSelectionData } from '../../device/device-tag-selection/device-tag-selection.component';
 import { ScriptEditorParamComponent } from './script-editor-param/script-editor-param.component';
+import { getJavaScriptSyntaxAnnotations } from './javascript-linter';
 
 @Component({
     selector: 'app-script-editor',
@@ -27,12 +28,8 @@ export class ScriptEditorComponent implements OnInit, OnDestroy {
         lineNumbers: true,
         theme: 'material',
         mode: 'javascript',
-        // lineWrapping: true,
-        // foldGutter: true,
-        // gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter', 'CodeMirror-lint-markers'],
-        // gutters: ["CodeMirror-lint-markers"],
-        // lint: {options: {esversion: 2021}},
-        lint: true,
+        gutters: ['CodeMirror-linenumbers', 'CodeMirror-lint-markers'],
+        lint: false
     };
     systemFunctions: SystemFunctions;
     templatesCode: TemplatesCode;
@@ -47,6 +44,14 @@ export class ScriptEditorComponent implements OnInit, OnDestroy {
     msgRemoveScript = '';
     ready = false;
     private destroy$ = new Subject<void>();
+    private codeMirrorSetupTimer: number;
+    private readonly lintOptions = {
+        getAnnotations: (code: string) => getJavaScriptSyntaxAnnotations(
+            code,
+            this.parameters.map(parameter => parameter.name),
+            !this.script.sync
+        )
+    };
 
     constructor(public dialogRef: MatDialogRef<ScriptEditorComponent>,
         public dialog: MatDialog,
@@ -86,13 +91,20 @@ export class ScriptEditorComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        window.clearTimeout(this.codeMirrorSetupTimer);
         this.destroy$.next(null);
         this.destroy$.complete();
     }
 
     setCM() {
         this.changeDetector.detectChanges();
-        this.CodeMirror?.codeMirror?.refresh();
+        const editor = this.CodeMirror?.codeMirror;
+        if (!editor) {
+            this.codeMirrorSetupTimer = window.setTimeout(() => this.setCM(), 50);
+            return;
+        }
+
+        editor.refresh();
         let spellCheckOverlay = {
             token: (stream) => {
                 for (let i = 0; i < this.checkSystemFnc.length; i++) {
@@ -104,7 +116,9 @@ export class ScriptEditorComponent implements OnInit, OnDestroy {
                 return null;
             }
         };
-        this.CodeMirror?.codeMirror?.addOverlay(spellCheckOverlay);
+        editor.addOverlay(spellCheckOverlay);
+        editor.setOption('lint', this.lintOptions);
+        editor.performLint();
     }
 
     onNoClick(): void {
@@ -253,6 +267,7 @@ export class ScriptEditorComponent implements OnInit, OnDestroy {
 
     toggleSync() {
         this.script.sync = !this.script.sync;
+        this.CodeMirror?.codeMirror?.performLint();
     }
 
     onConsoleClear() {

--- a/client/src/theme.scss
+++ b/client/src/theme.scss
@@ -134,6 +134,12 @@ $dark-theme: mat.m2-define-dark-theme((
 @import 'codemirror/addon/lint/lint';
 @import 'codemirror/addon/hint/show-hint';
 
+// CodeMirror appends lint tooltips to <body>. Keep them above Angular Material
+// dialogs, whose overlay container otherwise covers CodeMirror's default z-index: 100.
+.CodeMirror-lint-tooltip {
+    z-index: 10000;
+}
+
 
 /* ===== Token overrides: label/tab/icon ===== */
 


### PR DESCRIPTION
## Description

Adds real-time JavaScript syntax validation to the CodeMirror script editor using Acorn.

The editor content is parsed as the body of the actual FUXA function, including its parameters and sync/async mode.

## Changes

- Add Acorn as a client dependency
- Add a CodeMirror-compatible JavaScript syntax validator
- Display syntax errors in the editor gutter
- Highlight the error position in the source code
- Show the parser error message on hover
- Support `return` inside the script body
- Support `await` only for asynchronous scripts
- Revalidate when switching between sync and async mode
- Fix lint tooltip visibility inside Angular Material dialogs
- Wait for the asynchronous CodeMirror instance before enabling lint

## Notes

Only real JavaScript syntax errors are reported. Style preferences, such as omitted semicolons, are not treated as errors.

## Dependency change

This PR adds Acorn as a client runtime dependency. It is installed automatically through `npm install` or `npm ci`.
