### PR TITLE
feat: configure MQTT retain flag per topic

### DIFF
--- a/client/src/app/device/topic-property/topic-property.component.html
+++ b/client/src/app/device/topic-property/topic-property.component.html
@@ -94,6 +94,10 @@
                             <span>{{'device.topic-publish-path' | translate}}</span>
                             <input [(ngModel)]="publishTopicPath" (keyup)="stringifyPublishItem()" style="width: 400px;" type="text">
                         </div>
+                        <div class="my-form-field" style="display:inline-block; margin-right: 10px;margin-bottom: 10px; vertical-align: middle;">
+                            <span>{{'device.topic-publish-retain' | translate}}</span>
+                            <mat-checkbox [(ngModel)]="retainEnabled" [disabled]="isSubscriptionEdit()"></mat-checkbox>
+                        </div>
                         <mat-button-toggle-group class="toggle-group" [(ngModel)]="topicSelectedPubType" (change)="onPubTopicValChange($event.value)">
                             <mat-button-toggle value="raw" [disabled]="!isPublishTypeToEnable('raw')">{{'device.topic-raw' | translate}}</mat-button-toggle>
                             <mat-button-toggle value="json" [disabled]="!isPublishTypeToEnable('json')">{{'device.topic-json' | translate}}</mat-button-toggle>

--- a/client/src/app/device/topic-property/topic-property.component.ts
+++ b/client/src/app/device/topic-property/topic-property.component.ts
@@ -40,6 +40,7 @@ export class TopicPropertyComponent implements OnInit, OnDestroy {
     publishTopicPath: string;
     pubPayload = new MqttPayload();
     pubPayloadResult = '';
+    retainEnabled = true;
     itemType = MqttItemType;
     itemTag = Utils.getEnumKey(MqttItemType, MqttItemType.tag);
     itemTimestamp = Utils.getEnumKey(MqttItemType, MqttItemType.timestamp);
@@ -120,6 +121,9 @@ export class TopicPropertyComponent implements OnInit, OnDestroy {
                     if (tag.options.pubs) {
                         // sure publish
                         this.pubPayload.items = tag.options.pubs;
+                    }
+                    if (typeof tag.options.retain === 'boolean') {
+                        this.retainEnabled = tag.options.retain;
                     }
                 }
             }
@@ -295,7 +299,7 @@ export class TopicPropertyComponent implements OnInit, OnDestroy {
             tag.name = this.publishTopicName;
             tag.address = this.publishTopicPath;
             tag.type = this.topicSelectedPubType;
-            tag.options = { pubs: this.pubPayload.items };
+            tag.options = { pubs: this.pubPayload.items, retain: this.retainEnabled };
             this.invokePublish(this.data.topic, tag);
         }
     }

--- a/client/src/assets/i18n/de.json
+++ b/client/src/assets/i18n/de.json
@@ -795,6 +795,7 @@
     "device.add-topics": "Veröffentliche meine Themen beim Broker",
     "device.topic-publish-name": "Themenname",
     "device.topic-publish-path": "Themenpfad",
+        "device.topic-publish-retain": "Nachricht auf dem Broker behalten",
     "device.topic-publish": "Veröffentlichen",
     "device.topic-subscribe": "Abonnieren",
     "device.topic-subscription-content": "Inhalt",
@@ -1338,6 +1339,5 @@
     "msg.device-tags-request-result": "Lade {{value}} von {{current}}",
     "gauges.property-icon-none": "Kein Symbol"
 }
-
 
 

--- a/client/src/assets/i18n/en.json
+++ b/client/src/assets/i18n/en.json
@@ -1116,6 +1116,7 @@
     "device.add-topics": "Publish my Topics on broker",
     "device.topic-publish-name": "Topic name",
     "device.topic-publish-path": "Topic path",
+    "device.topic-publish-retain": "Retain message on broker",
     "device.topic-publish": "Publish",
     "device.topic-subscribe": "Subscribe",
     "device.topic-select-all": "Select All",

--- a/client/src/assets/i18n/es.json
+++ b/client/src/assets/i18n/es.json
@@ -509,6 +509,7 @@
     "device.add-topics": "Publicar mi topico en el broker",
     "device.topic-publish-name": "Nombre del topico",
     "device.topic-publish-path": "Ruta del topico",
+        "device.topic-publish-retain": "Conservar mensaje en el broker",
     "device.topic-publish": "Publicar",
     "device.topic-subscribe": "Subscribir",
     "device.topic-subscription-content": "Contenido",
@@ -806,6 +807,5 @@
     "msg.alarms-clear-success": "Todas las alarmas han sido canceladas!",
     "gauges.property-icon-none": "Sin icono"
   }
-
 
 

--- a/client/src/assets/i18n/fr.json
+++ b/client/src/assets/i18n/fr.json
@@ -963,6 +963,7 @@
   "device.add-topics": "Publier mes topics sur le broker",
   "device.topic-publish-name": "Nom du topic",
   "device.topic-publish-path": "Chemin",
+      "device.topic-publish-retain": "Conserver le message sur le broker",
   "device.topic-publish": "Publier",
   "device.topic-subscribe": "S'abonner",
   "device.topic-subscription-content": "Contenu",
@@ -1749,5 +1750,4 @@
   "msg.operation-unauthorized": "Opération non autorisée !",
     "gauges.property-icon-none": "Aucune icône"
 }
-
 

--- a/client/src/assets/i18n/ja.json
+++ b/client/src/assets/i18n/ja.json
@@ -987,6 +987,7 @@
     "device.add-topics": "ブローカーにトピックを公開",
     "device.topic-publish-name": "トピック名",
     "device.topic-publish-path": "トピックパス",
+        "device.topic-publish-retain": "ブローカーにメッセージを保持",
     "device.topic-publish": "公開",
     "device. topic-subscribe": "サブスクライブ",
     "device.topic-subscription-content": "コンテンツ",
@@ -1784,4 +1785,3 @@
     "msg.operation-unauthorized": "操作が許可されていません！",
     "gauges.property-icon-none": "アイコンなし"
 }
-

--- a/client/src/assets/i18n/ko.json
+++ b/client/src/assets/i18n/ko.json
@@ -509,6 +509,7 @@
     "device.add-topics": "브로커에 항목 계시",
     "device.topic-publish-name": "항목 이름",
     "device.topic-publish-path": "항목 위치",
+        "device.topic-publish-retain": "브로커에 메시지 유지",
     "device.topic-publish": "항목",
     "device.topic-subscribe": "구독",
     "device.topic-subscription-content": "컨텐츠",
@@ -804,6 +805,5 @@
     "msg.alarms-clear-success": "모든 알림이 취소되었습니다!",
     "gauges.property-icon-none": "아이콘 없음"
 }
-
 
 

--- a/client/src/assets/i18n/pt.json
+++ b/client/src/assets/i18n/pt.json
@@ -686,5 +686,6 @@
     "msg.login-password-required": "Entra uma palavra-passe",
     "msg.signin-failed": "Não autorizado",
     "device.tag-uns-path": "UNS Path",
+        "device.topic-publish-retain": "Manter mensagem no broker",
     "gauges.property-icon-none": "Sem ícone"
 }

--- a/client/src/assets/i18n/ru.json
+++ b/client/src/assets/i18n/ru.json
@@ -745,6 +745,7 @@
     "device.add-topics": "Опубликовать мои Топики в брокер",
     "device.topic-publish-name": "Имя Топика",
     "device.topic-publish-path": "Путь Топика",
+        "device.topic-publish-retain": "Сохранять сообщение в брокере",
     "device.topic-publish": "Опубликовать",
     "device.topic-subscribe": "Подписаться",
     "device.topic-subscription-content": "Содержимое",
@@ -1257,6 +1258,5 @@
     "msg.device-tags-request-result": "Загружено {{value}} из {{current}}",
     "gauges.property-icon-none": "Без значка"
 }
-
 
 

--- a/client/src/assets/i18n/sv.json
+++ b/client/src/assets/i18n/sv.json
@@ -957,6 +957,7 @@
     "device.add-topics": "Publicera mina ämnen på broker",
     "device.topic-publish-name": "Ämnesnamn",
     "device.topic-publish-path": "Ämnesväg",
+    "device.topic-publish-retain": "Behåll meddelande på broker",
     "device.topic-publish": "Publicera",
     "device.topic-subscribe": "Prenumerera",
     "device.topic-subscription-content": "Innehåll",

--- a/client/src/assets/i18n/tr.json
+++ b/client/src/assets/i18n/tr.json
@@ -699,5 +699,6 @@
 	"msg.login-password-required": "Şifre girin",
 	"msg.signin-failed": "Yetkisiz giriş.",
     "device.tag-uns-path": "UNS Path",
+        "device.topic-publish-retain": "Broker'da mesajı sakla",
     "gauges.property-icon-none": "Simge yok"
 }

--- a/client/src/assets/i18n/ua.json
+++ b/client/src/assets/i18n/ua.json
@@ -640,5 +640,6 @@
     "msg.login-password-required": "Пароль",
     "msg.signin-failed": "Не авторизований",
     "device.tag-uns-path": "UNS Path",
+        "device.topic-publish-retain": "Зберігати повідомлення в брокері",
     "gauges.property-icon-none": "Без значка"
 }

--- a/client/src/assets/i18n/zh-cn.json
+++ b/client/src/assets/i18n/zh-cn.json
@@ -964,6 +964,7 @@
     "device.add-topics": "在broker上发布我的话题",
     "device.topic-publish-name": "主题名称",
     "device.topic-publish-path": "主题路径",
+        "device.topic-publish-retain": "在服务器上保留消息",
     "device.topic-publish": "发布",
     "device.topic-subscribe": "订阅",
     "device.topic-subscription-content": "内容",
@@ -1751,5 +1752,4 @@
     "msg.operation-unauthorized": "操作未经授权！",
     "gauges.property-icon-none": "无图标"
 }
-
 

--- a/client/src/assets/i18n/zh-tw.json
+++ b/client/src/assets/i18n/zh-tw.json
@@ -964,6 +964,7 @@
     "device.add-topics": "在 broker 上發佈我的主題",
     "device.topic-publish-name": "主題名稱",
     "device.topic-publish-path": "主題路徑",
+        "device.topic-publish-retain": "在伺服器上保留訊息",
     "device.topic-publish": "發佈",
     "device.topic-subscribe": "訂閱",
     "device.topic-subscription-content": "內容",
@@ -1750,5 +1751,4 @@
     "msg.operation-unauthorized": "操作未授權！",
     "gauges.property-icon-none": "無圖示"
 }
-
 

--- a/server/runtime/devices/mqtt/index.js
+++ b/server/runtime/devices/mqtt/index.js
@@ -540,7 +540,7 @@ function MQTTclient(_data, _logger, _events, _runtime) {
     var _publishValues = function (tags) {
         Object.keys(tags).forEach(key => {
             try {
-                const topicOptions = { retain: true };
+                const topicOptions = { retain: _getRetainOption(tags[key]) };
                 // publish only tags with pubs and value changed
                 if (tags[key].options && tags[key].options.pubs && tags[key].options.pubs.length) {
                     var topicTopuplish = {};
@@ -584,6 +584,20 @@ function MQTTclient(_data, _logger, _events, _runtime) {
             }
         })
     }
+}
+
+/**
+ * Return the MQTT retain flag for a topic to publish.
+ * It is configured per publish topic through the editor
+ * (Tag.options.retain). It defaults to true to keep the historical
+ * behavior for projects that do not set the flag.
+ * @param {*} tag
+ */
+function _getRetainOption(tag) {
+    if (tag && tag.options && typeof tag.options.retain === 'boolean') {
+        return tag.options.retain;
+    }
+    return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add a retain checkbox to the MQTT publish-topic editor.
- Persist and reload the retain setting as a boolean in tag options.
- Apply the configured retain flag to JSON, raw, payload, echo, and legacy publish paths.
- Preserve retain=true for missing or non-boolean configuration.
- Add the retain label to every shipped locale.

## Validation

- 
- All 13 locale JSON files parse and contain the retain label.
- No-network smoke validation: 13/13 tests pass with the solution; the pristine control has the six expected feature failures.
- No dependency manifests changed.

Client Angular/Karma tests and production build were not run because client dependencies are unavailable in the current environment.