### PR TITLE
fix: align QuestDB addDaqValues guard with sqlite implementation

### DIFF
--- a/server/runtime/storage/questdb/index.js
+++ b/server/runtime/storage/questdb/index.js
@@ -37,13 +37,14 @@ function QuestDB(_settings, _log, _currentStorage) {
 
         for (const tagid in tagsValues) {
             let tag = tagsValues[tagid];
-            if (!tag.daq || utils.isNullOrUndefined(tag.value) || Number.isNaN(tag.value)) {
-                if (tag.daq && tag.daq.restored) {
-                    dataToRestore.push({ id: tag.id, deviceId: deviceId, value: tag.value });
-                }
-                if (tag.daq && !tag.daq.enabled) {
-                    continue;
-                }
+            if (!tag.daq) {
+                continue;
+            }
+            if (tag.daq.restored) {
+                dataToRestore.push({ id: tag.id, deviceId: deviceId, value: tag.value });
+            }
+            if (!tag.daq.enabled || utils.isNullOrUndefined(tag.value) || Number.isNaN(tag.value)) {
+                continue;
             }
 
             rowsToWrite.push({


### PR DESCRIPTION
## 📌 Description

Restoring values when using QuestDB did not work because of a bug in the `addDaqValues`  guard. Only tags with invalid values were added to the restore array:
```js
 if (!tag.daq || utils.isNullOrUndefined(tag.value) || Number.isNaN(tag.value)) {
                if (tag.daq && tag.daq.restored) {
``` 
This resulted in tags with restore enabled being restored to default value or value in project data instead of last value in database.

Changed it to work in the same way as the sqlite implementation.


### How to replicate
1. Setup QuestDB.
2. Add new tag and configure to be restored
3. Change the tag value in UI so that it gets written to the database
4. Open tag options and press OK without changes.
5. Tag value reverts back to stale data

---

## 🧪 Type of Change

Please mark the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

---

## 🚫 Build Artifacts Check

Please confirm:

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

---

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [x] Documentation updated if required
- [x] Issue opened (for major changes)

---

## 📝 Additional Notes

Add any other context or screenshots here.