### PR TITLE
Fix switch, script test, and Node-RED logout regressions

### DIFF
--- a/client/src/app/_services/auth.service.ts
+++ b/client/src/app/_services/auth.service.ts
@@ -85,7 +85,7 @@ export class AuthService {
 	}
 
 	signOut() {
-		if (this.useRefreshCookieAuth && environment.serverEnabled) {
+		if (environment.serverEnabled && (this.useRefreshCookieAuth || this.settings.getSettings()?.nodeRedEnabled)) {
 			let header = new HttpHeaders({ 'Skip-Auth': 'true', 'Skip-Error': 'true' });
 			this.http.post(this.endPointConfig + '/api/signout', {}, { headers: header, withCredentials: true }).subscribe({
 				next: () => this.finalizeSignOut(),

--- a/client/src/app/gauges/controls/html-switch/html-switch.component.ts
+++ b/client/src/app/gauges/controls/html-switch/html-switch.component.ts
@@ -101,7 +101,6 @@ export class HtmlSwitchComponent extends GaugeBaseComponent {
                         }
                     }
                 }
-                componentRef.instance.isReadonly = !!ga.property?.events?.length;
                 componentRef.instance['name'] = ga.name;
                 if (permission?.enabled === false) {
                     componentRef.instance.setDisabled(true);

--- a/client/src/app/gui-helpers/ngx-switch/ngx-switch.component.ts
+++ b/client/src/app/gui-helpers/ngx-switch/ngx-switch.component.ts
@@ -14,7 +14,6 @@ export class NgxSwitchComponent implements AfterViewInit {
     options: SwitchOptions = new SwitchOptions();
     checked = false;
     onUpdate: any;
-    isReadonly = false;
     disabled = false;
 
     constructor() {
@@ -25,9 +24,6 @@ export class NgxSwitchComponent implements AfterViewInit {
     }
 
     onClick() {
-        if (this.isReadonly) {
-            return;
-        }
         this.onRefresh();
         if (this.onUpdate) {
             this.onUpdate((this.checked) ? this.options.onValue.toString() : this.options.offValue.toString());

--- a/server/api/auth/index.js
+++ b/server/api/auth/index.js
@@ -16,6 +16,7 @@ var tokenExpiresIn;
 var enableRefreshCookieAuth = false;
 var refreshTokenExpiresIn = '7d';
 const refreshCookieName = 'fuxa_refresh';
+const nodeRedAuthCookieName = 'nodered_auth';
 
 function parseExpiresToMs(expiresIn) {
     if (expiresIn === undefined || expiresIn === null) {
@@ -75,6 +76,17 @@ function setRefreshCookie(res, token) {
 function clearRefreshCookie(res) {
     res.clearCookie(refreshCookieName, {
         path: BASE_PATH + '/api/refresh'
+    });
+}
+
+function clearNodeRedAuthCookie(res) {
+    res.clearCookie(nodeRedAuthCookieName, {
+        path: BASE_PATH + '/nodered',
+        sameSite: 'lax'
+    });
+    res.clearCookie(nodeRedAuthCookieName, {
+        path: BASE_PATH || '/',
+        sameSite: 'lax'
     });
 }
 
@@ -208,6 +220,7 @@ module.exports = {
             if (enableRefreshCookieAuth) {
                 clearRefreshCookie(res);
             }
+            clearNodeRedAuthCookie(res);
             res.status(204).end();
         });
 

--- a/server/api/scripts/index.js
+++ b/server/api/scripts/index.js
@@ -36,7 +36,8 @@ module.exports = {
             if (res.statusCode === 403) {
                 runtime.logger.error("api post runscript: Tocken Expired");
                 //runtime.settings.secureEnabled
-            } else if (script?.test && (!req.isAuthenticated || !authJwt.haveAdminPermission(permission))) {
+            } else if (runtime.settings?.secureEnabled && script?.test &&
+                       (!req.isAuthenticated || !authJwt.haveAdminPermission(permission))) {
                 res.status(401).json({ error: "unauthorized_error", message: "Unauthorized!" });
                 runtime.logger.error("api post runscript: Unauthorized test mode");
             } else if (!script?.test && !script?.id) {

--- a/server/integrations/node-red/index.js
+++ b/server/integrations/node-red/index.js
@@ -126,6 +126,11 @@ const getCookieValue = (req, name) => {
     return null;
 };
 
+const NODE_RED_AUTH_COOKIE_OPTIONS = {
+    path: '/nodered',
+    sameSite: 'lax',
+};
+
 const verifyApiKey = (runtime, apiKey) => {
     return runtime.apiKeys.getApiKeys().then(stored => {
         const now = Date.now();
@@ -184,8 +189,8 @@ function createNodeRedAuthMiddleware({ settings, runtime, logger, authJwt }) {
                 }
                 if (queryToken) {
                     res.cookie('nodered_auth', token, {
+                        ...NODE_RED_AUTH_COOKIE_OPTIONS,
                         httpOnly: true,
-                        sameSite: 'lax',
                         secure: !!settings.https,
                     });
                     if (req.method === 'GET') {
@@ -198,7 +203,7 @@ function createNodeRedAuthMiddleware({ settings, runtime, logger, authJwt }) {
             })
             .catch(() => {
                 if (cookieToken) {
-                    res.clearCookie('nodered_auth');
+                    res.clearCookie('nodered_auth', NODE_RED_AUTH_COOKIE_OPTIONS);
                 }
                 return res.status(401).json({ error: "unauthorized_error", message: "Invalid token!" });
             });

--- a/server/test/authorization/jwtLifecycleSecurity.test.js
+++ b/server/test/authorization/jwtLifecycleSecurity.test.js
@@ -156,6 +156,47 @@ describe('Security - JWT lifecycle', () => {
         }
     });
 
+    it('clears Node-RED auth cookies on signout', async () => {
+        const runtime = {
+            project: {},
+            settings: {
+                https: false
+            },
+            logger: {
+                error() {},
+                info() {}
+            }
+        };
+
+        authApi.init(runtime, SECRET, '1h', false, '7d');
+        const app = express();
+        app.use(authApi.app());
+        const server = await listen(app);
+
+        try {
+            const response = await request(server, {
+                method: 'POST',
+                path: '/api/signout',
+                headers: {
+                    Cookie: 'nodered_auth=stale-token'
+                }
+            });
+
+            expect(response.statusCode).to.equal(204);
+            const setCookies = response.headers['set-cookie'] || [];
+            expect(setCookies.some(cookie =>
+                cookie.startsWith('nodered_auth=;') &&
+                cookie.includes('Path=/nodered')
+            )).to.equal(true);
+            expect(setCookies.some(cookie =>
+                cookie.startsWith('nodered_auth=;') &&
+                cookie.includes('Path=/;')
+            )).to.equal(true);
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
     it('refreshes access tokens with current stored groups after demotion', async () => {
         const runtime = {
             project: {},

--- a/server/test/authorization/nodeRedSecurity.test.js
+++ b/server/test/authorization/nodeRedSecurity.test.js
@@ -27,8 +27,8 @@ function makeResponse() {
         cookie(name, value, options) {
             this.cookies.push({ name, value, options });
         },
-        clearCookie(name) {
-            this.clearedCookies.push(name);
+        clearCookie(name, options) {
+            this.clearedCookies.push({ name, options });
         },
         redirect(url) {
             this.redirectUrl = url;
@@ -199,7 +199,10 @@ describe('Node-RED secure mode authorization', () => {
 
         expect(result.allowed).to.equal(false);
         expect(result.res.statusCode).to.equal(401);
-        expect(result.res.clearedCookies).to.deep.equal(['nodered_auth']);
+        expect(result.res.clearedCookies).to.deep.equal([{
+            name: 'nodered_auth',
+            options: { path: '/nodered', sameSite: 'lax' }
+        }]);
     });
 
     it('keeps dashboard routes public', async () => {

--- a/server/test/authorization/runscriptSecurity.test.js
+++ b/server/test/authorization/runscriptSecurity.test.js
@@ -141,4 +141,51 @@ describe('Security - runscript authorization target binding', () => {
         expect(calls.authorised).to.equal(0);
         expect(calls.run).to.equal(0);
     });
+
+    it('allows script tests when security is disabled', async () => {
+        const calls = { authorised: 0, run: 0 };
+        const app = express();
+        app.use(express.json());
+
+        scriptsApi.init(
+            {
+                project: {},
+                settings: { secureEnabled: false },
+                logger: makeLogger(),
+                scriptsMgr: {
+                    isAuthorised: () => {
+                        calls.authorised += 1;
+                        return true;
+                    },
+                    runScript: () => {
+                        calls.run += 1;
+                        return Promise.resolve('executed');
+                    }
+                }
+            },
+            (req, res, next) => {
+                req.isAuthenticated = false;
+                next();
+            },
+            () => -1
+        );
+
+        app.use(scriptsApi.app());
+
+        const res = await request(app, 'POST', '/api/runscript', {
+            params: {
+                script: {
+                    test: true,
+                    name: 'test_script',
+                    parameters: [],
+                    code: 'return true;'
+                }
+            }
+        });
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.body).to.equal('executed');
+        expect(calls.authorised).to.equal(1);
+        expect(calls.run).to.equal(1);
+    });
 });


### PR DESCRIPTION
## Summary

This PR fixes three regressions:

- Switch controls with configured events could no longer update their tag/value.
- Script test execution was blocked when FUXA security was disabled.
- Node-RED remained accessible after FUXA logout because the `nodered_auth` cookie was not reliably cleared.

## Changes

### Switch control

Remove the readonly behavior that was applied when a switch had events configured. This allows the switch click handler to continue refreshing the control and calling `onUpdate`, so tag updates and events can both work.

### Script test authorization

Only enforce admin/auth checks for script test execution when `secureEnabled` is active. When FUXA security is disabled, test scripts are allowed to run as expected.

### Node-RED logout cleanup

- Set a stable `/nodered` path for the `nodered_auth` cookie.
- Clear `nodered_auth` with the matching path when the cookie is invalid.
- Clear `nodered_auth` during `/api/signout`.
- Make client logout call `/api/signout` when refresh-cookie auth or Node-RED is enabled.
