### PR TITLE
fix: keep string tag values on HTML select labels

### DIFF
--- a/client/src/app/gauges/controls/html-select/html-select.component.ts
+++ b/client/src/app/gauges/controls/html-select/html-select.component.ts
@@ -69,6 +69,9 @@ export class HtmlSelectComponent extends GaugeBaseComponent {
                 if (Number.isNaN(val)) {
                     // maybe boolean
                     val = Number(sig.value);
+                    if (Number.isNaN(val)) {
+                        val = sig.value;
+                    }
                 } else {
                     val = parseFloat(val.toFixed(5));
                 }


### PR DESCRIPTION
## 📌 Description

Select labels went blank when the bound tag was a string. `parseFloat` then `Number` both yield NaN, so `select.value` never matched an option. Fall back to the raw signal value after those coercions fail.

- What problem does this solve? String-valued select options show no selected label.
- What was changed? `HtmlSelectComponent.processValue` keeps non-numeric string values.
- Why is this needed? Number/boolean tags still work; strings were dropped.

## 🧪 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## 🚫 Build Artifacts Check

- [x] I did NOT commit `/client/dist`
- [x] I did NOT commit generated Angular build output
- [x] Only source files are included

## 🔍 Checklist

- [x] Code follows project coding standards
- [x] I tested my changes locally
- [ ] Documentation updated if required
- [x] Issue opened (for major changes)

Fixes #2493

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

## 📝 Additional Notes

Local check: `parseFloat('idle')` / `Number('idle')` are NaN; raw `'idle'` is kept. Numeric tags still go through `toFixed(5)`.

Made with [Cursor](https://cursor.com)